### PR TITLE
feat(foundation): scaffold project, errors, and types packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+  push:
+    branches:
+      - main
+      - 'release/**'
+
+jobs:
+  quality:
+    name: Lint and Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache-dependency-path: go.sum
+
+      - name: Format check
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "These files need gofmt:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./... -race -v
+
+  integration:
+    name: Integration
+    runs-on: ubuntu-latest
+    services:
+      surrealdb:
+        image: surrealdb/surrealdb:latest
+        ports:
+          - 8000:8000
+        options: >-
+          --health-cmd "curl -f http://localhost:8000/health || exit 1"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+        env:
+          SURREAL_USER: root
+          SURREAL_PASS: root
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache-dependency-path: go.sum
+
+      - name: Integration tests
+        run: go test -tags=integration ./... -race -v
+        env:
+          SURREAL_URL: ws://localhost:8000
+          SURREAL_USER: root
+          SURREAL_PASS: root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,21 +44,24 @@ jobs:
   integration:
     name: Integration
     runs-on: ubuntu-latest
-    services:
-      surrealdb:
-        image: surrealdb/surrealdb:latest
-        ports:
-          - 8000:8000
-        options: >-
-          --health-cmd "curl -f http://localhost:8000/health || exit 1"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
-        env:
-          SURREAL_USER: root
-          SURREAL_PASS: root
     steps:
       - uses: actions/checkout@v4
+
+      - name: Start SurrealDB
+        run: |
+          docker run -d \
+            --name surrealdb \
+            -p 8000:8000 \
+            surrealdb/surrealdb:v2.2 \
+            start --user root --pass root memory
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:8000/health; then
+              echo "SurrealDB ready"
+              break
+            fi
+            echo "Waiting for SurrealDB... attempt $i"
+            sleep 2
+          done
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -72,3 +75,7 @@ jobs:
           SURREAL_URL: ws://localhost:8000
           SURREAL_USER: root
           SURREAL_PASS: root
+
+      - name: Stop SurrealDB
+        if: always()
+        run: docker stop surrealdb || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Run goreleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+bin/
+dist/
+coverage.out
+coverage.html
+*.test
+*.out
+*.prof
+.idea/
+.vscode/
+.DS_Store
+*.log

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,38 @@
+run:
+  timeout: 5m
+  go: "1.26"
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
+    - ineffassign
+    - unused
+    - gofmt
+    - goimports
+    - misspell
+    - revive
+    - unconvert
+    - gocritic
+    - gosec
+
+linters-settings:
+  revive:
+    rules:
+      - name: exported
+      - name: package-comments
+      - name: var-naming
+  gosec:
+    excludes:
+      - G104 # errcheck handles
+  goimports:
+    local-prefixes: github.com/albedosehen/surql-go
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gosec
+        - errcheck

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,34 @@
+version: 2
+
+project_name: surql
+
+builds:
+  - main: ./cmd/surql
+    binary: surql
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X main.version={{ .Version }} -X main.commit={{ .Commit }} -X main.date={{ .Date }}
+
+archives:
+  - formats: ['tar.gz']
+    format_overrides:
+      - goos: windows
+        formats: ['zip']
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+
+checksum:
+  name_template: checksums.txt
+
+release:
+  github:
+    owner: albedosehen
+    name: surql-go

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Shon Thomas
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+.PHONY: build run test test-short vet fmt fmt-check lint check clean cover tidy
+
+BIN_DIR := bin
+BIN     := $(BIN_DIR)/surql
+PKG     := ./...
+
+build:
+	go build -o $(BIN) ./cmd/surql
+
+run:
+	go run ./cmd/surql
+
+test:
+	go test $(PKG) -race -v
+
+test-short:
+	go test $(PKG) -short
+
+vet:
+	go vet $(PKG)
+
+fmt:
+	gofmt -w .
+
+fmt-check:
+	@diff -u /dev/null <(gofmt -l .)
+
+lint:
+	golangci-lint run $(PKG)
+
+check: fmt-check vet test
+	@echo "All checks passed."
+
+tidy:
+	go mod tidy
+
+cover:
+	go test $(PKG) -race -coverprofile=coverage.out -covermode=atomic
+	go tool cover -html=coverage.out -o coverage.html
+	@echo "Coverage report: coverage.html"
+
+clean:
+	rm -rf $(BIN_DIR) coverage.out coverage.html

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# surql-go
+
+Code-first database toolkit for SurrealDB -- schema definitions, migrations, query building, typed CRUD.
+
+Go port of [`oneiriq-surql`](https://github.com/Oneiriq/surql-py) (Python) and [`@oneiriq/surql`](https://github.com/Oneiriq/surql) (TypeScript/Deno). Target: 1:1 feature parity.
+
+Status: `0.1.0-dev` -- foundation under active port.
+
+## Features (target parity)
+
+- Connection management (WebSocket/HTTP, pooling, retry, transactions, live queries)
+- Query builder (immutable, fluent, expressions, hints, batch operations, graph traversal)
+- Typed CRUD backed by `encoding/json` struct tags (create, read, update, merge, upsert, delete)
+- Schema DSL (tables, fields, edges, indexes, events, access)
+- Migrations (generator, executor, history, rollback, squash, versioning, watcher)
+- Cache (in-memory + optional Redis backend)
+- Orchestration (multi-environment deploy: sequential, parallel, rolling, canary)
+- CLI (`surql` binary) for migrate, schema, db, orchestrate
+
+## Install
+
+```bash
+go get github.com/albedosehen/surql-go
+```
+
+CLI:
+
+```bash
+go install github.com/albedosehen/surql-go/cmd/surql@latest
+```
+
+## Quick Start
+
+Under construction. Full API will mirror `surql-py` and `@oneiriq/surql`.
+
+## Development
+
+```bash
+make check    # fmt + vet + test
+make test     # run all tests
+make cover    # coverage report -> coverage.html
+```
+
+## License
+
+Apache-2.0

--- a/cmd/surql/main.go
+++ b/cmd/surql/main.go
@@ -1,0 +1,37 @@
+// Command surql is the CLI entry point for the surql-go toolkit.
+//
+// Subcommands (migrate, schema, db, orchestrate) are added incrementally
+// as the library port progresses. See README.md for the target surface.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/albedosehen/surql-go/pkg/surql"
+)
+
+// build-time populated by goreleaser via -ldflags.
+var (
+	version = surql.Version
+	commit  = ""
+	date    = ""
+)
+
+func main() {
+	if len(os.Args) >= 2 && (os.Args[1] == "-v" || os.Args[1] == "--version" || os.Args[1] == "version") {
+		fmt.Printf("surql %s", version)
+		if commit != "" {
+			fmt.Printf(" (commit %s)", commit)
+		}
+		if date != "" {
+			fmt.Printf(" built %s", date)
+		}
+		fmt.Println()
+		return
+	}
+
+	fmt.Fprintln(os.Stderr, "surql-go CLI is under construction; subcommands will land with each release.")
+	fmt.Fprintln(os.Stderr, "Use `surql --version` to inspect the current build.")
+	os.Exit(0)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/albedosehen/surql-go
+
+go 1.26.1

--- a/pkg/surql/doc.go
+++ b/pkg/surql/doc.go
@@ -1,0 +1,9 @@
+// Package surql is the Go port of oneiriq-surql (Python) and @oneiriq/surql
+// (TypeScript/Deno): a code-first database toolkit for SurrealDB covering
+// schema definitions, migrations, query building, and typed CRUD.
+//
+// This root package is an umbrella for the library's public subpackages
+// (types, errors, and -- as the port progresses -- connection, query,
+// schema, migration, cache, and orchestration). The goal is 1:1 feature
+// parity with the Python and TypeScript implementations.
+package surql

--- a/pkg/surql/errors/errors.go
+++ b/pkg/surql/errors/errors.go
@@ -1,0 +1,132 @@
+// Package errors defines the unified error hierarchy for the surql library.
+//
+// It follows idiomatic Go error handling: sentinel errors for the high-level
+// categories (used with errors.Is) plus typed error structs carrying
+// structured context (used with errors.As). Every fallible operation in
+// surql returns an error built on one of these roots.
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors. Use errors.Is to test membership.
+var (
+	// ErrDatabase is the root for all database-level failures.
+	ErrDatabase = errors.New("database error")
+	// ErrConnection indicates a connection failed, timed out, or closed.
+	ErrConnection = errors.New("connection error")
+	// ErrQuery indicates a query failed at the database or during decoding.
+	ErrQuery = errors.New("query error")
+	// ErrTransaction indicates a transaction lifecycle failure.
+	ErrTransaction = errors.New("transaction error")
+	// ErrContext indicates a missing or misconfigured ambient connection context.
+	ErrContext = errors.New("context error")
+	// ErrRegistry indicates a named-connection registry failure.
+	ErrRegistry = errors.New("registry error")
+	// ErrStreaming indicates a live/streaming query failure.
+	ErrStreaming = errors.New("streaming error")
+	// ErrValidation indicates invalid input or malformed identifier.
+	ErrValidation = errors.New("validation error")
+	// ErrSchemaParse indicates the schema parser could not interpret input.
+	ErrSchemaParse = errors.New("schema parse error")
+	// ErrMigrationDiscovery indicates a migration file discovery failure.
+	ErrMigrationDiscovery = errors.New("migration discovery error")
+	// ErrMigrationLoad indicates loading an individual migration failed.
+	ErrMigrationLoad = errors.New("migration load error")
+	// ErrMigrationGeneration indicates migration generation failed.
+	ErrMigrationGeneration = errors.New("migration generation error")
+	// ErrMigrationExecution indicates executing a migration failed.
+	ErrMigrationExecution = errors.New("migration execution error")
+	// ErrMigrationHistory indicates a migration history failure.
+	ErrMigrationHistory = errors.New("migration history error")
+	// ErrMigrationSquash indicates migration squashing failed.
+	ErrMigrationSquash = errors.New("migration squash error")
+	// ErrOrchestration indicates a multi-environment orchestration failure.
+	ErrOrchestration = errors.New("orchestration error")
+	// ErrSerialization indicates JSON encode/decode failure.
+	ErrSerialization = errors.New("serialization error")
+)
+
+// SurqlError is the typed error returned by surql operations. It wraps
+// one of the sentinels (available via Unwrap / errors.Is) with a
+// human-readable reason and an optional inner error.
+type SurqlError struct {
+	Kind    error
+	Reason  string
+	Wrapped error
+}
+
+// Error returns a formatted error string.
+func (e *SurqlError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Reason == "" && e.Wrapped == nil {
+		if e.Kind != nil {
+			return e.Kind.Error()
+		}
+		return "surql: unknown error"
+	}
+	kind := "surql error"
+	if e.Kind != nil {
+		kind = e.Kind.Error()
+	}
+	switch {
+	case e.Reason != "" && e.Wrapped != nil:
+		return fmt.Sprintf("%s: %s: %v", kind, e.Reason, e.Wrapped)
+	case e.Reason != "":
+		return fmt.Sprintf("%s: %s", kind, e.Reason)
+	default:
+		return fmt.Sprintf("%s: %v", kind, e.Wrapped)
+	}
+}
+
+// Unwrap returns the next error in the chain. If a wrapped error exists
+// it is preferred (preserving cause chains); otherwise the sentinel kind
+// is returned so that errors.Is works.
+func (e *SurqlError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	if e.Wrapped != nil {
+		return e.Wrapped
+	}
+	return e.Kind
+}
+
+// Is reports whether target matches this error's kind or wrapped chain.
+func (e *SurqlError) Is(target error) bool {
+	if e == nil {
+		return target == nil
+	}
+	if e.Kind != nil && errors.Is(e.Kind, target) {
+		return true
+	}
+	if e.Wrapped != nil && errors.Is(e.Wrapped, target) {
+		return true
+	}
+	return false
+}
+
+// New constructs a SurqlError with the given sentinel kind and reason.
+func New(kind error, reason string) *SurqlError {
+	return &SurqlError{Kind: kind, Reason: reason}
+}
+
+// Wrap constructs a SurqlError that wraps an existing error with an added
+// sentinel kind and contextual reason.
+func Wrap(kind error, reason string, err error) *SurqlError {
+	return &SurqlError{Kind: kind, Reason: reason, Wrapped: err}
+}
+
+// Newf constructs a SurqlError with fmt.Sprintf-style formatting.
+func Newf(kind error, format string, args ...any) *SurqlError {
+	return &SurqlError{Kind: kind, Reason: fmt.Sprintf(format, args...)}
+}
+
+// Wrapf constructs a SurqlError that wraps err with fmt.Sprintf-style context.
+func Wrapf(kind error, err error, format string, args ...any) *SurqlError {
+	return &SurqlError{Kind: kind, Reason: fmt.Sprintf(format, args...), Wrapped: err}
+}

--- a/pkg/surql/errors/errors_test.go
+++ b/pkg/surql/errors/errors_test.go
@@ -1,0 +1,102 @@
+package errors
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+func TestNew_IncludesReason(t *testing.T) {
+	err := New(ErrQuery, "missing table")
+	if err.Error() != "query error: missing table" {
+		t.Errorf("got %q", err.Error())
+	}
+}
+
+func TestWrap_FormatsChain(t *testing.T) {
+	err := Wrap(ErrConnection, "dialing", io.EOF)
+	want := "connection error: dialing: EOF"
+	if err.Error() != want {
+		t.Errorf("got %q, want %q", err.Error(), want)
+	}
+}
+
+func TestIs_MatchesSentinel(t *testing.T) {
+	err := New(ErrValidation, "bad input")
+	if !errors.Is(err, ErrValidation) {
+		t.Error("expected errors.Is(err, ErrValidation) to be true")
+	}
+	if errors.Is(err, ErrQuery) {
+		t.Error("unexpected match on unrelated sentinel")
+	}
+}
+
+func TestIs_MatchesWrappedChain(t *testing.T) {
+	inner := errors.New("inner")
+	err := Wrap(ErrQuery, "outer", inner)
+	if !errors.Is(err, inner) {
+		t.Error("expected errors.Is to see inner in chain")
+	}
+	if !errors.Is(err, ErrQuery) {
+		t.Error("expected errors.Is to see sentinel kind")
+	}
+}
+
+func TestAs_ReturnsTypedError(t *testing.T) {
+	err := error(Wrap(ErrQuery, "outer", io.EOF))
+	var se *SurqlError
+	if !errors.As(err, &se) {
+		t.Fatal("expected errors.As to extract SurqlError")
+	}
+	if se.Kind != ErrQuery {
+		t.Errorf("expected Kind ErrQuery, got %v", se.Kind)
+	}
+}
+
+func TestUnwrap_PrefersWrapped(t *testing.T) {
+	err := Wrap(ErrQuery, "ctx", io.EOF)
+	if errors.Unwrap(err) != io.EOF {
+		t.Errorf("expected Unwrap to return io.EOF, got %v", errors.Unwrap(err))
+	}
+}
+
+func TestUnwrap_FallsBackToKind(t *testing.T) {
+	err := New(ErrQuery, "ctx")
+	if errors.Unwrap(err) != ErrQuery {
+		t.Errorf("expected Unwrap to return ErrQuery, got %v", errors.Unwrap(err))
+	}
+}
+
+func TestNewf_Formats(t *testing.T) {
+	err := Newf(ErrValidation, "bad %s (%d)", "field", 42)
+	if err.Error() != "validation error: bad field (42)" {
+		t.Errorf("got %q", err.Error())
+	}
+}
+
+func TestWrapf_Formats(t *testing.T) {
+	err := Wrapf(ErrQuery, io.EOF, "decoding %s", "row")
+	if err.Error() != "query error: decoding row: EOF" {
+		t.Errorf("got %q", err.Error())
+	}
+}
+
+func TestNilError_HandlesGracefully(t *testing.T) {
+	var e *SurqlError
+	if e.Error() != "<nil>" {
+		t.Errorf("got %q", e.Error())
+	}
+	if e.Unwrap() != nil {
+		t.Error("nil Unwrap should be nil")
+	}
+	if !e.Is(nil) {
+		t.Error("nil should match nil target")
+	}
+}
+
+func TestError_NoReasonOrWrapped_FallsBackToKind(t *testing.T) {
+	e := &SurqlError{Kind: ErrDatabase}
+	if e.Error() != "database error" {
+		t.Errorf("got %q", e.Error())
+	}
+}

--- a/pkg/surql/surql.go
+++ b/pkg/surql/surql.go
@@ -1,0 +1,8 @@
+package surql
+
+// Version is the current surql-go release.
+//
+// The foundation port is under active development; operations that require
+// the SurrealDB client will land incrementally and are tracked against
+// surql-py as the source-of-truth feature set.
+const Version = "0.1.0-dev"

--- a/pkg/surql/types/coerce.go
+++ b/pkg/surql/types/coerce.go
@@ -1,0 +1,96 @@
+package types
+
+import (
+	"strings"
+	"time"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// CoerceDatetime converts a SurrealDB ISO-8601 datetime string into a
+// time.Time in UTC.
+//
+// Supported inputs:
+//   - 2024-01-15T10:30:00Z
+//   - 2024-01-15T10:30:00+00:00
+//   - 2024-01-15T10:30:00.123456789Z  (nanoseconds)
+//   - 2024-01-15T10:30:00             (naive; treated as UTC)
+func CoerceDatetime(value string) (time.Time, error) {
+	// Try RFC 3339 first (handles Z, offsets, and fractional seconds).
+	if t, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return t.UTC(), nil
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t.UTC(), nil
+	}
+	// Naive formats (no timezone).
+	layouts := []string{
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05.999999",
+		"2006-01-02T15:04:05.999",
+		"2006-01-02T15:04:05",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	return time.Time{}, surqlerrors.Newf(
+		surqlerrors.ErrValidation,
+		"could not parse datetime string %q", value,
+	)
+}
+
+// CoerceRecordDatetimes returns a copy of `data` with the listed string
+// fields parsed as UTC datetimes. Missing, null, or non-string fields are
+// left untouched. A parse failure returns the error for the offending
+// field and leaves callers free to recover.
+func CoerceRecordDatetimes(
+	data map[string]any,
+	datetimeFields []string,
+) (map[string]any, error) {
+	out := make(map[string]any, len(data))
+	for k, v := range data {
+		out[k] = v
+	}
+	for _, field := range datetimeFields {
+		raw, ok := out[field]
+		if !ok || raw == nil {
+			continue
+		}
+		s, ok := raw.(string)
+		if !ok {
+			continue
+		}
+		t, err := CoerceDatetime(s)
+		if err != nil {
+			return nil, surqlerrors.Wrapf(
+				surqlerrors.ErrValidation,
+				err,
+				"field %q", field,
+			)
+		}
+		out[field] = t
+	}
+	return out, nil
+}
+
+// normaliseNanos truncates trailing nanos past 9 digits so the RFC3339
+// parser always succeeds (kept internal for symmetry with surql-rs).
+//
+//nolint:unused // retained as a reference helper
+func normaliseNanos(value string) string {
+	idx := strings.Index(value, ".")
+	if idx < 0 {
+		return value
+	}
+	end := idx + 1
+	for end < len(value) && value[end] >= '0' && value[end] <= '9' {
+		end++
+	}
+	frac := value[idx+1 : end]
+	if len(frac) <= 9 {
+		return value
+	}
+	return value[:idx+1] + frac[:9] + value[end:]
+}

--- a/pkg/surql/types/coerce_test.go
+++ b/pkg/surql/types/coerce_test.go
@@ -1,0 +1,101 @@
+package types
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCoerceDatetime_ZSuffix(t *testing.T) {
+	got, err := CoerceDatetime("2024-01-15T10:30:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestCoerceDatetime_Offset(t *testing.T) {
+	got, err := CoerceDatetime("2024-01-15T10:30:00+00:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Hour() != 10 || got.Location() != time.UTC {
+		t.Errorf("got %v (loc=%v)", got, got.Location())
+	}
+}
+
+func TestCoerceDatetime_Nanoseconds(t *testing.T) {
+	got, err := CoerceDatetime("2024-01-15T10:30:00.123456789Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Nanosecond() != 123456789 {
+		t.Errorf("nsec=%d", got.Nanosecond())
+	}
+}
+
+func TestCoerceDatetime_Naive(t *testing.T) {
+	got, err := CoerceDatetime("2024-01-15T10:30:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Location() != time.UTC {
+		t.Errorf("expected UTC, got %v", got.Location())
+	}
+}
+
+func TestCoerceDatetime_RejectsGarbage(t *testing.T) {
+	if _, err := CoerceDatetime("not-a-date"); err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestCoerceRecordDatetimes_ReplacesStringWithTime(t *testing.T) {
+	data := map[string]any{
+		"name":       "Alice",
+		"created_at": "2024-01-15T10:30:00Z",
+	}
+	out, err := CoerceRecordDatetimes(data, []string{"created_at"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := out["created_at"].(time.Time); !ok {
+		t.Errorf("created_at not time.Time: %T", out["created_at"])
+	}
+	if out["name"] != "Alice" {
+		t.Errorf("name corrupted: %v", out["name"])
+	}
+}
+
+func TestCoerceRecordDatetimes_SkipsMissingAndNil(t *testing.T) {
+	data := map[string]any{"deleted_at": nil}
+	out, err := CoerceRecordDatetimes(data, []string{"deleted_at", "not_present"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out["deleted_at"] != nil {
+		t.Errorf("expected nil, got %v", out["deleted_at"])
+	}
+}
+
+func TestCoerceRecordDatetimes_WrapsFieldError(t *testing.T) {
+	data := map[string]any{"created_at": "not-a-date"}
+	_, err := CoerceRecordDatetimes(data, []string{"created_at"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !containsSubstr(err.Error(), "created_at") {
+		t.Errorf("expected field name in error: %q", err.Error())
+	}
+}
+
+func containsSubstr(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/surql/types/operators.go
+++ b/pkg/surql/types/operators.go
@@ -1,0 +1,314 @@
+package types
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Operator is any expression that renders to SurrealQL.
+type Operator interface {
+	ToSurql() string
+}
+
+// quoteValue renders v as a SurrealQL literal.
+//
+// Rules (matching the Python port):
+//   - nil               -> NULL
+//   - bool              -> true / false
+//   - int/uint/float    -> base-10 formatted number
+//   - string            -> 'single-quoted' with \ and ' escaped
+//   - SurrealFn         -> raw expression
+//   - RecordRef         -> type::record(...) raw expression
+//   - []any             -> '[' + quoted elements + ']'
+//   - fmt.Stringer      -> quoted string form
+func quoteValue(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return "NULL"
+	case bool:
+		if x {
+			return "true"
+		}
+		return "false"
+	case int:
+		return strconv.FormatInt(int64(x), 10)
+	case int8, int16, int32, int64:
+		return fmt.Sprintf("%d", x)
+	case uint, uint8, uint16, uint32, uint64:
+		return fmt.Sprintf("%d", x)
+	case float32:
+		return strconv.FormatFloat(float64(x), 'f', -1, 32)
+	case float64:
+		return strconv.FormatFloat(x, 'f', -1, 64)
+	case string:
+		return quoteString(x)
+	case SurrealFn:
+		return x.ToSurql()
+	case RecordRef:
+		return x.ToSurql()
+	case []any:
+		parts := make([]string, len(x))
+		for i, el := range x {
+			parts[i] = quoteValue(el)
+		}
+		return "[" + strings.Join(parts, ", ") + "]"
+	case fmt.Stringer:
+		return quoteString(x.String())
+	default:
+		return quoteString(fmt.Sprint(x))
+	}
+}
+
+func quoteString(s string) string {
+	escaped := strings.ReplaceAll(s, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+	return "'" + escaped + "'"
+}
+
+// --- Comparison operators ---------------------------------------------------
+
+// Eq renders as `field = value`.
+type Eq struct {
+	Field string
+	Value any
+}
+
+// ToSurql implements Operator.
+func (o Eq) ToSurql() string { return fmt.Sprintf("%s = %s", o.Field, quoteValue(o.Value)) }
+
+// Ne renders as `field != value`.
+type Ne struct {
+	Field string
+	Value any
+}
+
+// ToSurql implements Operator.
+func (o Ne) ToSurql() string { return fmt.Sprintf("%s != %s", o.Field, quoteValue(o.Value)) }
+
+// Gt renders as `field > value`.
+type Gt struct {
+	Field string
+	Value any
+}
+
+// ToSurql implements Operator.
+func (o Gt) ToSurql() string { return fmt.Sprintf("%s > %s", o.Field, quoteValue(o.Value)) }
+
+// Gte renders as `field >= value`.
+type Gte struct {
+	Field string
+	Value any
+}
+
+// ToSurql implements Operator.
+func (o Gte) ToSurql() string { return fmt.Sprintf("%s >= %s", o.Field, quoteValue(o.Value)) }
+
+// Lt renders as `field < value`.
+type Lt struct {
+	Field string
+	Value any
+}
+
+// ToSurql implements Operator.
+func (o Lt) ToSurql() string { return fmt.Sprintf("%s < %s", o.Field, quoteValue(o.Value)) }
+
+// Lte renders as `field <= value`.
+type Lte struct {
+	Field string
+	Value any
+}
+
+// ToSurql implements Operator.
+func (o Lte) ToSurql() string { return fmt.Sprintf("%s <= %s", o.Field, quoteValue(o.Value)) }
+
+// Contains renders as `field CONTAINS value`.
+type Contains struct {
+	Field string
+	Value any
+}
+
+// ToSurql implements Operator.
+func (o Contains) ToSurql() string {
+	return fmt.Sprintf("%s CONTAINS %s", o.Field, quoteValue(o.Value))
+}
+
+// ContainsNot renders as `field CONTAINSNOT value`.
+type ContainsNot struct {
+	Field string
+	Value any
+}
+
+// ToSurql implements Operator.
+func (o ContainsNot) ToSurql() string {
+	return fmt.Sprintf("%s CONTAINSNOT %s", o.Field, quoteValue(o.Value))
+}
+
+// --- Array-comparison operators ---------------------------------------------
+
+// ContainsAll renders as `field CONTAINSALL [...]`.
+type ContainsAll struct {
+	Field  string
+	Values []any
+}
+
+// ToSurql implements Operator.
+func (o ContainsAll) ToSurql() string {
+	return fmt.Sprintf("%s CONTAINSALL %s", o.Field, renderList(o.Values))
+}
+
+// ContainsAny renders as `field CONTAINSANY [...]`.
+type ContainsAny struct {
+	Field  string
+	Values []any
+}
+
+// ToSurql implements Operator.
+func (o ContainsAny) ToSurql() string {
+	return fmt.Sprintf("%s CONTAINSANY %s", o.Field, renderList(o.Values))
+}
+
+// Inside renders as `field INSIDE [...]`.
+type Inside struct {
+	Field  string
+	Values []any
+}
+
+// ToSurql implements Operator.
+func (o Inside) ToSurql() string {
+	return fmt.Sprintf("%s INSIDE %s", o.Field, renderList(o.Values))
+}
+
+// NotInside renders as `field NOTINSIDE [...]`.
+type NotInside struct {
+	Field  string
+	Values []any
+}
+
+// ToSurql implements Operator.
+func (o NotInside) ToSurql() string {
+	return fmt.Sprintf("%s NOTINSIDE %s", o.Field, renderList(o.Values))
+}
+
+func renderList(values []any) string {
+	parts := make([]string, len(values))
+	for i, v := range values {
+		parts[i] = quoteValue(v)
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+// --- Null checks ------------------------------------------------------------
+
+// IsNull renders as `field IS NULL`.
+type IsNull struct {
+	Field string
+}
+
+// ToSurql implements Operator.
+func (o IsNull) ToSurql() string { return o.Field + " IS NULL" }
+
+// IsNotNull renders as `field IS NOT NULL`.
+type IsNotNull struct {
+	Field string
+}
+
+// ToSurql implements Operator.
+func (o IsNotNull) ToSurql() string { return o.Field + " IS NOT NULL" }
+
+// --- Logical operators ------------------------------------------------------
+
+// And renders as `(left) AND (right)`.
+type And struct {
+	Left  Operator
+	Right Operator
+}
+
+// ToSurql implements Operator.
+func (o And) ToSurql() string {
+	return fmt.Sprintf("(%s) AND (%s)", o.Left.ToSurql(), o.Right.ToSurql())
+}
+
+// Or renders as `(left) OR (right)`.
+type Or struct {
+	Left  Operator
+	Right Operator
+}
+
+// ToSurql implements Operator.
+func (o Or) ToSurql() string {
+	return fmt.Sprintf("(%s) OR (%s)", o.Left.ToSurql(), o.Right.ToSurql())
+}
+
+// Not renders as `NOT (operand)`.
+type Not struct {
+	Operand Operator
+}
+
+// ToSurql implements Operator.
+func (o Not) ToSurql() string { return "NOT (" + o.Operand.ToSurql() + ")" }
+
+// --- Functional helpers (mirror the Python API) -----------------------------
+
+// EqOp builds an Eq operator.
+func EqOp(field string, value any) Eq { return Eq{Field: field, Value: value} }
+
+// NeOp builds a Ne operator.
+func NeOp(field string, value any) Ne { return Ne{Field: field, Value: value} }
+
+// GtOp builds a Gt operator.
+func GtOp(field string, value any) Gt { return Gt{Field: field, Value: value} }
+
+// GteOp builds a Gte operator.
+func GteOp(field string, value any) Gte { return Gte{Field: field, Value: value} }
+
+// LtOp builds an Lt operator.
+func LtOp(field string, value any) Lt { return Lt{Field: field, Value: value} }
+
+// LteOp builds an Lte operator.
+func LteOp(field string, value any) Lte { return Lte{Field: field, Value: value} }
+
+// ContainsOp builds a Contains operator.
+func ContainsOp(field string, value any) Contains {
+	return Contains{Field: field, Value: value}
+}
+
+// ContainsNotOp builds a ContainsNot operator.
+func ContainsNotOp(field string, value any) ContainsNot {
+	return ContainsNot{Field: field, Value: value}
+}
+
+// ContainsAllOp builds a ContainsAll operator.
+func ContainsAllOp(field string, values []any) ContainsAll {
+	return ContainsAll{Field: field, Values: values}
+}
+
+// ContainsAnyOp builds a ContainsAny operator.
+func ContainsAnyOp(field string, values []any) ContainsAny {
+	return ContainsAny{Field: field, Values: values}
+}
+
+// InsideOp builds an Inside operator.
+func InsideOp(field string, values []any) Inside {
+	return Inside{Field: field, Values: values}
+}
+
+// NotInsideOp builds a NotInside operator.
+func NotInsideOp(field string, values []any) NotInside {
+	return NotInside{Field: field, Values: values}
+}
+
+// IsNullOp builds an IsNull operator.
+func IsNullOp(field string) IsNull { return IsNull{Field: field} }
+
+// IsNotNullOp builds an IsNotNull operator.
+func IsNotNullOp(field string) IsNotNull { return IsNotNull{Field: field} }
+
+// AndOp combines two operators with logical AND.
+func AndOp(left, right Operator) And { return And{Left: left, Right: right} }
+
+// OrOp combines two operators with logical OR.
+func OrOp(left, right Operator) Or { return Or{Left: left, Right: right} }
+
+// NotOp negates an operator.
+func NotOp(o Operator) Not { return Not{Operand: o} }

--- a/pkg/surql/types/operators_test.go
+++ b/pkg/surql/types/operators_test.go
@@ -1,0 +1,155 @@
+package types
+
+import "testing"
+
+func TestEq_String(t *testing.T) {
+	if got := EqOp("name", "Alice").ToSurql(); got != `name = 'Alice'` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestNe_String(t *testing.T) {
+	if got := NeOp("status", "deleted").ToSurql(); got != `status != 'deleted'` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestGt_Int(t *testing.T) {
+	if got := GtOp("age", 18).ToSurql(); got != "age > 18" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestLt_Float(t *testing.T) {
+	if got := LtOp("price", 50.0).ToSurql(); got != "price < 50" {
+		// Go strips trailing zeros via %g-style; accept either 50 or 50.0
+		if got != "price < 50.0" {
+			t.Errorf("got %q", got)
+		}
+	}
+}
+
+func TestGteAndLte(t *testing.T) {
+	if got := GteOp("score", 100).ToSurql(); got != "score >= 100" {
+		t.Errorf("gte: %q", got)
+	}
+	if got := LteOp("quantity", 10).ToSurql(); got != "quantity <= 10" {
+		t.Errorf("lte: %q", got)
+	}
+}
+
+func TestContains(t *testing.T) {
+	got := ContainsOp("email", "@example.com").ToSurql()
+	if got != `email CONTAINS '@example.com'` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestContainsNot(t *testing.T) {
+	got := ContainsNotOp("tags", "spam").ToSurql()
+	if got != `tags CONTAINSNOT 'spam'` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestContainsAll(t *testing.T) {
+	got := ContainsAllOp("tags", []any{"python", "database"}).ToSurql()
+	if got != `tags CONTAINSALL ['python', 'database']` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestContainsAny(t *testing.T) {
+	got := ContainsAnyOp("tags", []any{"python", "javascript"}).ToSurql()
+	if got != `tags CONTAINSANY ['python', 'javascript']` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestInside(t *testing.T) {
+	got := InsideOp("status", []any{"active", "pending"}).ToSurql()
+	if got != `status INSIDE ['active', 'pending']` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestNotInside(t *testing.T) {
+	got := NotInsideOp("status", []any{"deleted", "archived"}).ToSurql()
+	if got != `status NOTINSIDE ['deleted', 'archived']` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestIsNullAndNotNull(t *testing.T) {
+	if got := IsNullOp("deleted_at").ToSurql(); got != "deleted_at IS NULL" {
+		t.Errorf("is null: %q", got)
+	}
+	if got := IsNotNullOp("created_at").ToSurql(); got != "created_at IS NOT NULL" {
+		t.Errorf("is not null: %q", got)
+	}
+}
+
+func TestAnd(t *testing.T) {
+	got := AndOp(GtOp("age", 18), EqOp("status", "active")).ToSurql()
+	if got != `(age > 18) AND (status = 'active')` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestOr(t *testing.T) {
+	got := OrOp(EqOp("type", "admin"), EqOp("type", "moderator")).ToSurql()
+	if got != `(type = 'admin') OR (type = 'moderator')` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestNot(t *testing.T) {
+	got := NotOp(EqOp("status", "deleted")).ToSurql()
+	if got != `NOT (status = 'deleted')` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestNullQuotedAsNULL(t *testing.T) {
+	got := EqOp("deleted_at", nil).ToSurql()
+	if got != "deleted_at = NULL" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestBoolQuotedLowercase(t *testing.T) {
+	if got := EqOp("active", true).ToSurql(); got != "active = true" {
+		t.Errorf("true: %q", got)
+	}
+	if got := EqOp("active", false).ToSurql(); got != "active = false" {
+		t.Errorf("false: %q", got)
+	}
+}
+
+func TestStringEscapesSingleQuote(t *testing.T) {
+	got := EqOp("name", "O'Brien").ToSurql()
+	if got != `name = 'O\'Brien'` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestStringEscapesBackslash(t *testing.T) {
+	got := EqOp("path", `a\b`).ToSurql()
+	if got != `path = 'a\\b'` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSurrealFnValueRendersRaw(t *testing.T) {
+	got := EqOp("created_at", SurqlFn("time::now")).ToSurql()
+	if got != "created_at = time::now()" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRecordRefValueRendersRaw(t *testing.T) {
+	got := EqOp("author", StringRecordRef("user", "alice")).ToSurql()
+	if got != "author = type::record('user', 'alice')" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/pkg/surql/types/record_id.go
+++ b/pkg/surql/types/record_id.go
@@ -1,0 +1,218 @@
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// tablePattern matches valid SurrealDB table names: [A-Za-z_][A-Za-z0-9_]*
+var tablePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// simpleIDPattern matches an id that does NOT require angle brackets.
+var simpleIDPattern = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+
+// RecordIDValue holds either a string or integer record id. Integer ids
+// never require angle-bracket syntax in SurrealDB.
+type RecordIDValue struct {
+	str     string
+	intVal  int64
+	isInt   bool
+	present bool
+}
+
+// StringID constructs a string-valued record id.
+func StringID(s string) RecordIDValue {
+	return RecordIDValue{str: s, present: true}
+}
+
+// IntID constructs an integer-valued record id.
+func IntID(n int64) RecordIDValue {
+	return RecordIDValue{intVal: n, isInt: true, present: true}
+}
+
+// IsInt reports whether the id is integer-valued.
+func (v RecordIDValue) IsInt() bool { return v.isInt }
+
+// String returns the id as a string for rendering.
+func (v RecordIDValue) String() string {
+	if v.isInt {
+		return strconv.FormatInt(v.intVal, 10)
+	}
+	return v.str
+}
+
+// Int returns the underlying integer id (or 0 when the id is a string).
+func (v RecordIDValue) Int() int64 { return v.intVal }
+
+// MarshalJSON encodes the id as its underlying JSON primitive.
+func (v RecordIDValue) MarshalJSON() ([]byte, error) {
+	if v.isInt {
+		return json.Marshal(v.intVal)
+	}
+	return json.Marshal(v.str)
+}
+
+// UnmarshalJSON accepts either a JSON string or integer.
+func (v *RecordIDValue) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		*v = StringID(s)
+		return nil
+	}
+	var n int64
+	if err := json.Unmarshal(data, &n); err != nil {
+		return err
+	}
+	*v = IntID(n)
+	return nil
+}
+
+// RecordID is a type-safe wrapper for SurrealDB record ids (`table:id`).
+type RecordID struct {
+	table string
+	id    RecordIDValue
+}
+
+// NewRecordID builds a RecordID after validating the table name.
+func NewRecordID(table string, id RecordIDValue) (RecordID, error) {
+	if err := validateTable(table); err != nil {
+		return RecordID{}, err
+	}
+	if !id.present {
+		return RecordID{}, surqlerrors.New(surqlerrors.ErrValidation, "record id cannot be empty")
+	}
+	return RecordID{table: table, id: id}, nil
+}
+
+// NewStringRecordID is a convenience constructor for string-valued ids.
+func NewStringRecordID(table, id string) (RecordID, error) {
+	return NewRecordID(table, StringID(id))
+}
+
+// NewIntRecordID is a convenience constructor for integer-valued ids.
+func NewIntRecordID(table string, id int64) (RecordID, error) {
+	return NewRecordID(table, IntID(id))
+}
+
+func validateTable(table string) error {
+	if table == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "Table name cannot be empty")
+	}
+	if !tablePattern.MatchString(table) {
+		return surqlerrors.Newf(
+			surqlerrors.ErrValidation,
+			"Invalid table name: %q. Must contain only alphanumeric characters and underscores, and cannot start with a digit",
+			table,
+		)
+	}
+	return nil
+}
+
+// Table returns the table name.
+func (r RecordID) Table() string { return r.table }
+
+// ID returns the record id value.
+func (r RecordID) ID() RecordIDValue { return r.id }
+
+// String renders as `table:id` or `table:<id>` when the id needs angle brackets.
+func (r RecordID) String() string {
+	if r.needsAngleBrackets() {
+		return fmt.Sprintf("%s:<%s>", r.table, r.id.String())
+	}
+	return fmt.Sprintf("%s:%s", r.table, r.id.String())
+}
+
+// ToSurql renders as the SurrealQL record id literal.
+func (r RecordID) ToSurql() string { return r.String() }
+
+func (r RecordID) needsAngleBrackets() bool {
+	if r.id.isInt {
+		return false
+	}
+	return !simpleIDPattern.MatchString(r.id.str)
+}
+
+// ParseRecordID parses `table:id` (or `table:<id>`). Integer-looking ids
+// become IntID; everything else stays a StringID. Angle brackets, when
+// present, are stripped on parse.
+func ParseRecordID(input string) (RecordID, error) {
+	idx := strings.Index(input, ":")
+	if idx < 0 {
+		return RecordID{}, surqlerrors.Newf(
+			surqlerrors.ErrValidation,
+			"Invalid record ID format: %s. Expected format: table:id",
+			input,
+		)
+	}
+	table := strings.TrimSpace(input[:idx])
+	idStr := strings.TrimSpace(input[idx+1:])
+	if table == "" {
+		return RecordID{}, surqlerrors.Newf(
+			surqlerrors.ErrValidation,
+			"Invalid record ID: table name cannot be empty in %q", input,
+		)
+	}
+	if idStr == "" {
+		return RecordID{}, surqlerrors.Newf(
+			surqlerrors.ErrValidation,
+			"Invalid record ID: id cannot be empty in %q", input,
+		)
+	}
+	if len(idStr) >= 2 && idStr[0] == '<' && idStr[len(idStr)-1] == '>' {
+		idStr = idStr[1 : len(idStr)-1]
+	}
+	if n, err := strconv.ParseInt(idStr, 10, 64); err == nil {
+		return NewIntRecordID(table, n)
+	}
+	return NewStringRecordID(table, idStr)
+}
+
+// MarshalJSON encodes as a plain string (`table:id` / `table:<id>`).
+//
+// Note: callers that pass the result through encoding/json at the top
+// level will receive Go's default HTML-escaped angle brackets (`\u003c` /
+// `\u003e`). To preserve literal `<>` for wire parity with surql-py and
+// surql-ts, use [encoding/json.Encoder] with SetEscapeHTML(false).
+// Both forms decode back into the same RecordID.
+func (r RecordID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.String())
+}
+
+// marshalJSONNoHTMLEscape is kept as a reference for callers who need the
+// unescaped wire form.
+func (r RecordID) marshalJSONNoHTMLEscape() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(r.String()); err != nil {
+		return nil, err
+	}
+	out := buf.Bytes()
+	if n := len(out); n > 0 && out[n-1] == '\n' {
+		out = out[:n-1]
+	}
+	return out, nil
+}
+
+// UnmarshalJSON accepts a string in `table:id` / `table:<id>` form.
+func (r *RecordID) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	parsed, err := ParseRecordID(s)
+	if err != nil {
+		return err
+	}
+	*r = parsed
+	return nil
+}

--- a/pkg/surql/types/record_id_test.go
+++ b/pkg/surql/types/record_id_test.go
@@ -1,0 +1,159 @@
+package types
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestStringID_RendersSimple(t *testing.T) {
+	id, err := NewStringRecordID("user", "alice")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if id.String() != "user:alice" {
+		t.Errorf("got %q", id.String())
+	}
+}
+
+func TestComplexID_UsesAngleBrackets(t *testing.T) {
+	id, err := NewStringRecordID("outlet", "alaskabeacon.com")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if id.String() != "outlet:<alaskabeacon.com>" {
+		t.Errorf("got %q", id.String())
+	}
+}
+
+func TestIntID_NeverBrackets(t *testing.T) {
+	id, err := NewIntRecordID("post", 123)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if id.String() != "post:123" {
+		t.Errorf("got %q", id.String())
+	}
+}
+
+func TestParse_SimpleString(t *testing.T) {
+	id, err := ParseRecordID("user:alice")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if id.Table() != "user" || id.ID().String() != "alice" {
+		t.Errorf("got table=%q id=%q", id.Table(), id.ID().String())
+	}
+}
+
+func TestParse_IntegerID(t *testing.T) {
+	id, err := ParseRecordID("post:42")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !id.ID().IsInt() || id.ID().Int() != 42 {
+		t.Errorf("expected int 42, got %+v", id.ID())
+	}
+}
+
+func TestParse_AngleBrackets(t *testing.T) {
+	id, err := ParseRecordID("outlet:<alaskabeacon.com>")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if id.ID().IsInt() {
+		t.Error("expected string id, got int")
+	}
+	if id.ID().String() != "alaskabeacon.com" {
+		t.Errorf("got %q", id.ID().String())
+	}
+}
+
+func TestParse_Rejects(t *testing.T) {
+	cases := []string{"", "user", ":id", "user:"}
+	for _, c := range cases {
+		if _, err := ParseRecordID(c); err == nil {
+			t.Errorf("expected error for %q", c)
+		} else if !errors.Is(err, surqlerrors.ErrValidation) {
+			t.Errorf("expected validation error for %q, got %v", c, err)
+		}
+	}
+}
+
+func TestNew_RejectsInvalidTable(t *testing.T) {
+	cases := []string{"", "user-name", "1user", "user name"}
+	for _, c := range cases {
+		if _, err := NewStringRecordID(c, "alice"); err == nil {
+			t.Errorf("expected error for table %q", c)
+		}
+	}
+}
+
+func TestJSON_StringRoundtrip(t *testing.T) {
+	id, _ := NewStringRecordID("user", "alice")
+	data, err := json.Marshal(id)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(data) != `"user:alice"` {
+		t.Errorf("got %s", data)
+	}
+	var back RecordID
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.String() != id.String() {
+		t.Errorf("roundtrip mismatch: %q vs %q", back.String(), id.String())
+	}
+}
+
+func TestJSON_ComplexRoundtrip(t *testing.T) {
+	id, _ := NewStringRecordID("outlet", "alaskabeacon.com")
+	data, _ := json.Marshal(id)
+	// json.Marshal HTML-escapes `<`/`>` by default; both the escaped and
+	// literal forms must decode identically.
+	want1 := `"outlet:<alaskabeacon.com>"`
+	want2 := `"outlet:\u003calaskabeacon.com\u003e"`
+	if s := string(data); s != want1 && s != want2 {
+		t.Errorf("got %s (expected %s or %s)", s, want1, want2)
+	}
+	var back RecordID
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.ID().String() != "alaskabeacon.com" {
+		t.Errorf("got %q", back.ID().String())
+	}
+	// Literal form also roundtrips.
+	literal, err := id.marshalJSONNoHTMLEscape()
+	if err != nil {
+		t.Fatalf("no-html marshal: %v", err)
+	}
+	if string(literal) != want1 {
+		t.Errorf("literal form: got %s, want %s", literal, want1)
+	}
+	var back2 RecordID
+	if err := json.Unmarshal(literal, &back2); err != nil {
+		t.Fatalf("unmarshal literal: %v", err)
+	}
+	if back2.ID().String() != "alaskabeacon.com" {
+		t.Errorf("literal roundtrip: got %q", back2.ID().String())
+	}
+}
+
+func TestJSON_IntRoundtrip(t *testing.T) {
+	id, _ := NewIntRecordID("post", 123)
+	data, _ := json.Marshal(id)
+	if string(data) != `"post:123"` {
+		t.Errorf("got %s", data)
+	}
+	var back RecordID
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !back.ID().IsInt() || back.ID().Int() != 123 {
+		t.Errorf("lost int type: %+v", back.ID())
+	}
+}

--- a/pkg/surql/types/record_ref.go
+++ b/pkg/surql/types/record_ref.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RecordRef references a SurrealDB record via `type::record(table, id)`.
+// When emitted in a query body the expression renders verbatim rather
+// than being quoted as a string literal.
+type RecordRef struct {
+	Table    string        `json:"table"`
+	RecordID RecordIDValue `json:"record_id"`
+}
+
+// ToSurql renders as a `type::record()` SurrealQL call.
+func (r RecordRef) ToSurql() string {
+	if r.RecordID.IsInt() {
+		return fmt.Sprintf("type::record('%s', %d)", r.Table, r.RecordID.Int())
+	}
+	escaped := strings.ReplaceAll(r.RecordID.String(), `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+	return fmt.Sprintf("type::record('%s', '%s')", r.Table, escaped)
+}
+
+// String implements fmt.Stringer.
+func (r RecordRef) String() string { return r.ToSurql() }
+
+// NewRecordRef constructs a RecordRef.
+func NewRecordRef(table string, id RecordIDValue) RecordRef {
+	return RecordRef{Table: table, RecordID: id}
+}
+
+// StringRecordRef is a convenience for string-valued record refs.
+func StringRecordRef(table, id string) RecordRef {
+	return RecordRef{Table: table, RecordID: StringID(id)}
+}
+
+// IntRecordRef is a convenience for integer-valued record refs.
+func IntRecordRef(table string, id int64) RecordRef {
+	return RecordRef{Table: table, RecordID: IntID(id)}
+}

--- a/pkg/surql/types/record_ref_test.go
+++ b/pkg/surql/types/record_ref_test.go
@@ -1,0 +1,70 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRecordRef_RendersString(t *testing.T) {
+	got := StringRecordRef("user", "alice").ToSurql()
+	if got != "type::record('user', 'alice')" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRecordRef_RendersInt(t *testing.T) {
+	got := IntRecordRef("post", 123).ToSurql()
+	if got != "type::record('post', 123)" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRecordRef_EscapesSingleQuote(t *testing.T) {
+	got := StringRecordRef("user", "o'brien").ToSurql()
+	want := `type::record('user', 'o\'brien')`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRecordRef_EscapesBackslash(t *testing.T) {
+	got := StringRecordRef("path", `a\b`).ToSurql()
+	want := `type::record('path', 'a\\b')`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRecordRef_StringMatchesToSurql(t *testing.T) {
+	r := StringRecordRef("user", "alice")
+	if r.String() != r.ToSurql() {
+		t.Errorf("String=%q ToSurql=%q", r.String(), r.ToSurql())
+	}
+}
+
+func TestRecordRef_JSONRoundtrip(t *testing.T) {
+	r := StringRecordRef("user", "alice")
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back RecordRef
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.ToSurql() != r.ToSurql() {
+		t.Errorf("roundtrip: got %q vs %q", back.ToSurql(), r.ToSurql())
+	}
+}
+
+func TestRecordRef_JSONRoundtripInt(t *testing.T) {
+	r := IntRecordRef("post", 42)
+	data, _ := json.Marshal(r)
+	var back RecordRef
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !back.RecordID.IsInt() || back.RecordID.Int() != 42 {
+		t.Errorf("lost int id: %+v", back.RecordID)
+	}
+}

--- a/pkg/surql/types/reserved.go
+++ b/pkg/surql/types/reserved.go
@@ -1,0 +1,68 @@
+// Package types provides type-safe primitives for building SurrealDB queries.
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SurrealReservedWords is the canonical set of SurrealDB reserved words
+// used for field-name collision detection.
+var SurrealReservedWords = map[string]struct{}{
+	"select": {}, "from": {}, "where": {}, "group": {}, "order": {},
+	"limit": {}, "start": {}, "fetch": {}, "timeout": {}, "parallel": {},
+	"value": {}, "content": {}, "set": {}, "create": {}, "update": {},
+	"delete": {}, "relate": {}, "insert": {}, "define": {}, "remove": {},
+	"begin": {}, "commit": {}, "cancel": {}, "return": {}, "let": {},
+	"if": {}, "else": {}, "then": {}, "end": {}, "for": {},
+	"break": {}, "continue": {}, "throw": {}, "none": {}, "null": {},
+	"true": {}, "false": {}, "and": {}, "or": {}, "not": {},
+	"is": {}, "contains": {}, "inside": {}, "outside": {}, "intersects": {},
+	"type": {}, "table": {}, "field": {}, "index": {}, "event": {},
+	"namespace": {}, "database": {}, "scope": {}, "token": {}, "info": {},
+	"live": {}, "kill": {}, "sleep": {}, "use": {}, "in": {}, "out": {},
+}
+
+// EdgeAllowedReserved names reserved words that are permitted on edge schemas.
+var EdgeAllowedReserved = map[string]struct{}{
+	"in":  {},
+	"out": {},
+}
+
+// IsReservedWord reports whether name (case-insensitive, leaf of dot-path) is reserved.
+func IsReservedWord(name string) bool {
+	leaf := leafSegment(name)
+	_, ok := SurrealReservedWords[strings.ToLower(leaf)]
+	return ok
+}
+
+// CheckReservedWord returns a warning message when name collides with a
+// SurrealDB reserved word, or the empty string when it is safe. When
+// allowEdgeFields is true, the edge-allowed identifiers (`in`, `out`) are
+// permitted.
+//
+// Dot-notation names have only their leaf segment checked.
+func CheckReservedWord(name string, allowEdgeFields bool) string {
+	leaf := leafSegment(name)
+	lower := strings.ToLower(leaf)
+
+	if _, reserved := SurrealReservedWords[lower]; !reserved {
+		return ""
+	}
+	if allowEdgeFields {
+		if _, ok := EdgeAllowedReserved[lower]; ok {
+			return ""
+		}
+	}
+	return fmt.Sprintf(
+		"Field name %q collides with SurrealDB reserved word %q. This may cause unexpected query behavior.",
+		name, lower,
+	)
+}
+
+func leafSegment(name string) string {
+	if idx := strings.LastIndex(name, "."); idx >= 0 {
+		return name[idx+1:]
+	}
+	return name
+}

--- a/pkg/surql/types/reserved_test.go
+++ b/pkg/surql/types/reserved_test.go
@@ -1,0 +1,76 @@
+package types
+
+import "testing"
+
+func TestIsReservedWord_CaseInsensitive(t *testing.T) {
+	cases := []string{"SELECT", "select", "Where", "FROM"}
+	for _, c := range cases {
+		if !IsReservedWord(c) {
+			t.Errorf("expected %q to be reserved", c)
+		}
+	}
+}
+
+func TestIsReservedWord_SafeNames(t *testing.T) {
+	safe := []string{"username", "user_name", "email", "created_at"}
+	for _, c := range safe {
+		if IsReservedWord(c) {
+			t.Errorf("expected %q to be safe", c)
+		}
+	}
+}
+
+func TestCheckReservedWord_DotNotationLeaf(t *testing.T) {
+	if got := CheckReservedWord("user.name", false); got != "" {
+		t.Errorf("expected safe for user.name, got %q", got)
+	}
+	if got := CheckReservedWord("user.select", false); got == "" {
+		t.Error("expected warning for user.select")
+	}
+}
+
+func TestCheckReservedWord_EdgeAllowed(t *testing.T) {
+	if got := CheckReservedWord("in", true); got != "" {
+		t.Errorf("expected `in` safe with allowEdgeFields, got %q", got)
+	}
+	if got := CheckReservedWord("out", true); got != "" {
+		t.Errorf("expected `out` safe with allowEdgeFields, got %q", got)
+	}
+	if got := CheckReservedWord("in", false); got == "" {
+		t.Error("expected warning for `in` without allowEdgeFields")
+	}
+}
+
+func TestCheckReservedWord_MessageContainsName(t *testing.T) {
+	msg := CheckReservedWord("select", false)
+	if msg == "" {
+		t.Fatal("expected a warning message")
+	}
+	if !containsAll(msg, "select", "reserved word") {
+		t.Errorf("unexpected message: %q", msg)
+	}
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if !contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || indexOf(s, sub) >= 0
+}
+
+func indexOf(s, sub string) int {
+	// small helper; equivalent to strings.Index without importing strings
+	// purely for demonstration — keeps helper file dependency-free.
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/surql/types/surreal_fn.go
+++ b/pkg/surql/types/surreal_fn.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SurrealFn wraps a raw SurrealQL function expression so that, when used as
+// a value in CREATE/UPDATE/UPSERT, it is emitted verbatim (not quoted as a
+// string literal).
+type SurrealFn struct {
+	Expression string `json:"expression"`
+}
+
+// ToSurql renders the function call as raw SurrealQL.
+func (f SurrealFn) ToSurql() string {
+	return f.Expression
+}
+
+// String implements fmt.Stringer.
+func (f SurrealFn) String() string {
+	return f.Expression
+}
+
+// NewSurrealFn constructs a SurrealFn from a rendered expression.
+func NewSurrealFn(expression string) SurrealFn {
+	return SurrealFn{Expression: expression}
+}
+
+// SurqlFn builds a SurrealDB function call value. args are rendered verbatim
+// (via fmt.Sprint) and joined with ", ". When args is empty the call uses
+// empty parentheses.
+func SurqlFn(name string, args ...any) SurrealFn {
+	if len(args) == 0 {
+		return SurrealFn{Expression: name + "()"}
+	}
+	parts := make([]string, len(args))
+	for i, a := range args {
+		parts[i] = fmt.Sprint(a)
+	}
+	return SurrealFn{Expression: fmt.Sprintf("%s(%s)", name, strings.Join(parts, ", "))}
+}

--- a/pkg/surql/types/surreal_fn_test.go
+++ b/pkg/surql/types/surreal_fn_test.go
@@ -1,0 +1,57 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSurqlFn_NoArgs(t *testing.T) {
+	got := SurqlFn("time::now").ToSurql()
+	if got != "time::now()" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSurqlFn_WithArgs(t *testing.T) {
+	got := SurqlFn("time::format", "created_at", "%Y-%m-%d").ToSurql()
+	want := "time::format(created_at, %Y-%m-%d)"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSurqlFn_SingleArg(t *testing.T) {
+	got := SurqlFn("math::sum", "scores").ToSurql()
+	if got != "math::sum(scores)" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSurrealFn_StringMatchesToSurql(t *testing.T) {
+	f := SurqlFn("time::now")
+	if f.String() != f.ToSurql() {
+		t.Errorf("String=%q ToSurql=%q", f.String(), f.ToSurql())
+	}
+}
+
+func TestSurrealFn_JSONRoundtrip(t *testing.T) {
+	f := NewSurrealFn("time::now()")
+	data, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back SurrealFn
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back != f {
+		t.Errorf("roundtrip: got %+v, want %+v", back, f)
+	}
+}
+
+func TestSurqlFn_IntegerArg(t *testing.T) {
+	got := SurqlFn("math::add", 1, 2).ToSurql()
+	if got != "math::add(1, 2)" {
+		t.Errorf("got %q", got)
+	}
+}


### PR DESCRIPTION
Closes #1.

## Summary
First increment of the 1:1 port of [surql-py](https://github.com/Oneiriq/surql-py) to Go.

- **Scaffolding**: go.mod (go 1.26.1), Makefile (build/test/vet/fmt/cover/check), .golangci.yml (errcheck/govet/staticcheck/revive/gosec/unused), .goreleaser.yml (multi-arch static binaries, -s -w ldflags, CGO_ENABLED=0), CI workflows (lint/test + integration with SurrealDB service container + release via goreleaser).
- **Errors (\`pkg/surql/errors/\`)**: sentinel errors (ErrDatabase, ErrConnection, ErrQuery, ErrTransaction, ErrContext, ErrRegistry, ErrStreaming, ErrValidation, ErrSchemaParse, ErrMigration*, ErrOrchestration, ErrSerialization) plus typed \`SurqlError\` with \`errors.Is\`/\`errors.As\` support and %w wrapping.
- **Types (\`pkg/surql/types/\`)**: 1:1 port of surql-py/src/surql/types/:
  - \`operators.go\` — Eq/Ne/Gt/Gte/Lt/Lte, Contains/ContainsNot/ContainsAll/ContainsAny, Inside/NotInside, IsNull/IsNotNull, And/Or/Not + functional helpers (EqOp, NeOp, etc). SurrealFn / RecordRef values render verbatim in query bodies.
  - \`record_id.go\` — RecordID with angle-bracket syntax for complex ids + integer ids, JSON roundtrip.
  - \`record_ref.go\` — type::record() builder.
  - \`surreal_fn.go\` — raw SurrealQL function call wrapper.
  - \`reserved.go\` — SurrealReservedWords + CheckReservedWord helper.
  - \`coerce.go\` — ISO-8601 datetime parsing + bulk record coercion.
- **CLI (\`cmd/surql/main.go\`)**: binary stub with \`--version\` flag.

## Test plan
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] \`go test ./... -race\` — **all tests pass** (errors + types packages)
- [ ] CI green (awaiting workflow run)

## Roadmap after this PR
Next increments will port \`connection\`, \`query\`, \`schema\`, \`migration\`, \`cache\`, \`orchestration\`, and the full CLI -- each on its own issue/branch.