### PR TITLE
feat(connection): config + auth credential types

### DIFF
--- a/pkg/surql/connection/auth.go
+++ b/pkg/surql/connection/auth.go
@@ -1,0 +1,166 @@
+package connection
+
+// AuthType is the SurrealDB authentication level.
+type AuthType string
+
+const (
+	// AuthRoot == server root user.
+	AuthRoot AuthType = "root"
+	// AuthNamespace == namespace user.
+	AuthNamespace AuthType = "namespace"
+	// AuthDatabase == database user.
+	AuthDatabase AuthType = "database"
+	// AuthScope == record/scope-level user.
+	AuthScope AuthType = "scope"
+)
+
+// Credentials is implemented by every credential type so the runtime
+// client can serialise them to the SurrealDB SDK signin/signup payload.
+type Credentials interface {
+	AuthType() AuthType
+	ToSigninPayload() map[string]any
+}
+
+// RootCredentials carry server root-level username + password.
+type RootCredentials struct {
+	Username string `json:"username"`
+	Password string `json:"password,omitempty"`
+}
+
+// AuthType implements Credentials.
+func (RootCredentials) AuthType() AuthType { return AuthRoot }
+
+// ToSigninPayload implements Credentials.
+func (c RootCredentials) ToSigninPayload() map[string]any {
+	out := map[string]any{"username": c.Username}
+	if c.Password != "" {
+		out["password"] = c.Password
+	}
+	return out
+}
+
+// NewRootCredentials constructs a RootCredentials.
+func NewRootCredentials(username, password string) RootCredentials {
+	return RootCredentials{Username: username, Password: password}
+}
+
+// NamespaceCredentials carry namespace-scoped signin material.
+type NamespaceCredentials struct {
+	Namespace string `json:"namespace"`
+	Username  string `json:"username"`
+	Password  string `json:"password,omitempty"`
+}
+
+// AuthType implements Credentials.
+func (NamespaceCredentials) AuthType() AuthType { return AuthNamespace }
+
+// ToSigninPayload implements Credentials.
+func (c NamespaceCredentials) ToSigninPayload() map[string]any {
+	out := map[string]any{
+		"namespace": c.Namespace,
+		"username":  c.Username,
+	}
+	if c.Password != "" {
+		out["password"] = c.Password
+	}
+	return out
+}
+
+// NewNamespaceCredentials constructs a NamespaceCredentials.
+func NewNamespaceCredentials(namespace, username, password string) NamespaceCredentials {
+	return NamespaceCredentials{Namespace: namespace, Username: username, Password: password}
+}
+
+// DatabaseCredentials carry database-scoped signin material.
+type DatabaseCredentials struct {
+	Namespace string `json:"namespace"`
+	Database  string `json:"database"`
+	Username  string `json:"username"`
+	Password  string `json:"password,omitempty"`
+}
+
+// AuthType implements Credentials.
+func (DatabaseCredentials) AuthType() AuthType { return AuthDatabase }
+
+// ToSigninPayload implements Credentials.
+func (c DatabaseCredentials) ToSigninPayload() map[string]any {
+	out := map[string]any{
+		"namespace": c.Namespace,
+		"database":  c.Database,
+		"username":  c.Username,
+	}
+	if c.Password != "" {
+		out["password"] = c.Password
+	}
+	return out
+}
+
+// NewDatabaseCredentials constructs a DatabaseCredentials.
+func NewDatabaseCredentials(namespace, database, username, password string) DatabaseCredentials {
+	return DatabaseCredentials{
+		Namespace: namespace, Database: database, Username: username, Password: password,
+	}
+}
+
+// ScopeCredentials carry record/scope-level signin material. Variables are
+// flattened into the top-level signin payload (e.g. email, password).
+type ScopeCredentials struct {
+	Namespace string         `json:"namespace"`
+	Database  string         `json:"database"`
+	Access    string         `json:"access"`
+	Variables map[string]any `json:"variables,omitempty"`
+}
+
+// AuthType implements Credentials.
+func (ScopeCredentials) AuthType() AuthType { return AuthScope }
+
+// ToSigninPayload implements Credentials.
+func (c ScopeCredentials) ToSigninPayload() map[string]any {
+	out := map[string]any{
+		"namespace": c.Namespace,
+		"database":  c.Database,
+		"access":    c.Access,
+	}
+	for k, v := range c.Variables {
+		out[k] = v
+	}
+	return out
+}
+
+// NewScopeCredentials constructs ScopeCredentials with an empty variable set.
+func NewScopeCredentials(namespace, database, access string) ScopeCredentials {
+	return ScopeCredentials{
+		Namespace: namespace, Database: database, Access: access,
+		Variables: map[string]any{},
+	}
+}
+
+// With attaches a scope variable (e.g. "email", "password") and returns a
+// copy.
+func (c ScopeCredentials) With(key string, value any) ScopeCredentials {
+	vars := make(map[string]any, len(c.Variables)+1)
+	for k, v := range c.Variables {
+		vars[k] = v
+	}
+	vars[key] = value
+	c.Variables = vars
+	return c
+}
+
+// TokenAuth carries an existing JWT.
+type TokenAuth struct {
+	Token string `json:"token"`
+}
+
+// NewTokenAuth constructs a TokenAuth.
+func NewTokenAuth(token string) TokenAuth {
+	return TokenAuth{Token: token}
+}
+
+// Compile-time interface checks.
+var (
+	_ Credentials = RootCredentials{}
+	_ Credentials = NamespaceCredentials{}
+	_ Credentials = DatabaseCredentials{}
+	_ Credentials = ScopeCredentials{}
+)

--- a/pkg/surql/connection/auth_test.go
+++ b/pkg/surql/connection/auth_test.go
@@ -1,0 +1,117 @@
+package connection
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAuthType_Values(t *testing.T) {
+	cases := map[AuthType]string{
+		AuthRoot:      "root",
+		AuthNamespace: "namespace",
+		AuthDatabase:  "database",
+		AuthScope:     "scope",
+	}
+	for at, want := range cases {
+		if string(at) != want {
+			t.Errorf("%v: got %q, want %q", at, string(at), want)
+		}
+	}
+}
+
+func TestRootCredentials_Payload(t *testing.T) {
+	c := NewRootCredentials("root", "secret")
+	p := c.ToSigninPayload()
+	if p["username"] != "root" || p["password"] != "secret" {
+		t.Errorf("payload: %+v", p)
+	}
+	if c.AuthType() != AuthRoot {
+		t.Errorf("authtype: %v", c.AuthType())
+	}
+}
+
+func TestNamespaceCredentials_Payload(t *testing.T) {
+	c := NewNamespaceCredentials("prod", "u", "p")
+	p := c.ToSigninPayload()
+	if p["namespace"] != "prod" || p["username"] != "u" || p["password"] != "p" {
+		t.Errorf("payload: %+v", p)
+	}
+	if c.AuthType() != AuthNamespace {
+		t.Error("authtype mismatch")
+	}
+}
+
+func TestDatabaseCredentials_Payload(t *testing.T) {
+	c := NewDatabaseCredentials("prod", "app", "u", "p")
+	p := c.ToSigninPayload()
+	if p["namespace"] != "prod" || p["database"] != "app" {
+		t.Errorf("ns/db: %+v", p)
+	}
+	if p["username"] != "u" || p["password"] != "p" {
+		t.Errorf("user/pass: %+v", p)
+	}
+	if c.AuthType() != AuthDatabase {
+		t.Error("authtype mismatch")
+	}
+}
+
+func TestScopeCredentials_PayloadFlattensVariables(t *testing.T) {
+	c := NewScopeCredentials("prod", "app", "user").
+		With("email", "a@example.com").
+		With("password", "secret")
+	p := c.ToSigninPayload()
+	if p["namespace"] != "prod" || p["database"] != "app" || p["access"] != "user" {
+		t.Errorf("base: %+v", p)
+	}
+	if p["email"] != "a@example.com" || p["password"] != "secret" {
+		t.Errorf("vars: %+v", p)
+	}
+	if c.AuthType() != AuthScope {
+		t.Error("authtype mismatch")
+	}
+}
+
+func TestScopeCredentials_WithDoesNotMutate(t *testing.T) {
+	a := NewScopeCredentials("prod", "app", "user")
+	b := a.With("email", "a@example.com")
+	if len(a.Variables) != 0 {
+		t.Errorf("original should be untouched, got %+v", a.Variables)
+	}
+	if b.Variables["email"] != "a@example.com" {
+		t.Errorf("derived missing email: %+v", b.Variables)
+	}
+}
+
+func TestRootCredentials_OmitsEmptyPassword(t *testing.T) {
+	c := RootCredentials{Username: "root"}
+	data, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if containsString(string(data), "password") {
+		t.Errorf("should omit empty password: %s", data)
+	}
+}
+
+func TestCredentialsInterface(t *testing.T) {
+	var _ Credentials = NewRootCredentials("r", "p")
+	var _ Credentials = NewNamespaceCredentials("n", "u", "p")
+	var _ Credentials = NewDatabaseCredentials("n", "d", "u", "p")
+	var _ Credentials = NewScopeCredentials("n", "d", "a")
+}
+
+func TestTokenAuth(t *testing.T) {
+	t1 := NewTokenAuth("abc")
+	if t1.Token != "abc" {
+		t.Errorf("token: %q", t1.Token)
+	}
+}
+
+func containsString(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/surql/connection/config.go
+++ b/pkg/surql/connection/config.go
@@ -1,0 +1,408 @@
+package connection
+
+import (
+	"math"
+	"os"
+	"strconv"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// EnvPrefix is the environment variable prefix used by LoadConfigFromEnv.
+const EnvPrefix = "SURQL_"
+
+// Protocol is the connection protocol implied by the configured URL.
+type Protocol int
+
+const (
+	// ProtocolWebSocket == ws://
+	ProtocolWebSocket Protocol = iota
+	// ProtocolWebSocketSecure == wss://
+	ProtocolWebSocketSecure
+	// ProtocolHTTP == http://
+	ProtocolHTTP
+	// ProtocolHTTPS == https://
+	ProtocolHTTPS
+	// ProtocolMemory == mem:// or memory://
+	ProtocolMemory
+	// ProtocolFile == file://
+	ProtocolFile
+	// ProtocolSurrealKV == surrealkv://
+	ProtocolSurrealKV
+)
+
+// String returns the canonical scheme name.
+func (p Protocol) String() string {
+	switch p {
+	case ProtocolWebSocket:
+		return "ws"
+	case ProtocolWebSocketSecure:
+		return "wss"
+	case ProtocolHTTP:
+		return "http"
+	case ProtocolHTTPS:
+		return "https"
+	case ProtocolMemory:
+		return "memory"
+	case ProtocolFile:
+		return "file"
+	case ProtocolSurrealKV:
+		return "surrealkv"
+	default:
+		return "unknown"
+	}
+}
+
+// SupportsLiveQueries reports whether the protocol supports LIVE SELECT.
+func (p Protocol) SupportsLiveQueries() bool {
+	return p != ProtocolHTTP && p != ProtocolHTTPS
+}
+
+// IsEmbedded reports whether the protocol runs in-process (no server).
+func (p Protocol) IsEmbedded() bool {
+	return p == ProtocolMemory || p == ProtocolFile || p == ProtocolSurrealKV
+}
+
+// ConnectionConfig is the SurrealDB connection configuration.
+//
+// Field names follow the Python port (DBURL, DBNS, DB, ...) for
+// wire-compatibility with env loading; convenient accessors (URL,
+// Namespace, Database, ...) are provided for the shorter aliases.
+//
+//nolint:revive // Allow exported field name repetition with package name
+type ConnectionConfig struct {
+	DBURL              string  `json:"db_url"`
+	DBNS               string  `json:"db_ns"`
+	DB                 string  `json:"db"`
+	DBUser             *string `json:"db_user,omitempty"`
+	DBPass             *string `json:"db_pass,omitempty"`
+	DBTimeout          float64 `json:"db_timeout"`
+	DBMaxConnections   uint32  `json:"db_max_connections"`
+	DBRetryMaxAttempts uint32  `json:"db_retry_max_attempts"`
+	DBRetryMinWait     float64 `json:"db_retry_min_wait"`
+	DBRetryMaxWait     float64 `json:"db_retry_max_wait"`
+	DBRetryMultiplier  float64 `json:"db_retry_multiplier"`
+	EnableLiveQueries  bool    `json:"enable_live_queries"`
+}
+
+// DefaultConfig returns the library defaults (same as the Python port).
+func DefaultConfig() ConnectionConfig {
+	return ConnectionConfig{
+		DBURL:              "ws://localhost:8000/rpc",
+		DBNS:               "development",
+		DB:                 "main",
+		DBUser:             nil,
+		DBPass:             nil,
+		DBTimeout:          30.0,
+		DBMaxConnections:   10,
+		DBRetryMaxAttempts: 3,
+		DBRetryMinWait:     1.0,
+		DBRetryMaxWait:     10.0,
+		DBRetryMultiplier:  2.0,
+		EnableLiveQueries:  true,
+	}
+}
+
+// URL returns DBURL (alias).
+func (c ConnectionConfig) URL() string { return c.DBURL }
+
+// Namespace returns DBNS (alias).
+func (c ConnectionConfig) Namespace() string { return c.DBNS }
+
+// Database returns DB (alias).
+func (c ConnectionConfig) Database() string { return c.DB }
+
+// Username returns DBUser (alias).
+func (c ConnectionConfig) Username() *string { return c.DBUser }
+
+// Password returns DBPass (alias).
+func (c ConnectionConfig) Password() *string { return c.DBPass }
+
+// Timeout returns DBTimeout (alias).
+func (c ConnectionConfig) Timeout() float64 { return c.DBTimeout }
+
+// MaxConnections returns DBMaxConnections (alias).
+func (c ConnectionConfig) MaxConnections() uint32 { return c.DBMaxConnections }
+
+// RetryMaxAttempts returns DBRetryMaxAttempts (alias).
+func (c ConnectionConfig) RetryMaxAttempts() uint32 { return c.DBRetryMaxAttempts }
+
+// RetryMinWait returns DBRetryMinWait (alias).
+func (c ConnectionConfig) RetryMinWait() float64 { return c.DBRetryMinWait }
+
+// RetryMaxWait returns DBRetryMaxWait (alias).
+func (c ConnectionConfig) RetryMaxWait() float64 { return c.DBRetryMaxWait }
+
+// RetryMultiplier returns DBRetryMultiplier (alias).
+func (c ConnectionConfig) RetryMultiplier() float64 { return c.DBRetryMultiplier }
+
+// Protocol infers the protocol from DBURL (validates as a side effect).
+func (c ConnectionConfig) Protocol() (Protocol, error) {
+	return detectProtocol(c.DBURL)
+}
+
+// Validate applies all the rules from the Python port.
+func (c ConnectionConfig) Validate() error {
+	if err := validateURL(c.DBURL); err != nil {
+		return err
+	}
+	if err := validateIdentifier(c.DBNS, "namespace"); err != nil {
+		return err
+	}
+	if err := validateIdentifier(c.DB, "database"); err != nil {
+		return err
+	}
+	if err := validateNumericRange("timeout", c.DBTimeout, 1.0, math.Inf(1)); err != nil {
+		return err
+	}
+	if err := validateNumericRange("max_connections", float64(c.DBMaxConnections), 1.0, 100.0); err != nil {
+		return err
+	}
+	if err := validateNumericRange("retry_max_attempts", float64(c.DBRetryMaxAttempts), 1.0, 10.0); err != nil {
+		return err
+	}
+	if err := validateNumericRange("retry_min_wait", c.DBRetryMinWait, 0.1, math.Inf(1)); err != nil {
+		return err
+	}
+	if err := validateNumericRange("retry_max_wait", c.DBRetryMaxWait, 1.0, math.Inf(1)); err != nil {
+		return err
+	}
+	if err := validateNumericRange("retry_multiplier", c.DBRetryMultiplier, 1.0, math.Inf(1)); err != nil {
+		return err
+	}
+	if c.DBRetryMaxWait <= c.DBRetryMinWait {
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"db_retry_max_wait must be greater than db_retry_min_wait")
+	}
+	proto, err := detectProtocol(c.DBURL)
+	if err != nil {
+		return err
+	}
+	if c.EnableLiveQueries && !proto.SupportsLiveQueries() {
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"Live queries require WebSocket (ws://, wss://) or embedded (mem://, memory://, file://, surrealkv://) connection")
+	}
+	return nil
+}
+
+// LoadConfigFromEnv loads SurrealDB configuration from process env vars
+// prefixed with EnvPrefix (SURQL_). Missing values fall back to defaults.
+//
+// Recognised names: SURQL_URL, SURQL_NAMESPACE, SURQL_DATABASE,
+// SURQL_USERNAME, SURQL_PASSWORD, SURQL_TIMEOUT, SURQL_MAX_CONNECTIONS,
+// SURQL_RETRY_MAX_ATTEMPTS, SURQL_RETRY_MIN_WAIT, SURQL_RETRY_MAX_WAIT,
+// SURQL_RETRY_MULTIPLIER, SURQL_ENABLE_LIVE_QUERIES. Python-port legacy
+// aliases (DB_URL, DB_NS, DB, DB_USER, DB_PASS, ...) are also accepted.
+func LoadConfigFromEnv() (ConnectionConfig, error) {
+	return LoadConfigFromEnvWithPrefix(EnvPrefix)
+}
+
+// LoadConfigFromEnvWithPrefix is LoadConfigFromEnv with a custom prefix
+// (e.g. "SURQL_PRIMARY_" for named connections).
+func LoadConfigFromEnvWithPrefix(prefix string) (ConnectionConfig, error) {
+	return LoadConfigFromSource(prefix, func(key string) (string, bool) {
+		return os.LookupEnv(key)
+	})
+}
+
+// LoadConfigFromSource builds a config from an arbitrary key lookup.
+// Tests pass a map-backed lookup to avoid mutating process env.
+func LoadConfigFromSource(prefix string, lookup func(string) (string, bool)) (ConnectionConfig, error) {
+	cfg := DefaultConfig()
+	if v, ok := getWithAliases(lookup, prefix, "URL", "DB_URL"); ok {
+		cfg.DBURL = v
+	}
+	if v, ok := getWithAliases(lookup, prefix, "NAMESPACE", "DB_NS"); ok {
+		cfg.DBNS = v
+	}
+	if v, ok := getWithAliases(lookup, prefix, "DATABASE", "DB"); ok {
+		cfg.DB = v
+	}
+	if v, ok := getWithAliases(lookup, prefix, "USERNAME", "DB_USER"); ok {
+		u := v
+		cfg.DBUser = &u
+	}
+	if v, ok := getWithAliases(lookup, prefix, "PASSWORD", "DB_PASS"); ok {
+		p := v
+		cfg.DBPass = &p
+	}
+	if v, ok := getWithAliases(lookup, prefix, "TIMEOUT", "DB_TIMEOUT"); ok {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return ConnectionConfig{}, surqlerrors.Wrapf(surqlerrors.ErrValidation, err, "invalid timeout=%q", v)
+		}
+		cfg.DBTimeout = f
+	}
+	if v, ok := getWithAliases(lookup, prefix, "MAX_CONNECTIONS", "DB_MAX_CONNECTIONS"); ok {
+		n, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			return ConnectionConfig{}, surqlerrors.Wrapf(surqlerrors.ErrValidation, err, "invalid max_connections=%q", v)
+		}
+		cfg.DBMaxConnections = uint32(n)
+	}
+	if v, ok := getWithAliases(lookup, prefix, "RETRY_MAX_ATTEMPTS", "DB_RETRY_MAX_ATTEMPTS"); ok {
+		n, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			return ConnectionConfig{}, surqlerrors.Wrapf(surqlerrors.ErrValidation, err, "invalid retry_max_attempts=%q", v)
+		}
+		cfg.DBRetryMaxAttempts = uint32(n)
+	}
+	if v, ok := getWithAliases(lookup, prefix, "RETRY_MIN_WAIT", "DB_RETRY_MIN_WAIT"); ok {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return ConnectionConfig{}, surqlerrors.Wrapf(surqlerrors.ErrValidation, err, "invalid retry_min_wait=%q", v)
+		}
+		cfg.DBRetryMinWait = f
+	}
+	if v, ok := getWithAliases(lookup, prefix, "RETRY_MAX_WAIT", "DB_RETRY_MAX_WAIT"); ok {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return ConnectionConfig{}, surqlerrors.Wrapf(surqlerrors.ErrValidation, err, "invalid retry_max_wait=%q", v)
+		}
+		cfg.DBRetryMaxWait = f
+	}
+	if v, ok := getWithAliases(lookup, prefix, "RETRY_MULTIPLIER", "DB_RETRY_MULTIPLIER"); ok {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return ConnectionConfig{}, surqlerrors.Wrapf(surqlerrors.ErrValidation, err, "invalid retry_multiplier=%q", v)
+		}
+		cfg.DBRetryMultiplier = f
+	}
+	if v, ok := getWithAliases(lookup, prefix, "ENABLE_LIVE_QUERIES"); ok {
+		b, err := parseBool(v)
+		if err != nil {
+			return ConnectionConfig{}, err
+		}
+		cfg.EnableLiveQueries = b
+	}
+	if err := cfg.Validate(); err != nil {
+		return ConnectionConfig{}, err
+	}
+	return cfg, nil
+}
+
+// LoadConfigFromMap is a test-friendly alternative to LoadConfigFromEnv.
+func LoadConfigFromMap(prefix string, m map[string]string) (ConnectionConfig, error) {
+	return LoadConfigFromSource(prefix, func(k string) (string, bool) {
+		v, ok := m[k]
+		return v, ok
+	})
+}
+
+// NamedConnectionConfig is a named ConnectionConfig for multi-DB setups.
+//
+//nolint:revive // Package/field name repetition is intentional for clarity
+type NamedConnectionConfig struct {
+	Name   string           `json:"name"`
+	Config ConnectionConfig `json:"config"`
+}
+
+// LoadNamedConfigFromEnv loads a named connection using prefix SURQL_<NAME>_.
+func LoadNamedConfigFromEnv(name string) (NamedConnectionConfig, error) {
+	prefix := EnvPrefix + strings.ToUpper(name) + "_"
+	cfg, err := LoadConfigFromEnvWithPrefix(prefix)
+	if err != nil {
+		return NamedConnectionConfig{}, err
+	}
+	return NamedConnectionConfig{Name: strings.ToLower(name), Config: cfg}, nil
+}
+
+// LoadNamedConfigFromSource is the test-friendly variant of LoadNamedConfigFromEnv.
+func LoadNamedConfigFromSource(name string, lookup func(string) (string, bool)) (NamedConnectionConfig, error) {
+	prefix := EnvPrefix + strings.ToUpper(name) + "_"
+	cfg, err := LoadConfigFromSource(prefix, lookup)
+	if err != nil {
+		return NamedConnectionConfig{}, err
+	}
+	return NamedConnectionConfig{Name: strings.ToLower(name), Config: cfg}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+func validateURL(url string) error {
+	if url == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "URL cannot be empty")
+	}
+	_, err := detectProtocol(url)
+	return err
+}
+
+func validateIdentifier(value, context string) error {
+	if value == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "Identifier cannot be empty")
+	}
+	for _, r := range value {
+		ok := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-'
+		if !ok {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"Identifier (%s) must be alphanumeric with optional underscores/hyphens", context)
+		}
+	}
+	return nil
+}
+
+func validateNumericRange(name string, value, minVal, maxVal float64) error {
+	if math.IsNaN(value) {
+		return surqlerrors.Newf(surqlerrors.ErrValidation, "%s must be a finite number", name)
+	}
+	if value < minVal {
+		return surqlerrors.Newf(surqlerrors.ErrValidation, "%s must be >= %v", name, minVal)
+	}
+	if value > maxVal {
+		return surqlerrors.Newf(surqlerrors.ErrValidation, "%s must be <= %v", name, maxVal)
+	}
+	return nil
+}
+
+func detectProtocol(url string) (Protocol, error) {
+	trimmed := strings.TrimSpace(url)
+	switch {
+	case strings.HasPrefix(trimmed, "ws://"):
+		if trimmed == "ws://" {
+			return 0, surqlerrors.New(surqlerrors.ErrValidation, "URL host must not be empty")
+		}
+		return ProtocolWebSocket, nil
+	case strings.HasPrefix(trimmed, "wss://"):
+		return ProtocolWebSocketSecure, nil
+	case strings.HasPrefix(trimmed, "http://"):
+		return ProtocolHTTP, nil
+	case strings.HasPrefix(trimmed, "https://"):
+		return ProtocolHTTPS, nil
+	case strings.HasPrefix(trimmed, "mem://"), strings.HasPrefix(trimmed, "memory://"):
+		return ProtocolMemory, nil
+	case strings.HasPrefix(trimmed, "file://"):
+		return ProtocolFile, nil
+	case strings.HasPrefix(trimmed, "surrealkv://"):
+		return ProtocolSurrealKV, nil
+	default:
+		return 0, surqlerrors.New(surqlerrors.ErrValidation,
+			"URL must use one of: ws://, wss://, http://, https://, mem://, memory://, file://, surrealkv://")
+	}
+}
+
+func getWithAliases(lookup func(string) (string, bool), prefix string, keys ...string) (string, bool) {
+	for _, k := range keys {
+		name := prefix + k
+		if v, ok := lookup(name); ok {
+			return v, true
+		}
+		if v, ok := lookup(strings.ToLower(name)); ok {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+func parseBool(s string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "1", "true", "yes", "on":
+		return true, nil
+	case "0", "false", "no", "off":
+		return false, nil
+	default:
+		return false, surqlerrors.Newf(surqlerrors.ErrValidation, "invalid boolean value %q", s)
+	}
+}

--- a/pkg/surql/connection/config_test.go
+++ b/pkg/surql/connection/config_test.go
@@ -1,0 +1,220 @@
+package connection
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestDefaultsAreValid(t *testing.T) {
+	cfg := DefaultConfig()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if cfg.URL() != "ws://localhost:8000/rpc" {
+		t.Errorf("url: %q", cfg.URL())
+	}
+	if cfg.Namespace() != "development" || cfg.Database() != "main" {
+		t.Errorf("ns=%q db=%q", cfg.Namespace(), cfg.Database())
+	}
+	if !cfg.EnableLiveQueries {
+		t.Error("live queries should default to enabled")
+	}
+}
+
+func TestValidateRejectsEmptyURL(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.DBURL = ""
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error")
+	} else if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestValidateRejectsUnsupportedProtocol(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.DBURL = "ftp://localhost"
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestValidateAcceptsEmbeddedProtocols(t *testing.T) {
+	for _, url := range []string{
+		"mem://",
+		"memory://",
+		"file:///tmp/db.sdb",
+		"surrealkv:///tmp/db.skv",
+	} {
+		cfg := DefaultConfig()
+		cfg.DBURL = url
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("%s: %v", url, err)
+		}
+	}
+}
+
+func TestLiveQueriesRejectedOverHTTP(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.DBURL = "https://db.example.com/rpc"
+	cfg.EnableLiveQueries = true
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error")
+	}
+	cfg.EnableLiveQueries = false
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("https with live queries off should be valid: %v", err)
+	}
+}
+
+func TestInvalidIdentifiers(t *testing.T) {
+	for _, bad := range []string{"", "has space", "has/slash", "has!bang"} {
+		cfg := DefaultConfig()
+		cfg.DBNS = bad
+		if err := cfg.Validate(); err == nil {
+			t.Errorf("ns %q should be invalid", bad)
+		}
+	}
+}
+
+func TestRetryMaxMustExceedMin(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.DBRetryMinWait = 5.0
+	cfg.DBRetryMaxWait = 3.0
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestProtocolDetection(t *testing.T) {
+	cases := []struct {
+		url      string
+		protocol Protocol
+	}{
+		{"ws://localhost:8000", ProtocolWebSocket},
+		{"wss://host/rpc", ProtocolWebSocketSecure},
+		{"http://host", ProtocolHTTP},
+		{"https://host", ProtocolHTTPS},
+		{"mem://", ProtocolMemory},
+		{"memory://", ProtocolMemory},
+		{"file:///tmp/db", ProtocolFile},
+		{"surrealkv:///tmp/db", ProtocolSurrealKV},
+	}
+	for _, tc := range cases {
+		cfg := DefaultConfig()
+		cfg.DBURL = tc.url
+		cfg.EnableLiveQueries = tc.protocol.SupportsLiveQueries()
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("%s: validate: %v", tc.url, err)
+		}
+		p, err := cfg.Protocol()
+		if err != nil {
+			t.Fatalf("%s: protocol: %v", tc.url, err)
+		}
+		if p != tc.protocol {
+			t.Errorf("%s: got %v, want %v", tc.url, p, tc.protocol)
+		}
+	}
+}
+
+func TestProtocolHelpers(t *testing.T) {
+	if !ProtocolWebSocket.SupportsLiveQueries() || !ProtocolMemory.SupportsLiveQueries() {
+		t.Error("ws/memory should support live queries")
+	}
+	if ProtocolHTTP.SupportsLiveQueries() || ProtocolHTTPS.SupportsLiveQueries() {
+		t.Error("http(s) should not support live queries")
+	}
+	if !ProtocolMemory.IsEmbedded() {
+		t.Error("memory should be embedded")
+	}
+	if ProtocolWebSocket.IsEmbedded() {
+		t.Error("ws should not be embedded")
+	}
+}
+
+func TestLoadConfigFromMap(t *testing.T) {
+	prefix := "SURQL_TEST_CFG_"
+	env := map[string]string{
+		prefix + "URL":                 "wss://env.example/rpc",
+		prefix + "NAMESPACE":           "envns",
+		prefix + "DATABASE":            "envdb",
+		prefix + "USERNAME":            "envuser",
+		prefix + "TIMEOUT":             "45.5",
+		prefix + "ENABLE_LIVE_QUERIES": "false",
+	}
+	cfg, err := LoadConfigFromMap(prefix, env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.URL() != "wss://env.example/rpc" {
+		t.Errorf("url: %q", cfg.URL())
+	}
+	if cfg.Namespace() != "envns" || cfg.Database() != "envdb" {
+		t.Errorf("ns/db: %q/%q", cfg.Namespace(), cfg.Database())
+	}
+	if cfg.Username() == nil || *cfg.Username() != "envuser" {
+		t.Errorf("username: %v", cfg.Username())
+	}
+	if math.Abs(cfg.Timeout()-45.5) > 1e-9 {
+		t.Errorf("timeout: %v", cfg.Timeout())
+	}
+	if cfg.EnableLiveQueries {
+		t.Error("enable_live_queries should be false")
+	}
+}
+
+func TestLoadConfigAcceptsLegacyAliases(t *testing.T) {
+	prefix := "SURQL_LEGACY_"
+	env := map[string]string{
+		prefix + "DB_URL":  "ws://legacy.example/rpc",
+		prefix + "DB_NS":   "legns",
+		prefix + "DB":      "legdb",
+		prefix + "DB_USER": "leguser",
+		prefix + "DB_PASS": "legpass",
+	}
+	cfg, err := LoadConfigFromMap(prefix, env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.URL() != "ws://legacy.example/rpc" {
+		t.Errorf("url: %q", cfg.URL())
+	}
+	if cfg.Namespace() != "legns" || cfg.Database() != "legdb" {
+		t.Errorf("ns/db: %q/%q", cfg.Namespace(), cfg.Database())
+	}
+	if cfg.Password() == nil || *cfg.Password() != "legpass" {
+		t.Errorf("password: %v", cfg.Password())
+	}
+}
+
+func TestLoadNamedConfigFromSource(t *testing.T) {
+	prefix := "SURQL_PRIMARY_"
+	env := map[string]string{
+		prefix + "URL":       "ws://primary.example/rpc",
+		prefix + "NAMESPACE": "pns",
+		prefix + "DATABASE":  "pdb",
+	}
+	named, err := LoadNamedConfigFromSource("primary", func(k string) (string, bool) {
+		v, ok := env[k]
+		return v, ok
+	})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if named.Name != "primary" {
+		t.Errorf("name: %q", named.Name)
+	}
+	if named.Config.URL() != "ws://primary.example/rpc" {
+		t.Errorf("url: %q", named.Config.URL())
+	}
+}
+
+func TestLoadConfigInvalidTimeout(t *testing.T) {
+	_, err := LoadConfigFromMap("X_", map[string]string{"X_TIMEOUT": "not-a-float"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/pkg/surql/connection/doc.go
+++ b/pkg/surql/connection/doc.go
@@ -1,0 +1,10 @@
+// Package connection exposes pure-data types describing how to connect
+// and authenticate to SurrealDB: ConnectionConfig (URL / namespace /
+// database / timeouts / retries / live-queries flag), NamedConnectionConfig,
+// and the four credential kinds (Root / Namespace / Database / Scope)
+// plus JWT TokenAuth.
+//
+// It is a 1:1 port of surql-py/src/surql/connection/{config,auth}.py. The
+// runtime DatabaseClient and AuthManager (which wrap the SurrealDB SDK
+// and handle signin / signup / live queries) land in a follow-up PR.
+package connection


### PR DESCRIPTION
Closes #3.

## Summary
Port the pure data types from surql-py/src/surql/connection/:
- **\`config.go\`**: \`Protocol\` enum (WebSocket/WebSocketSecure/HTTP/HTTPS/Memory/File/SurrealKV), \`ConnectionConfig\` with Python-port field names + convenience accessors, \`Validate()\` mirroring surql-py rules, env loading (\`LoadConfigFromEnv\` / \`LoadConfigFromEnvWithPrefix\` / \`LoadConfigFromSource\` / \`LoadConfigFromMap\`) with legacy aliases, \`NamedConnectionConfig\` for \`SURQL_<NAME>_\` multi-DB setups.
- **\`auth.go\`**: \`AuthType\` string enum, \`Credentials\` interface, \`RootCredentials\`/\`NamespaceCredentials\`/\`DatabaseCredentials\`/\`ScopeCredentials\` (with chainable \`With()\` variable setter), \`TokenAuth\`.
- Env loading uses a lookup-function abstraction so tests don't mutate process env.

Runtime client + AuthManager land alongside the SurrealDB Go SDK integration.

## Test plan
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./... -race\` — all pass (connection + errors + types)
- [ ] CI green