### PR TITLE
feat(query): hints + result wrappers

### DIFF
--- a/pkg/surql/query/doc.go
+++ b/pkg/surql/query/doc.go
@@ -1,0 +1,12 @@
+// Package query provides query construction and result handling for the
+// surql-go library. It is a 1:1 port of surql-py/src/surql/query/.
+//
+// This increment exposes the hints API (IndexHint, ParallelHint, TimeoutHint,
+// FetchHint, ExplainHint) and the result wrappers (QueryResult, RecordResult,
+// ListResult, CountResult, AggregateResult, PageInfo, PaginatedResult) plus
+// the raw-response extraction helpers (ExtractResult, ExtractOne,
+// ExtractScalar, HasResults).
+//
+// Subsequent increments add the immutable Query builder, expressions,
+// typed/batch/graph CRUD, and the async executor.
+package query

--- a/pkg/surql/query/hints.go
+++ b/pkg/surql/query/hints.go
@@ -1,0 +1,263 @@
+package query
+
+import (
+	"fmt"
+	"strconv"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// HintType is the category of a query hint, used to dedupe when MergeHints
+// collapses overlapping hints.
+type HintType string
+
+const (
+	// HintIndex is the index-selection hint category.
+	HintIndex HintType = "index"
+	// HintParallel is the parallel-execution hint category.
+	HintParallel HintType = "parallel"
+	// HintTimeout is the timeout-override hint category.
+	HintTimeout HintType = "timeout"
+	// HintFetch is the fetch-strategy hint category.
+	HintFetch HintType = "fetch"
+	// HintExplain is the execution-plan hint category.
+	HintExplain HintType = "explain"
+)
+
+// QueryHint renders a SurrealQL comment that the query planner interprets.
+type QueryHint interface {
+	ToSurql() string
+	Type() HintType
+}
+
+// FetchStrategy controls how records are retrieved for a query.
+type FetchStrategy string
+
+const (
+	// FetchEager fetches all records up front.
+	FetchEager FetchStrategy = "eager"
+	// FetchLazy fetches records on demand.
+	FetchLazy FetchStrategy = "lazy"
+	// FetchBatch fetches records in fixed-size batches.
+	FetchBatch FetchStrategy = "batch"
+)
+
+// IndexHint forces or suggests use of a particular index.
+type IndexHint struct {
+	Table string `json:"table"`
+	Index string `json:"index"`
+	Force bool   `json:"force,omitempty"`
+}
+
+// NewIndexHint builds an IndexHint that suggests (does not force) the index.
+func NewIndexHint(table, index string) IndexHint {
+	return IndexHint{Table: table, Index: index}
+}
+
+// WithForce returns a copy with the FORCE flag set.
+func (h IndexHint) WithForce(force bool) IndexHint {
+	h.Force = force
+	return h
+}
+
+// ToSurql implements QueryHint.
+func (h IndexHint) ToSurql() string {
+	prefix := "USE"
+	if h.Force {
+		prefix = "FORCE"
+	}
+	return fmt.Sprintf("/* %s INDEX %s.%s */", prefix, h.Table, h.Index)
+}
+
+// Type implements QueryHint.
+func (IndexHint) Type() HintType { return HintIndex }
+
+// ParallelHint toggles parallel query execution and bounds worker count.
+type ParallelHint struct {
+	Enabled    bool  `json:"enabled"`
+	MaxWorkers *uint `json:"max_workers,omitempty"`
+}
+
+// ParallelEnabled enables parallel execution with the server-picked worker count.
+func ParallelEnabled() ParallelHint { return ParallelHint{Enabled: true} }
+
+// ParallelDisabled disables parallel execution.
+func ParallelDisabled() ParallelHint { return ParallelHint{Enabled: false} }
+
+// ParallelWithWorkers enables parallel execution capped at n workers.
+// Returns ErrValidation when n is outside 1..=32.
+func ParallelWithWorkers(n uint) (ParallelHint, error) {
+	if n < 1 || n > 32 {
+		return ParallelHint{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"ParallelHint max_workers must be in 1..=32, got %d", n)
+	}
+	return ParallelHint{Enabled: true, MaxWorkers: &n}, nil
+}
+
+// ToSurql implements QueryHint.
+func (h ParallelHint) ToSurql() string {
+	if !h.Enabled {
+		return "/* PARALLEL OFF */"
+	}
+	if h.MaxWorkers != nil {
+		return fmt.Sprintf("/* PARALLEL %d */", *h.MaxWorkers)
+	}
+	return "/* PARALLEL ON */"
+}
+
+// Type implements QueryHint.
+func (ParallelHint) Type() HintType { return HintParallel }
+
+// TimeoutHint overrides the query timeout.
+type TimeoutHint struct {
+	Seconds float64 `json:"seconds"`
+}
+
+// NewTimeoutHint builds a TimeoutHint. Returns ErrValidation on non-positive seconds.
+func NewTimeoutHint(seconds float64) (TimeoutHint, error) {
+	if seconds != seconds /* NaN */ || seconds <= 0 {
+		return TimeoutHint{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"TimeoutHint seconds must be > 0, got %v", seconds)
+	}
+	return TimeoutHint{Seconds: seconds}, nil
+}
+
+// ToSurql implements QueryHint.
+func (h TimeoutHint) ToSurql() string {
+	return "/* TIMEOUT " + trimFloat(h.Seconds) + "s */"
+}
+
+// Type implements QueryHint.
+func (TimeoutHint) Type() HintType { return HintTimeout }
+
+// FetchHint controls how records are fetched.
+type FetchHint struct {
+	Strategy  FetchStrategy `json:"strategy"`
+	BatchSize *uint32       `json:"batch_size,omitempty"`
+}
+
+// FetchEagerHint builds an eager-fetch FetchHint.
+func FetchEagerHint() FetchHint { return FetchHint{Strategy: FetchEager} }
+
+// FetchLazyHint builds a lazy-fetch FetchHint.
+func FetchLazyHint() FetchHint { return FetchHint{Strategy: FetchLazy} }
+
+// FetchBatchHint builds a batch-fetch FetchHint (size must be in 1..=10000).
+func FetchBatchHint(batchSize uint32) (FetchHint, error) {
+	if batchSize < 1 || batchSize > 10_000 {
+		return FetchHint{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"FetchHint batch_size must be in 1..=10000, got %d", batchSize)
+	}
+	bs := batchSize
+	return FetchHint{Strategy: FetchBatch, BatchSize: &bs}, nil
+}
+
+// Validate reports missing-batch-size errors (mirrors surql-py).
+func (h FetchHint) Validate() error {
+	if h.Strategy == FetchBatch && h.BatchSize == nil {
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"FetchHint batch_size required when strategy is batch")
+	}
+	return nil
+}
+
+// ToSurql implements QueryHint.
+func (h FetchHint) ToSurql() string {
+	if h.Strategy == FetchBatch && h.BatchSize != nil {
+		return fmt.Sprintf("/* FETCH BATCH %d */", *h.BatchSize)
+	}
+	switch h.Strategy {
+	case FetchEager:
+		return "/* FETCH EAGER */"
+	case FetchLazy:
+		return "/* FETCH LAZY */"
+	case FetchBatch:
+		return "/* FETCH BATCH */"
+	default:
+		return "/* FETCH */"
+	}
+}
+
+// Type implements QueryHint.
+func (FetchHint) Type() HintType { return HintFetch }
+
+// ExplainHint requests the query execution plan.
+type ExplainHint struct {
+	Full bool `json:"full,omitempty"`
+}
+
+// ExplainShort builds a short-form ExplainHint.
+func ExplainShort() ExplainHint { return ExplainHint{Full: false} }
+
+// ExplainFull builds a full-form ExplainHint.
+func ExplainFull() ExplainHint { return ExplainHint{Full: true} }
+
+// ToSurql implements QueryHint.
+func (h ExplainHint) ToSurql() string {
+	if h.Full {
+		return "/* EXPLAIN FULL */"
+	}
+	return "/* EXPLAIN */"
+}
+
+// Type implements QueryHint.
+func (ExplainHint) Type() HintType { return HintExplain }
+
+// ValidateHint checks a hint against the query's target table.
+//
+// Returns human-readable problems; an empty slice means the hint is OK.
+// `table` is the query's target table, or "" if not known.
+func ValidateHint(hint QueryHint, table string) []string {
+	var errors []string
+	if idx, ok := hint.(IndexHint); ok && table != "" && idx.Table != table {
+		errors = append(errors, fmt.Sprintf(
+			"Index hint table %q does not match query table %q", idx.Table, table))
+	}
+	return errors
+}
+
+// MergeHints collapses duplicate hints by HintType, keeping the last one
+// of each type and preserving the insertion order of unique types.
+func MergeHints(hints []QueryHint) []QueryHint {
+	idx := map[HintType]int{}
+	var out []QueryHint
+	for _, h := range hints {
+		t := h.Type()
+		if i, ok := idx[t]; ok {
+			out[i] = h
+		} else {
+			idx[t] = len(out)
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+// RenderHints joins a slice of hints into a single SurrealQL comment string.
+func RenderHints(hints []QueryHint) string {
+	if len(hints) == 0 {
+		return ""
+	}
+	merged := MergeHints(hints)
+	parts := make([]string, 0, len(merged))
+	for _, h := range merged {
+		parts = append(parts, h.ToSurql())
+	}
+	// manual join avoids extra allocation and mirrors the Python " ".join()
+	out := parts[0]
+	for i := 1; i < len(parts); i++ {
+		out += " " + parts[i]
+	}
+	return out
+}
+
+// HintRenderer is kept for API symmetry with surql-py.
+type HintRenderer struct{}
+
+// RenderHints is the stateful wrapper for RenderHints.
+func (HintRenderer) RenderHints(hints []QueryHint) string { return RenderHints(hints) }
+
+// trimFloat prints f without unnecessary trailing zeros (30.0 -> "30").
+func trimFloat(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}

--- a/pkg/surql/query/hints_test.go
+++ b/pkg/surql/query/hints_test.go
@@ -1,0 +1,167 @@
+package query
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestIndexHint_RendersUseAndForce(t *testing.T) {
+	if got := NewIndexHint("user", "email_idx").ToSurql(); got != "/* USE INDEX user.email_idx */" {
+		t.Errorf("got %q", got)
+	}
+	if got := NewIndexHint("user", "email_idx").WithForce(true).ToSurql(); got != "/* FORCE INDEX user.email_idx */" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestParallelHint_Renders(t *testing.T) {
+	if got := ParallelEnabled().ToSurql(); got != "/* PARALLEL ON */" {
+		t.Errorf("got %q", got)
+	}
+	if got := ParallelDisabled().ToSurql(); got != "/* PARALLEL OFF */" {
+		t.Errorf("got %q", got)
+	}
+	h, err := ParallelWithWorkers(4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := h.ToSurql(); got != "/* PARALLEL 4 */" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestParallelHint_RejectsBadWorkerCount(t *testing.T) {
+	if _, err := ParallelWithWorkers(0); err == nil {
+		t.Error("expected error for 0 workers")
+	}
+	if _, err := ParallelWithWorkers(33); err == nil {
+		t.Error("expected error for 33 workers")
+	}
+}
+
+func TestTimeoutHint_Renders(t *testing.T) {
+	h, err := NewTimeoutHint(30.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := h.ToSurql(); got != "/* TIMEOUT 30s */" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestTimeoutHint_RejectsNonPositive(t *testing.T) {
+	if _, err := NewTimeoutHint(0); err == nil {
+		t.Error("expected error for 0")
+	}
+	if _, err := NewTimeoutHint(-1.0); err == nil {
+		t.Error("expected error for negative")
+	}
+}
+
+func TestFetchHint_Renders(t *testing.T) {
+	if got := FetchEagerHint().ToSurql(); got != "/* FETCH EAGER */" {
+		t.Errorf("got %q", got)
+	}
+	if got := FetchLazyHint().ToSurql(); got != "/* FETCH LAZY */" {
+		t.Errorf("got %q", got)
+	}
+	h, err := FetchBatchHint(100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := h.ToSurql(); got != "/* FETCH BATCH 100 */" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestFetchHint_BatchValidatesSize(t *testing.T) {
+	if _, err := FetchBatchHint(0); err == nil {
+		t.Error("expected error for 0")
+	}
+	if _, err := FetchBatchHint(10_001); err == nil {
+		t.Error("expected error for 10001")
+	}
+	bad := FetchHint{Strategy: FetchBatch}
+	if err := bad.Validate(); err == nil {
+		t.Error("expected validation error")
+	}
+}
+
+func TestExplainHint_Renders(t *testing.T) {
+	if got := ExplainShort().ToSurql(); got != "/* EXPLAIN */" {
+		t.Errorf("got %q", got)
+	}
+	if got := ExplainFull().ToSurql(); got != "/* EXPLAIN FULL */" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestValidateHint_ChecksTable(t *testing.T) {
+	idx := NewIndexHint("user", "email_idx")
+	if errs := ValidateHint(idx, "user"); len(errs) != 0 {
+		t.Errorf("matching table should be valid: %v", errs)
+	}
+	errs := ValidateHint(idx, "post")
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %v", errs)
+	}
+	if !strings.Contains(errs[0], "user") || !strings.Contains(errs[0], "post") {
+		t.Errorf("unexpected message: %q", errs[0])
+	}
+}
+
+func TestMergeHints_ReplacesDuplicates(t *testing.T) {
+	h1, _ := NewTimeoutHint(10.0)
+	h2, _ := NewTimeoutHint(20.0)
+	merged := MergeHints([]QueryHint{h1, h2})
+	if len(merged) != 1 {
+		t.Fatalf("expected 1, got %d", len(merged))
+	}
+	if got := merged[0].(TimeoutHint).Seconds; got != 20.0 {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestMergeHints_KeepsDistinctTypes(t *testing.T) {
+	t1, _ := NewTimeoutHint(30.0)
+	t2, _ := NewTimeoutHint(60.0)
+	merged := MergeHints([]QueryHint{t1, ParallelEnabled(), t2})
+	if len(merged) != 2 {
+		t.Fatalf("expected 2, got %d", len(merged))
+	}
+}
+
+func TestRenderHints_Empty(t *testing.T) {
+	if got := RenderHints(nil); got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderHints_JoinsAll(t *testing.T) {
+	t1, _ := NewTimeoutHint(30.0)
+	out := RenderHints([]QueryHint{t1, ParallelEnabled()})
+	if !strings.Contains(out, "/* TIMEOUT 30s */") {
+		t.Errorf("missing timeout: %q", out)
+	}
+	if !strings.Contains(out, "/* PARALLEL ON */") {
+		t.Errorf("missing parallel: %q", out)
+	}
+}
+
+func TestRenderer_MatchesFreeFunction(t *testing.T) {
+	hints := []QueryHint{ExplainFull()}
+	renderer := HintRenderer{}
+	if renderer.RenderHints(hints) != RenderHints(hints) {
+		t.Error("renderer and free function should match")
+	}
+}
+
+func TestValidationErrorsAreClassified(t *testing.T) {
+	_, err := NewTimeoutHint(-1)
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}

--- a/pkg/surql/query/results.go
+++ b/pkg/surql/query/results.go
@@ -1,0 +1,261 @@
+package query
+
+import (
+	"encoding/json"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// QueryResult is the generic query execution wrapper.
+type QueryResult[T any] struct {
+	Data   T      `json:"data"`
+	Time   string `json:"time,omitempty"`
+	Status string `json:"status"`
+}
+
+// Success builds a QueryResult with status="OK".
+func Success[T any](data T, execTime string) QueryResult[T] {
+	return QueryResult[T]{Data: data, Time: execTime, Status: "OK"}
+}
+
+// RecordResult wraps a single (possibly-missing) record.
+type RecordResult[T any] struct {
+	Record *T   `json:"record"`
+	Exists bool `json:"exists"`
+}
+
+// Record builds a RecordResult.
+func Record[T any](rec *T, exists bool) RecordResult[T] {
+	return RecordResult[T]{Record: rec, Exists: exists}
+}
+
+// Unwrap returns the record or panics if nil.
+func (r RecordResult[T]) Unwrap() T {
+	if r.Record == nil {
+		panic("RecordResult.Unwrap called on a nil record")
+	}
+	return *r.Record
+}
+
+// TryUnwrap returns the record or ErrValidation when nil.
+func (r RecordResult[T]) TryUnwrap() (T, error) {
+	var zero T
+	if r.Record == nil {
+		return zero, surqlerrors.New(surqlerrors.ErrValidation, "Cannot unwrap nil record")
+	}
+	return *r.Record, nil
+}
+
+// UnwrapOr returns the record or the given default when nil.
+func (r RecordResult[T]) UnwrapOr(def T) T {
+	if r.Record == nil {
+		return def
+	}
+	return *r.Record
+}
+
+// ListResult wraps a slice of records with optional pagination hints.
+type ListResult[T any] struct {
+	Records []T     `json:"records"`
+	Total   *uint64 `json:"total,omitempty"`
+	Limit   *uint64 `json:"limit,omitempty"`
+	Offset  *uint64 `json:"offset,omitempty"`
+	HasMore bool    `json:"has_more"`
+}
+
+// Records builds a ListResult with has_more inferred from the pagination
+// inputs (mirrors surql-py's heuristic).
+func Records[T any](items []T, total, limit, offset *uint64) ListResult[T] {
+	hasMore := false
+	switch {
+	case total != nil && limit != nil && offset != nil:
+		hasMore = (*offset)+(*limit) < *total
+	case total == nil && limit != nil:
+		hasMore = uint64(len(items)) == *limit
+	}
+	return ListResult[T]{
+		Records: items, Total: total, Limit: limit, Offset: offset, HasMore: hasMore,
+	}
+}
+
+// Len returns the number of records.
+func (r ListResult[T]) Len() int { return len(r.Records) }
+
+// IsEmpty reports whether the list is empty.
+func (r ListResult[T]) IsEmpty() bool { return len(r.Records) == 0 }
+
+// First returns the first record or nil.
+func (r ListResult[T]) First() *T {
+	if len(r.Records) == 0 {
+		return nil
+	}
+	return &r.Records[0]
+}
+
+// Last returns the last record or nil.
+func (r ListResult[T]) Last() *T {
+	if len(r.Records) == 0 {
+		return nil
+	}
+	return &r.Records[len(r.Records)-1]
+}
+
+// CountResult holds a COUNT aggregation.
+type CountResult struct {
+	Count int64 `json:"count"`
+}
+
+// NewCountResult builds a CountResult.
+func NewCountResult(n int64) CountResult { return CountResult{Count: n} }
+
+// AggregateResult is the generic aggregation wrapper.
+type AggregateResult struct {
+	Value     json.RawMessage `json:"value"`
+	Operation string          `json:"operation,omitempty"`
+	Field     string          `json:"field,omitempty"`
+}
+
+// Aggregate builds an AggregateResult. The value can be any JSON-serialisable
+// value; it is re-encoded into json.RawMessage for opaque round-tripping.
+func Aggregate(value any, operation, field string) (AggregateResult, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return AggregateResult{}, surqlerrors.Wrap(surqlerrors.ErrSerialization, "aggregate value", err)
+	}
+	return AggregateResult{Value: raw, Operation: operation, Field: field}, nil
+}
+
+// PageInfo carries pagination metadata.
+type PageInfo struct {
+	CurrentPage uint64 `json:"current_page"`
+	PageSize    uint64 `json:"page_size"`
+	TotalPages  uint64 `json:"total_pages"`
+	TotalItems  uint64 `json:"total_items"`
+	HasPrevious bool   `json:"has_previous"`
+	HasNext     bool   `json:"has_next"`
+}
+
+// PaginatedResult wraps a page of items with metadata.
+type PaginatedResult[T any] struct {
+	Items    []T      `json:"items"`
+	PageInfo PageInfo `json:"page_info"`
+}
+
+// Paginated builds a PaginatedResult. `page` is 1-indexed.
+func Paginated[T any](items []T, page, pageSize, total uint64) PaginatedResult[T] {
+	var totalPages uint64
+	if pageSize > 0 {
+		totalPages = (total + pageSize - 1) / pageSize
+	}
+	return PaginatedResult[T]{
+		Items: items,
+		PageInfo: PageInfo{
+			CurrentPage: page,
+			PageSize:    pageSize,
+			TotalPages:  totalPages,
+			TotalItems:  total,
+			HasPrevious: page > 1,
+			HasNext:     page < totalPages,
+		},
+	}
+}
+
+// Len returns the number of items on the current page.
+func (p PaginatedResult[T]) Len() int { return len(p.Items) }
+
+// IsEmpty reports whether the current page is empty.
+func (p PaginatedResult[T]) IsEmpty() bool { return len(p.Items) == 0 }
+
+// ExtractResult pulls the array of records from a raw SurrealDB response,
+// handling both nested (`[{"result": [...]}]` from db.query) and flat
+// (`[{...}, ...]` from db.select) formats.
+func ExtractResult(result any) []map[string]any {
+	if result == nil {
+		return nil
+	}
+	// []any top-level
+	if arr, ok := result.([]any); ok {
+		if len(arr) == 0 {
+			return nil
+		}
+		// Nested?
+		if first, ok := arr[0].(map[string]any); ok {
+			if _, hasResult := first["result"]; hasResult {
+				var out []map[string]any
+				for _, item := range arr {
+					m, ok := item.(map[string]any)
+					if !ok {
+						continue
+					}
+					inner, has := m["result"]
+					if !has {
+						continue
+					}
+					pushValue(&out, inner)
+				}
+				return out
+			}
+		}
+		// Flat: collect map[string]any elements only
+		var out []map[string]any
+		for _, item := range arr {
+			if m, ok := item.(map[string]any); ok {
+				out = append(out, m)
+			}
+		}
+		return out
+	}
+	// Single object with "result"
+	if m, ok := result.(map[string]any); ok {
+		if inner, has := m["result"]; has {
+			var out []map[string]any
+			pushValue(&out, inner)
+			return out
+		}
+	}
+	return nil
+}
+
+func pushValue(out *[]map[string]any, v any) {
+	switch vv := v.(type) {
+	case []any:
+		for _, x := range vv {
+			if m, ok := x.(map[string]any); ok {
+				*out = append(*out, m)
+			}
+		}
+	case map[string]any:
+		*out = append(*out, vv)
+	case nil:
+		// no-op
+	default:
+		*out = append(*out, map[string]any{"value": vv})
+	}
+}
+
+// ExtractOne returns the first record from a raw response, or nil.
+func ExtractOne(result any) map[string]any {
+	records := ExtractResult(result)
+	if len(records) == 0 {
+		return nil
+	}
+	return records[0]
+}
+
+// ExtractScalar pulls a scalar value from an aggregate response. Returns
+// `def` when the result is empty or the key is missing.
+func ExtractScalar(result any, key string, def any) any {
+	one := ExtractOne(result)
+	if one == nil {
+		return def
+	}
+	if v, ok := one[key]; ok {
+		return v
+	}
+	return def
+}
+
+// HasResults reports whether the response contains at least one record.
+func HasResults(result any) bool {
+	return len(ExtractResult(result)) > 0
+}

--- a/pkg/surql/query/results_test.go
+++ b/pkg/surql/query/results_test.go
@@ -1,0 +1,214 @@
+package query
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRecordResult_Unwrap(t *testing.T) {
+	v := 42
+	r := Record(&v, true)
+	if got := r.Unwrap(); got != 42 {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestRecordResult_UnwrapOr(t *testing.T) {
+	var r RecordResult[int]
+	if got := r.UnwrapOr(5); got != 5 {
+		t.Errorf("got %v", got)
+	}
+	v := 1
+	if got := Record(&v, true).UnwrapOr(5); got != 1 {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestRecordResult_TryUnwrapNil(t *testing.T) {
+	var r RecordResult[int]
+	if _, err := r.TryUnwrap(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestListResult_Helpers(t *testing.T) {
+	three := uint64(3)
+	ten := uint64(10)
+	zero := uint64(0)
+	lr := Records([]int{1, 2, 3}, &three, &ten, &zero)
+	if lr.Len() != 3 || lr.IsEmpty() {
+		t.Errorf("len=%d empty=%v", lr.Len(), lr.IsEmpty())
+	}
+	if *lr.First() != 1 || *lr.Last() != 3 {
+		t.Errorf("first/last")
+	}
+}
+
+func TestRecords_HasMoreFromTotal(t *testing.T) {
+	twenty := uint64(20)
+	three := uint64(3)
+	zero := uint64(0)
+	lr := Records([]int{1, 2, 3}, &twenty, &three, &zero)
+	if !lr.HasMore {
+		t.Error("expected has_more")
+	}
+	threeAgain := uint64(3)
+	done := Records([]int{1, 2, 3}, &threeAgain, &three, &zero)
+	if done.HasMore {
+		t.Error("expected no has_more")
+	}
+}
+
+func TestRecords_HasMoreFromLimitOnly(t *testing.T) {
+	three := uint64(3)
+	lr := Records([]int{1, 2, 3}, nil, &three, nil)
+	if !lr.HasMore {
+		t.Error("expected has_more")
+	}
+	lr2 := Records([]int{1, 2}, nil, &three, nil)
+	if lr2.HasMore {
+		t.Error("expected no has_more")
+	}
+}
+
+func TestPaginated_ComputesPages(t *testing.T) {
+	p := Paginated([]int{1, 2, 3}, 1, 10, 100)
+	if p.PageInfo.TotalPages != 10 {
+		t.Errorf("total_pages: %d", p.PageInfo.TotalPages)
+	}
+	if p.PageInfo.HasPrevious || !p.PageInfo.HasNext {
+		t.Errorf("has_prev=%v has_next=%v", p.PageInfo.HasPrevious, p.PageInfo.HasNext)
+	}
+}
+
+func TestPaginated_LastPageRounding(t *testing.T) {
+	p := Paginated[int](nil, 10, 10, 95)
+	if p.PageInfo.TotalPages != 10 {
+		t.Errorf("got %d", p.PageInfo.TotalPages)
+	}
+	if p.PageInfo.HasNext || !p.PageInfo.HasPrevious {
+		t.Errorf("has_prev=%v has_next=%v", p.PageInfo.HasPrevious, p.PageInfo.HasNext)
+	}
+}
+
+func TestPaginated_ZeroPageSize(t *testing.T) {
+	p := Paginated[int](nil, 1, 0, 100)
+	if p.PageInfo.TotalPages != 0 {
+		t.Errorf("got %d", p.PageInfo.TotalPages)
+	}
+}
+
+func TestExtract_Flat(t *testing.T) {
+	raw := []any{map[string]any{"id": "user:123", "name": "Alice"}}
+	out := ExtractResult(raw)
+	if len(out) != 1 || out[0]["name"] != "Alice" {
+		t.Errorf("got %+v", out)
+	}
+}
+
+func TestExtract_Nested(t *testing.T) {
+	raw := []any{
+		map[string]any{"result": []any{map[string]any{"id": "user:123", "name": "Alice"}}},
+	}
+	out := ExtractResult(raw)
+	if len(out) != 1 || out[0]["name"] != "Alice" {
+		t.Errorf("got %+v", out)
+	}
+}
+
+func TestExtract_NestedMultiple(t *testing.T) {
+	raw := []any{
+		map[string]any{"result": []any{
+			map[string]any{"id": "user:1"},
+			map[string]any{"id": "user:2"},
+		}},
+		map[string]any{"result": []any{map[string]any{"id": "user:3"}}},
+	}
+	out := ExtractResult(raw)
+	if len(out) != 3 {
+		t.Errorf("got %d records", len(out))
+	}
+}
+
+func TestExtract_Empty(t *testing.T) {
+	if out := ExtractResult([]any{}); len(out) != 0 {
+		t.Errorf("got %+v", out)
+	}
+}
+
+func TestExtract_Nil(t *testing.T) {
+	if out := ExtractResult(nil); out != nil && len(out) != 0 {
+		t.Errorf("got %+v", out)
+	}
+}
+
+func TestExtract_ObjectWithResult(t *testing.T) {
+	raw := map[string]any{"result": []any{map[string]any{"id": "u:1"}}}
+	if out := ExtractResult(raw); len(out) != 1 {
+		t.Errorf("got %d", len(out))
+	}
+}
+
+func TestExtractOne(t *testing.T) {
+	raw := []any{map[string]any{"result": []any{map[string]any{"id": "user:123", "name": "Alice"}}}}
+	one := ExtractOne(raw)
+	if one == nil || one["name"] != "Alice" {
+		t.Errorf("got %+v", one)
+	}
+	if ExtractOne([]any{}) != nil {
+		t.Error("expected nil")
+	}
+}
+
+func TestExtractScalar(t *testing.T) {
+	raw := []any{map[string]any{"result": []any{map[string]any{"count": 42}}}}
+	if got := ExtractScalar(raw, "count", 0); got != 42 {
+		t.Errorf("got %v", got)
+	}
+	if got := ExtractScalar([]any{}, "count", 0); got != 0 {
+		t.Errorf("got %v", got)
+	}
+	rawMissing := []any{map[string]any{"id": "u:1"}}
+	if got := ExtractScalar(rawMissing, "total", 0); got != 0 {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestHasResults(t *testing.T) {
+	if !HasResults([]any{map[string]any{"result": []any{map[string]any{"id": "u:1"}}}}) {
+		t.Error("expected true")
+	}
+	if HasResults([]any{}) {
+		t.Error("expected false")
+	}
+	if !HasResults([]any{map[string]any{"id": "u:1"}}) {
+		t.Error("expected true on flat")
+	}
+	if HasResults([]any{map[string]any{"result": []any{}}}) {
+		t.Error("expected false on empty nested")
+	}
+}
+
+func TestSuccess(t *testing.T) {
+	r := Success([]int{1, 2, 3}, "12ms")
+	if r.Status != "OK" || r.Time != "12ms" || len(r.Data) != 3 {
+		t.Errorf("got %+v", r)
+	}
+}
+
+func TestCountAndAggregate(t *testing.T) {
+	if NewCountResult(42).Count != 42 {
+		t.Error("count mismatch")
+	}
+	a, err := Aggregate(25.5, "AVG", "age")
+	if err != nil {
+		t.Fatalf("aggregate: %v", err)
+	}
+	var got float64
+	if err := json.Unmarshal(a.Value, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got != 25.5 {
+		t.Errorf("got %v", got)
+	}
+}


### PR DESCRIPTION
Closes #5.

## Summary
Port surql-py/src/surql/query/{hints,results}.py to Go.

- **\`query/hints.go\`**: \`QueryHint\` interface + \`HintType\` category. IndexHint / ParallelHint / TimeoutHint / FetchHint / ExplainHint render to SurrealQL comments. Validation: ParallelHint 1..=32 workers, TimeoutHint > 0, FetchHint batch 1..=10000. \`ValidateHint\`/\`MergeHints\`/\`RenderHints\` + \`HintRenderer\` shim.
- **\`query/results.go\`**: QueryResult[T], RecordResult[T] (Unwrap / TryUnwrap / UnwrapOr), ListResult[T], CountResult, AggregateResult (json.RawMessage for opaque round-trip), PageInfo, PaginatedResult[T]. \`Success\` / \`Record\` / \`Records\` / \`Paginated\` / \`Aggregate\` builders match surql-py's heuristics. Raw extraction helpers on \`any\`: ExtractResult / ExtractOne / ExtractScalar (with default) / HasResults handle both nested and flat shapes.
- \`doc.go\`: package-level godoc.

## Test plan
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./... -race\` — all packages green
- [ ] CI green