### PR TITLE
feat(query): port expressions module

### DIFF
--- a/pkg/surql/query/expressions.go
+++ b/pkg/surql/query/expressions.go
@@ -1,0 +1,235 @@
+package query
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/albedosehen/surql-go/pkg/surql/types"
+)
+
+// ExpressionKind tags an Expression by category (field / value / function /
+// raw). Consumers can introspect without re-parsing the SurrealQL string.
+type ExpressionKind string
+
+const (
+	// ExprRaw is the default / aliased / raw category.
+	ExprRaw ExpressionKind = "raw"
+	// ExprField is a field reference.
+	ExprField ExpressionKind = "field"
+	// ExprValue is a quoted literal.
+	ExprValue ExpressionKind = "value"
+	// ExprFunction is a function-call expression.
+	ExprFunction ExpressionKind = "function"
+)
+
+// Expression is a typed SurrealQL fragment: a rendered string plus a kind tag.
+type Expression struct {
+	SQL  string         `json:"sql"`
+	Kind ExpressionKind `json:"kind,omitempty"`
+}
+
+// ToSurql renders as SurrealQL.
+func (e Expression) ToSurql() string { return e.SQL }
+
+// String implements fmt.Stringer.
+func (e Expression) String() string { return e.SQL }
+
+// NewRaw builds a raw-kind Expression.
+func NewRaw(sql string) Expression { return Expression{SQL: sql, Kind: ExprRaw} }
+
+// NewField builds a field-kind Expression.
+func NewField(name string) Expression { return Expression{SQL: name, Kind: ExprField} }
+
+// NewValue builds a value-kind Expression, quoted with SurrealQL rules.
+func NewValue(v any) Expression {
+	return Expression{SQL: quoteValueExpr(v), Kind: ExprValue}
+}
+
+// NewFunction builds a function-kind Expression from a pre-rendered `FN(...)`.
+func NewFunction(sql string) Expression { return Expression{SQL: sql, Kind: ExprFunction} }
+
+// Field is the free-function alias for [NewField].
+func Field(name string) Expression { return NewField(name) }
+
+// Value is the free-function alias for [NewValue].
+func Value(v any) Expression { return NewValue(v) }
+
+// Raw is the free-function alias for [NewRaw].
+func Raw(sql string) Expression { return NewRaw(sql) }
+
+// ExprArg is the union type accepted by Func / Concat: either a built
+// Expression or a raw string fragment.
+type ExprArg struct {
+	expr *Expression
+	str  *string
+}
+
+// E wraps an Expression for Func / Concat.
+func E(e Expression) ExprArg { return ExprArg{expr: &e} }
+
+// S wraps a raw string for Func / Concat.
+func S(s string) ExprArg { return ExprArg{str: &s} }
+
+func (a ExprArg) render() string {
+	if a.expr != nil {
+		return a.expr.ToSurql()
+	}
+	if a.str != nil {
+		return *a.str
+	}
+	return ""
+}
+
+// Func builds a function-call Expression: `Func("UPPER", E(Field("name")))`.
+func Func(name string, args ...ExprArg) Expression {
+	parts := make([]string, len(args))
+	for i, a := range args {
+		parts[i] = a.render()
+	}
+	return NewFunction(fmt.Sprintf("%s(%s)", name, strings.Join(parts, ", ")))
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate functions
+// ---------------------------------------------------------------------------
+
+// Count builds `COUNT(*)` or `COUNT(field)` when fieldName is non-empty.
+func Count(fieldName string) Expression {
+	if fieldName == "" {
+		return NewFunction("COUNT(*)")
+	}
+	return NewFunction(fmt.Sprintf("COUNT(%s)", fieldName))
+}
+
+// Sum builds `SUM(field)`.
+func Sum(fieldName string) Expression { return NewFunction(fmt.Sprintf("SUM(%s)", fieldName)) }
+
+// Avg builds `AVG(field)`.
+func Avg(fieldName string) Expression { return NewFunction(fmt.Sprintf("AVG(%s)", fieldName)) }
+
+// MinFn builds `MIN(field)`.
+func MinFn(fieldName string) Expression { return NewFunction(fmt.Sprintf("MIN(%s)", fieldName)) }
+
+// MaxFn builds `MAX(field)`.
+func MaxFn(fieldName string) Expression { return NewFunction(fmt.Sprintf("MAX(%s)", fieldName)) }
+
+// ---------------------------------------------------------------------------
+// String functions
+// ---------------------------------------------------------------------------
+
+// Upper builds `string::uppercase(field)`.
+func Upper(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("string::uppercase(%s)", fieldName))
+}
+
+// Lower builds `string::lowercase(field)`.
+func Lower(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("string::lowercase(%s)", fieldName))
+}
+
+// Concat builds `string::concat(a, b, c, ...)`.
+func Concat(parts ...ExprArg) Expression {
+	rendered := make([]string, len(parts))
+	for i, p := range parts {
+		rendered[i] = p.render()
+	}
+	return NewFunction(fmt.Sprintf("string::concat(%s)", strings.Join(rendered, ", ")))
+}
+
+// ---------------------------------------------------------------------------
+// Array functions
+// ---------------------------------------------------------------------------
+
+// ArrayLength builds `array::len(field)`.
+func ArrayLength(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("array::len(%s)", fieldName))
+}
+
+// ArrayContains builds `array::includes(field, value)`.
+func ArrayContains(fieldName string, v any) Expression {
+	return NewFunction(fmt.Sprintf("array::includes(%s, %s)", fieldName, quoteValueExpr(v)))
+}
+
+// ---------------------------------------------------------------------------
+// Math functions
+// ---------------------------------------------------------------------------
+
+// Abs builds `math::abs(field)`.
+func Abs(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("math::abs(%s)", fieldName))
+}
+
+// Ceil builds `math::ceil(field)`.
+func Ceil(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("math::ceil(%s)", fieldName))
+}
+
+// Floor builds `math::floor(field)`.
+func Floor(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("math::floor(%s)", fieldName))
+}
+
+// Round builds `math::round(field, precision)`. Pass 0 for integer rounding.
+func Round(fieldName string, precision int) Expression {
+	return NewFunction(fmt.Sprintf("math::round(%s, %d)", fieldName, precision))
+}
+
+// MathMean builds `math::mean(field)`.
+func MathMean(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("math::mean(%s)", fieldName))
+}
+
+// MathSum builds `math::sum(field)`.
+func MathSum(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("math::sum(%s)", fieldName))
+}
+
+// MathMax builds `math::max(field)`.
+func MathMax(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("math::max(%s)", fieldName))
+}
+
+// MathMin builds `math::min(field)`.
+func MathMin(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("math::min(%s)", fieldName))
+}
+
+// ---------------------------------------------------------------------------
+// Time, type, composition
+// ---------------------------------------------------------------------------
+
+// TimeNow builds `time::now()`.
+func TimeNow() Expression { return NewFunction("time::now()") }
+
+// TimeFormat builds `time::format(field, 'fmt')`.
+func TimeFormat(fieldName, format string) Expression {
+	return NewFunction(fmt.Sprintf("time::format(%s, %s)", fieldName, quoteValueExpr(format)))
+}
+
+// TypeIs builds `type::is::<type_name>(field)`.
+func TypeIs(fieldName, typeName string) Expression {
+	return NewFunction(fmt.Sprintf("type::is::%s(%s)", typeName, fieldName))
+}
+
+// Cast builds `<target_type>field` — SurrealQL cast syntax.
+func Cast(fieldName, targetType string) Expression {
+	return NewRaw(fmt.Sprintf("<%s>%s", targetType, fieldName))
+}
+
+// As aliases an expression: `As(Count(""), "total")` -> `COUNT(*) AS total`.
+func As(expr Expression, alias string) Expression {
+	return NewRaw(fmt.Sprintf("%s AS %s", expr.ToSurql(), alias))
+}
+
+// ---------------------------------------------------------------------------
+// quoteValueExpr: SurrealQL literal renderer used by expression helpers.
+// Delegates to the types package's operator rendering to stay consistent.
+// ---------------------------------------------------------------------------
+
+func quoteValueExpr(v any) string {
+	// Reuse the rendering path via a scratch Eq operator. This keeps quoting
+	// logic DRY with the types/operators package.
+	rendered := types.EqOp("__x__", v).ToSurql()
+	const prefix = "__x__ = "
+	return strings.TrimPrefix(rendered, prefix)
+}

--- a/pkg/surql/query/expressions_test.go
+++ b/pkg/surql/query/expressions_test.go
@@ -1,0 +1,145 @@
+package query
+
+import "testing"
+
+func TestFieldAndValue(t *testing.T) {
+	if got := Field("user.name").ToSurql(); got != "user.name" {
+		t.Errorf("got %q", got)
+	}
+	if got := Value("Alice").ToSurql(); got != `'Alice'` {
+		t.Errorf("got %q", got)
+	}
+	if got := Value(42).ToSurql(); got != "42" {
+		t.Errorf("got %q", got)
+	}
+	if got := Value(true).ToSurql(); got != "true" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestCount_Renders(t *testing.T) {
+	if got := Count("").ToSurql(); got != "COUNT(*)" {
+		t.Errorf("got %q", got)
+	}
+	if got := Count("id").ToSurql(); got != "COUNT(id)" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestAggregateFunctions(t *testing.T) {
+	if Sum("price").ToSurql() != "SUM(price)" ||
+		Avg("age").ToSurql() != "AVG(age)" ||
+		MinFn("price").ToSurql() != "MIN(price)" ||
+		MaxFn("price").ToSurql() != "MAX(price)" {
+		t.Error("aggregate mismatch")
+	}
+}
+
+func TestMathNativeAggregates(t *testing.T) {
+	if MathMean("score").ToSurql() != "math::mean(score)" ||
+		MathSum("price").ToSurql() != "math::sum(price)" ||
+		MathMax("score").ToSurql() != "math::max(score)" ||
+		MathMin("price").ToSurql() != "math::min(price)" {
+		t.Error("math aggregate mismatch")
+	}
+}
+
+func TestStringFunctions(t *testing.T) {
+	if Upper("name").ToSurql() != "string::uppercase(name)" {
+		t.Error("upper")
+	}
+	if Lower("email").ToSurql() != "string::lowercase(email)" {
+		t.Error("lower")
+	}
+	c := Concat(E(Field("first_name")), E(Value(" ")), E(Field("last_name")))
+	if c.ToSurql() != "string::concat(first_name, ' ', last_name)" {
+		t.Errorf("concat: %q", c.ToSurql())
+	}
+}
+
+func TestArrayFunctions(t *testing.T) {
+	if ArrayLength("tags").ToSurql() != "array::len(tags)" {
+		t.Error("array_length")
+	}
+	if got := ArrayContains("tags", "python").ToSurql(); got != "array::includes(tags, 'python')" {
+		t.Errorf("array_contains: %q", got)
+	}
+}
+
+func TestMathFunctions(t *testing.T) {
+	if Abs("temperature").ToSurql() != "math::abs(temperature)" {
+		t.Error("abs")
+	}
+	if Ceil("price").ToSurql() != "math::ceil(price)" {
+		t.Error("ceil")
+	}
+	if Floor("price").ToSurql() != "math::floor(price)" {
+		t.Error("floor")
+	}
+	if Round("price", 2).ToSurql() != "math::round(price, 2)" {
+		t.Error("round")
+	}
+}
+
+func TestTimeFunctions(t *testing.T) {
+	if TimeNow().ToSurql() != "time::now()" {
+		t.Error("time_now")
+	}
+	if got := TimeFormat("created_at", "%Y-%m-%d").ToSurql(); got != "time::format(created_at, '%Y-%m-%d')" {
+		t.Errorf("time_format: %q", got)
+	}
+}
+
+func TestTypeFunctions(t *testing.T) {
+	if TypeIs("value", "string").ToSurql() != "type::is::string(value)" {
+		t.Error("type_is")
+	}
+	if Cast("id", "string").ToSurql() != "<string>id" {
+		t.Error("cast")
+	}
+}
+
+func TestFunc_AcceptsMixedArgs(t *testing.T) {
+	c := Func("CONCAT", E(Field("first")), S("' '"), E(Field("last")))
+	if c.ToSurql() != "CONCAT(first, ' ', last)" {
+		t.Errorf("got %q", c.ToSurql())
+	}
+}
+
+func TestAs_AliasesExpressions(t *testing.T) {
+	if got := As(Count(""), "total").ToSurql(); got != "COUNT(*) AS total" {
+		t.Errorf("got %q", got)
+	}
+	inner := Concat(E(Field("first")), E(Field("last")))
+	if got := As(inner, "full_name").ToSurql(); got != "string::concat(first, last) AS full_name" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRaw_PassesThrough(t *testing.T) {
+	if Raw("time::now()").ToSurql() != "time::now()" {
+		t.Error("raw")
+	}
+}
+
+func TestKindTag_ReflectsConstructor(t *testing.T) {
+	if Field("x").Kind != ExprField {
+		t.Error("field kind")
+	}
+	if Value(1).Kind != ExprValue {
+		t.Error("value kind")
+	}
+	if Count("").Kind != ExprFunction {
+		t.Error("count kind")
+	}
+	if Raw("x").Kind != ExprRaw {
+		t.Error("raw kind")
+	}
+}
+
+func TestString_MatchesToSurql(t *testing.T) {
+	e := Count("")
+	if e.String() != e.ToSurql() {
+		t.Error("String / ToSurql mismatch")
+	}
+}


### PR DESCRIPTION
Closes #7.

## Summary
Port surql-py/src/surql/query/expressions.py to Go.

- \`Expression\` struct with \`Kind\` tag (ExpressionKind Raw / Field / Value / Function).
- Constructors: \`Field\` / \`Value\` / \`Raw\` / \`Func\` (\`E()\` for expressions, \`S()\` for raw strings in Func/Concat).
- **25+ function builders:** \`Count\` (empty string => *), \`Sum\` / \`Avg\` / \`MinFn\` / \`MaxFn\` (renamed to avoid stdlib math.Min/Max collision), \`MathMean\` / \`MathSum\` / \`MathMax\` / \`MathMin\`, \`Upper\` / \`Lower\` / \`Concat\`, \`ArrayLength\` / \`ArrayContains\`, \`Abs\` / \`Ceil\` / \`Floor\` / \`Round\`, \`TimeNow\` / \`TimeFormat\`, \`TypeIs\` / \`Cast\`, \`As\` / \`Raw\`.
- Delegates literal quoting to \`types.EqOp\` path to stay DRY with operator rendering.

## Test plan
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./... -race\` — all packages green
- [ ] CI green