### PR TITLE
feat(query): port immutable Query builder + helpers

### DIFF
--- a/pkg/surql/query/builder.go
+++ b/pkg/surql/query/builder.go
@@ -1,0 +1,784 @@
+package query
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/types"
+)
+
+// Operation tags the high-level SurrealQL statement a Query produces.
+type Operation string
+
+const (
+	// OpSelect renders `SELECT ... FROM ...`.
+	OpSelect Operation = "SELECT"
+	// OpInsert renders `CREATE ... CONTENT {...}`.
+	OpInsert Operation = "INSERT"
+	// OpUpdate renders `UPDATE ... SET ...`.
+	OpUpdate Operation = "UPDATE"
+	// OpUpsert renders `UPSERT ... CONTENT {...}`.
+	OpUpsert Operation = "UPSERT"
+	// OpDelete renders `DELETE ...`.
+	OpDelete Operation = "DELETE"
+	// OpRelate renders `RELATE from->edge->to`.
+	OpRelate Operation = "RELATE"
+)
+
+// OrderField is one `(field, direction)` pair used in `ORDER BY`.
+type OrderField struct {
+	Field     string
+	Direction string
+}
+
+// Query is an immutable SurrealQL query builder.
+//
+// Every method returns a new Query; the receiver is never mutated. The
+// zero value represents an empty query with no operation yet assigned.
+// `ToSurql` renders the accumulated state to a SurrealQL string and
+// returns `ErrValidation` if the query is incomplete.
+type Query struct {
+	// Operation is the statement kind; empty until one of Select/Insert/... is called.
+	Operation Operation
+
+	// TableName is the target table or record id.
+	TableName string
+
+	// Fields lists the projection columns for SELECT.
+	Fields []string
+
+	// Conditions are raw SurrealQL WHERE fragments (already operator-rendered).
+	Conditions []string
+
+	// OrderFields are the ORDER BY pairs in insertion order.
+	OrderFields []OrderField
+
+	// GroupFields are the explicit GROUP BY columns.
+	GroupFields []string
+
+	// GroupAllFlag toggles SurrealQL's `GROUP ALL` aggregation.
+	GroupAllFlag bool
+
+	// LimitValue bounds the number of rows when non-nil.
+	LimitValue *int
+
+	// OffsetValue skips rows when non-nil (rendered as `START n`).
+	OffsetValue *int
+
+	// InsertData carries the body for INSERT statements.
+	InsertData map[string]any
+
+	// UpdateData carries the body for UPDATE / UPSERT statements.
+	UpdateData map[string]any
+
+	// RelateFrom is the source record for RELATE.
+	RelateFrom string
+
+	// RelateTo is the destination record for RELATE.
+	RelateTo string
+
+	// RelateData is the edge body for RELATE.
+	RelateData map[string]any
+
+	// JoinClauses are raw JOIN fragments appended after the FROM.
+	JoinClauses []string
+
+	// GraphTraversal is the `->edge->target` suffix for SELECT.
+	GraphTraversal string
+
+	// ReturnFormat controls the `RETURN ...` clause on mutations.
+	ReturnFormat ReturnFormat
+
+	// Vector search parameters (MTREE-style `<|k,distance|>`).
+	VectorField     string
+	VectorValue     []float64
+	VectorK         *int
+	VectorDistance  VectorDistanceType
+	VectorThreshold *float64
+
+	// Hints accumulates optimization comments rendered by [RenderHints].
+	Hints []QueryHint
+}
+
+// NewQuery returns an empty Query.
+func NewQuery() Query { return Query{} }
+
+// ---------------------------------------------------------------------------
+// Helpers (private) — copy-and-mutate semantics.
+// ---------------------------------------------------------------------------
+
+// clone returns a deep-enough copy so that caller mutations on the
+// returned value cannot leak back into the original slices/maps.
+func (q Query) clone() Query {
+	out := q
+	if q.Fields != nil {
+		out.Fields = append([]string(nil), q.Fields...)
+	}
+	if q.Conditions != nil {
+		out.Conditions = append([]string(nil), q.Conditions...)
+	}
+	if q.OrderFields != nil {
+		out.OrderFields = append([]OrderField(nil), q.OrderFields...)
+	}
+	if q.GroupFields != nil {
+		out.GroupFields = append([]string(nil), q.GroupFields...)
+	}
+	if q.JoinClauses != nil {
+		out.JoinClauses = append([]string(nil), q.JoinClauses...)
+	}
+	if q.VectorValue != nil {
+		out.VectorValue = append([]float64(nil), q.VectorValue...)
+	}
+	if q.Hints != nil {
+		out.Hints = append([]QueryHint(nil), q.Hints...)
+	}
+	if q.InsertData != nil {
+		out.InsertData = copyMap(q.InsertData)
+	}
+	if q.UpdateData != nil {
+		out.UpdateData = copyMap(q.UpdateData)
+	}
+	if q.RelateData != nil {
+		out.RelateData = copyMap(q.RelateData)
+	}
+	return out
+}
+
+func copyMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Fluent API
+// ---------------------------------------------------------------------------
+
+// Select starts a SELECT query. A nil or empty slice selects `*`.
+func (q Query) Select(fields []string) Query {
+	out := q.clone()
+	out.Operation = OpSelect
+	if len(fields) == 0 {
+		out.Fields = []string{"*"}
+	} else {
+		out.Fields = append([]string(nil), fields...)
+	}
+	return out
+}
+
+// FromTable sets the table (or record id) the query targets. Returns
+// ErrValidation when the table portion is not a safe identifier.
+func (q Query) FromTable(table string) (Query, error) {
+	if err := validateIdentifier(splitTablePart(table), "table name"); err != nil {
+		return Query{}, err
+	}
+	out := q.clone()
+	out.TableName = table
+	return out, nil
+}
+
+// Where appends a condition. Accepts either a string (inserted as-is)
+// or a `types.Operator` (rendered via its `ToSurql` method).
+func (q Query) Where(condition any) (Query, error) {
+	var rendered string
+	switch c := condition.(type) {
+	case string:
+		rendered = c
+	case types.Operator:
+		rendered = c.ToSurql()
+	case nil:
+		return Query{}, surqlerrors.New(surqlerrors.ErrValidation, "Where condition cannot be nil")
+	default:
+		return Query{}, surqlerrors.Newf(
+			surqlerrors.ErrValidation,
+			"Where condition must be a string or types.Operator, got %T", condition,
+		)
+	}
+	out := q.clone()
+	out.Conditions = append(out.Conditions, rendered)
+	return out, nil
+}
+
+// OrderBy appends an ORDER BY pair. `direction` must be `ASC` or `DESC`
+// (case-insensitive); any other value returns ErrValidation.
+func (q Query) OrderBy(field, direction string) (Query, error) {
+	dir := strings.ToUpper(direction)
+	if dir != "ASC" && dir != "DESC" {
+		return Query{}, surqlerrors.Newf(
+			surqlerrors.ErrValidation,
+			"Invalid direction: %s. Must be ASC or DESC", direction,
+		)
+	}
+	out := q.clone()
+	out.OrderFields = append(out.OrderFields, OrderField{Field: field, Direction: dir})
+	return out, nil
+}
+
+// GroupBy appends explicit group keys.
+func (q Query) GroupBy(fields ...string) Query {
+	out := q.clone()
+	out.GroupFields = append(out.GroupFields, fields...)
+	return out
+}
+
+// GroupAll sets `GROUP ALL` for whole-result aggregation.
+func (q Query) GroupAll() Query {
+	out := q.clone()
+	out.GroupAllFlag = true
+	return out
+}
+
+// Limit sets the LIMIT clause. Negative values yield ErrValidation.
+func (q Query) Limit(n int) (Query, error) {
+	if n < 0 {
+		return Query{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"Limit must be non-negative, got %d", n)
+	}
+	v := n
+	out := q.clone()
+	out.LimitValue = &v
+	return out, nil
+}
+
+// Offset sets the OFFSET (rendered as `START n`). Negative values yield ErrValidation.
+func (q Query) Offset(n int) (Query, error) {
+	if n < 0 {
+		return Query{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"Offset must be non-negative, got %d", n)
+	}
+	v := n
+	out := q.clone()
+	out.OffsetValue = &v
+	return out, nil
+}
+
+// Insert builds an INSERT (SurrealDB `CREATE ... CONTENT {...}`) query.
+func (q Query) Insert(table string, data map[string]any) (Query, error) {
+	if err := validateIdentifier(table, "table name"); err != nil {
+		return Query{}, err
+	}
+	if err := validateDataKeys(data); err != nil {
+		return Query{}, err
+	}
+	out := q.clone()
+	out.Operation = OpInsert
+	out.TableName = table
+	out.InsertData = copyMap(data)
+	return out, nil
+}
+
+// Update builds an UPDATE query.
+func (q Query) Update(target string, data map[string]any) (Query, error) {
+	if err := validateIdentifier(splitTablePart(target), "table name"); err != nil {
+		return Query{}, err
+	}
+	if err := validateDataKeys(data); err != nil {
+		return Query{}, err
+	}
+	out := q.clone()
+	out.Operation = OpUpdate
+	out.TableName = target
+	out.UpdateData = copyMap(data)
+	return out, nil
+}
+
+// Upsert builds an UPSERT query (insert-or-update).
+func (q Query) Upsert(target string, data map[string]any) (Query, error) {
+	if err := validateIdentifier(splitTablePart(target), "table name"); err != nil {
+		return Query{}, err
+	}
+	if err := validateDataKeys(data); err != nil {
+		return Query{}, err
+	}
+	out := q.clone()
+	out.Operation = OpUpsert
+	out.TableName = target
+	out.UpdateData = copyMap(data)
+	return out, nil
+}
+
+// Delete builds a DELETE query.
+func (q Query) Delete(target string) (Query, error) {
+	if err := validateIdentifier(splitTablePart(target), "table name"); err != nil {
+		return Query{}, err
+	}
+	out := q.clone()
+	out.Operation = OpDelete
+	out.TableName = target
+	return out, nil
+}
+
+// Relate builds a RELATE query. `from` and `to` may be a `string` or
+// `types.RecordID`; any other concrete type returns ErrValidation.
+func (q Query) Relate(edgeTable string, from, to any, data map[string]any) (Query, error) {
+	if err := validateIdentifier(edgeTable, "edge table name"); err != nil {
+		return Query{}, err
+	}
+	fromStr, err := relateEndpoint(from)
+	if err != nil {
+		return Query{}, err
+	}
+	toStr, err := relateEndpoint(to)
+	if err != nil {
+		return Query{}, err
+	}
+	if err := validateIdentifier(splitTablePart(fromStr), "from table name"); err != nil {
+		return Query{}, err
+	}
+	if err := validateIdentifier(splitTablePart(toStr), "to table name"); err != nil {
+		return Query{}, err
+	}
+	if data != nil {
+		if err := validateDataKeys(data); err != nil {
+			return Query{}, err
+		}
+	}
+	out := q.clone()
+	out.Operation = OpRelate
+	out.TableName = edgeTable
+	out.RelateFrom = fromStr
+	out.RelateTo = toStr
+	out.RelateData = copyMap(data)
+	return out, nil
+}
+
+// Traverse sets the graph traversal suffix appended to the FROM clause.
+func (q Query) Traverse(path string) Query {
+	out := q.clone()
+	out.GraphTraversal = path
+	return out
+}
+
+// Join appends a raw JOIN clause.
+func (q Query) Join(clause string) Query {
+	out := q.clone()
+	out.JoinClauses = append(out.JoinClauses, clause)
+	return out
+}
+
+// VectorSearch configures a SurrealDB MTREE k-nearest-neighbour search.
+// Pass a non-nil `threshold` to emit the three-arg operator form.
+func (q Query) VectorSearch(
+	field string,
+	vector []float64,
+	k int,
+	distance VectorDistanceType,
+	threshold *float64,
+) (Query, error) {
+	if k < 1 {
+		return Query{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"k must be at least 1, got %d", k)
+	}
+	if len(vector) == 0 {
+		return Query{}, surqlerrors.New(surqlerrors.ErrValidation, "Vector cannot be empty")
+	}
+	kv := k
+	out := q.clone()
+	out.VectorField = field
+	out.VectorValue = append([]float64(nil), vector...)
+	out.VectorK = &kv
+	out.VectorDistance = distance
+	if threshold != nil {
+		t := *threshold
+		out.VectorThreshold = &t
+	}
+	return out, nil
+}
+
+// SimilarityScore adds `vector::similarity::<metric>(field, vector) AS alias`
+// to the projection.
+func (q Query) SimilarityScore(field string, vector []float64, metric VectorDistanceType, alias string) Query {
+	vec := renderVectorLiteral(vector)
+	metricLower := strings.ToLower(string(metric))
+	if alias == "" {
+		alias = "similarity"
+	}
+	expr := fmt.Sprintf("vector::similarity::%s(%s, %s) AS %s", metricLower, field, vec, alias)
+	out := q.clone()
+	out.Fields = append(out.Fields, expr)
+	return out
+}
+
+// WithReturnFormat sets the RETURN clause to a specific format.
+func (q Query) WithReturnFormat(f ReturnFormat) Query {
+	out := q.clone()
+	out.ReturnFormat = f
+	return out
+}
+
+// ReturnNone shortcut for `RETURN NONE`.
+func (q Query) ReturnNone() Query { return q.WithReturnFormat(ReturnNone) }
+
+// ReturnDiff shortcut for `RETURN DIFF`.
+func (q Query) ReturnDiff() Query { return q.WithReturnFormat(ReturnDiff) }
+
+// ReturnFull shortcut for `RETURN FULL`.
+func (q Query) ReturnFull() Query { return q.WithReturnFormat(ReturnFull) }
+
+// ReturnBefore shortcut for `RETURN BEFORE`.
+func (q Query) ReturnBefore() Query { return q.WithReturnFormat(ReturnBefore) }
+
+// ReturnAfter shortcut for `RETURN AFTER`.
+func (q Query) ReturnAfter() Query { return q.WithReturnFormat(ReturnAfter) }
+
+// Hint appends a query optimization hint.
+func (q Query) Hint(hint QueryHint) Query {
+	out := q.clone()
+	out.Hints = append(out.Hints, hint)
+	return out
+}
+
+// WithHints appends multiple hints in order.
+func (q Query) WithHints(hints ...QueryHint) Query {
+	out := q.clone()
+	out.Hints = append(out.Hints, hints...)
+	return out
+}
+
+// ForceIndex adds an `IndexHint` with the force flag set. Requires the
+// table to have been set first.
+func (q Query) ForceIndex(index string) (Query, error) {
+	if q.TableName == "" {
+		return Query{}, surqlerrors.New(surqlerrors.ErrValidation, "Table name required for index hint")
+	}
+	return q.Hint(IndexHint{Table: q.TableName, Index: index, Force: true}), nil
+}
+
+// UseIndex adds a soft `IndexHint` (non-forcing).
+func (q Query) UseIndex(index string) (Query, error) {
+	if q.TableName == "" {
+		return Query{}, surqlerrors.New(surqlerrors.ErrValidation, "Table name required for index hint")
+	}
+	return q.Hint(IndexHint{Table: q.TableName, Index: index, Force: false}), nil
+}
+
+// WithTimeout adds a TimeoutHint.
+func (q Query) WithTimeout(seconds float64) (Query, error) {
+	hint, err := NewTimeoutHint(seconds)
+	if err != nil {
+		return Query{}, err
+	}
+	return q.Hint(hint), nil
+}
+
+// Parallel adds a ParallelHint. When maxWorkers is nil, enables with
+// the server default worker count.
+func (q Query) Parallel(maxWorkers *uint) (Query, error) {
+	if maxWorkers == nil {
+		return q.Hint(ParallelEnabled()), nil
+	}
+	hint, err := ParallelWithWorkers(*maxWorkers)
+	if err != nil {
+		return Query{}, err
+	}
+	return q.Hint(hint), nil
+}
+
+// WithFetch adds a FetchHint.
+func (q Query) WithFetch(strategy FetchStrategy, batchSize *uint32) (Query, error) {
+	switch strategy {
+	case FetchEager:
+		return q.Hint(FetchEagerHint()), nil
+	case FetchLazy:
+		return q.Hint(FetchLazyHint()), nil
+	case FetchBatch:
+		if batchSize == nil {
+			return Query{}, surqlerrors.New(surqlerrors.ErrValidation,
+				"FetchHint batch_size required when strategy is batch")
+		}
+		hint, err := FetchBatchHint(*batchSize)
+		if err != nil {
+			return Query{}, err
+		}
+		return q.Hint(hint), nil
+	default:
+		return Query{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"unknown fetch strategy: %q", strategy)
+	}
+}
+
+// Explain adds an ExplainHint. `full=true` asks for the full plan.
+func (q Query) Explain(full bool) Query {
+	if full {
+		return q.Hint(ExplainFull())
+	}
+	return q.Hint(ExplainShort())
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+// ToSurql renders the Query to a SurrealQL string. Returns ErrValidation
+// when the query is incomplete or internally inconsistent.
+func (q Query) ToSurql() (string, error) {
+	if q.Operation == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Query operation not specified")
+	}
+	var (
+		base string
+		err  error
+	)
+	switch q.Operation {
+	case OpSelect:
+		base, err = q.buildSelect()
+	case OpInsert:
+		base, err = q.buildInsert()
+	case OpUpdate:
+		base, err = q.buildUpdate()
+	case OpDelete:
+		base, err = q.buildDelete()
+	case OpUpsert:
+		base, err = q.buildUpsert()
+	case OpRelate:
+		base, err = q.buildRelate()
+	default:
+		return "", surqlerrors.Newf(surqlerrors.ErrValidation, "Unsupported operation: %s", q.Operation)
+	}
+	if err != nil {
+		return "", err
+	}
+	if len(q.Hints) > 0 {
+		return RenderHints(q.Hints) + "\n" + base, nil
+	}
+	return base, nil
+}
+
+// MustToSurql is ToSurql that panics on error. Convenient for tests.
+func (q Query) MustToSurql() string {
+	s, err := q.ToSurql()
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func (q Query) buildSelect() (string, error) {
+	if q.TableName == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Table name required for SELECT query")
+	}
+	fieldsStr := "*"
+	if len(q.Fields) > 0 {
+		fieldsStr = strings.Join(q.Fields, ", ")
+	}
+	head := "SELECT " + fieldsStr + " FROM " + q.TableName
+	if q.GraphTraversal != "" {
+		head += q.GraphTraversal
+	}
+	parts := []string{head}
+	parts = append(parts, q.JoinClauses...)
+
+	var whereParts []string
+	if q.VectorField != "" && len(q.VectorValue) > 0 && q.VectorK != nil && q.VectorDistance != "" {
+		vec := renderVectorLiteral(q.VectorValue)
+		var op string
+		if q.VectorThreshold != nil {
+			op = fmt.Sprintf("<|%d,%s,%s|>", *q.VectorK, string(q.VectorDistance), formatFloat(*q.VectorThreshold))
+		} else {
+			op = fmt.Sprintf("<|%d,%s|>", *q.VectorK, string(q.VectorDistance))
+		}
+		whereParts = append(whereParts, fmt.Sprintf("%s %s %s", q.VectorField, op, vec))
+	}
+	for _, c := range q.Conditions {
+		whereParts = append(whereParts, "("+c+")")
+	}
+	if len(whereParts) > 0 {
+		parts = append(parts, "WHERE "+strings.Join(whereParts, " AND "))
+	}
+
+	if q.GroupAllFlag {
+		parts = append(parts, "GROUP ALL")
+	} else if len(q.GroupFields) > 0 {
+		parts = append(parts, "GROUP BY "+strings.Join(q.GroupFields, ", "))
+	}
+
+	if len(q.OrderFields) > 0 {
+		ordered := make([]string, len(q.OrderFields))
+		for i, of := range q.OrderFields {
+			ordered[i] = of.Field + " " + of.Direction
+		}
+		parts = append(parts, "ORDER BY "+strings.Join(ordered, ", "))
+	}
+
+	if q.LimitValue != nil {
+		parts = append(parts, "LIMIT "+strconv.Itoa(*q.LimitValue))
+	}
+	if q.OffsetValue != nil {
+		parts = append(parts, "START "+strconv.Itoa(*q.OffsetValue))
+	}
+	return strings.Join(parts, " "), nil
+}
+
+func (q Query) buildInsert() (string, error) {
+	if q.TableName == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Table name required for INSERT query")
+	}
+	if len(q.InsertData) == 0 {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Insert data required for INSERT query")
+	}
+	body := renderDataObject(q.InsertData)
+	parts := []string{"CREATE " + q.TableName + " CONTENT " + body}
+	if q.ReturnFormat != "" {
+		parts = append(parts, "RETURN "+q.ReturnFormat.ToSurql())
+	}
+	return strings.Join(parts, " "), nil
+}
+
+func (q Query) buildUpdate() (string, error) {
+	if q.TableName == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Table name required for UPDATE query")
+	}
+	if len(q.UpdateData) == 0 {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Update data required for UPDATE query")
+	}
+	keys := sortedKeys(q.UpdateData)
+	setParts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		setParts = append(setParts, k+" = "+quoteValueExpr(q.UpdateData[k]))
+	}
+	parts := []string{"UPDATE " + q.TableName + " SET " + strings.Join(setParts, ", ")}
+	if len(q.Conditions) > 0 {
+		parts = append(parts, "WHERE "+joinConditions(q.Conditions))
+	}
+	if q.ReturnFormat != "" {
+		parts = append(parts, "RETURN "+q.ReturnFormat.ToSurql())
+	}
+	return strings.Join(parts, " "), nil
+}
+
+func (q Query) buildUpsert() (string, error) {
+	if q.TableName == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Table name required for UPSERT query")
+	}
+	if len(q.UpdateData) == 0 {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Data required for UPSERT query")
+	}
+	body := renderDataObject(q.UpdateData)
+	parts := []string{"UPSERT " + q.TableName + " CONTENT " + body}
+	if len(q.Conditions) > 0 {
+		parts = append(parts, "WHERE "+joinConditions(q.Conditions))
+	}
+	if q.ReturnFormat != "" {
+		parts = append(parts, "RETURN "+q.ReturnFormat.ToSurql())
+	}
+	return strings.Join(parts, " "), nil
+}
+
+func (q Query) buildDelete() (string, error) {
+	if q.TableName == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Table name required for DELETE query")
+	}
+	parts := []string{"DELETE " + q.TableName}
+	if len(q.Conditions) > 0 {
+		parts = append(parts, "WHERE "+joinConditions(q.Conditions))
+	}
+	if q.ReturnFormat != "" {
+		parts = append(parts, "RETURN "+q.ReturnFormat.ToSurql())
+	}
+	return strings.Join(parts, " "), nil
+}
+
+func (q Query) buildRelate() (string, error) {
+	if q.TableName == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Edge table name required for RELATE query")
+	}
+	if q.RelateFrom == "" || q.RelateTo == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "From and to records required for RELATE query")
+	}
+	head := fmt.Sprintf("RELATE %s->%s->%s", q.RelateFrom, q.TableName, q.RelateTo)
+	parts := []string{head}
+	if len(q.RelateData) > 0 {
+		parts = append(parts, "CONTENT "+renderDataObject(q.RelateData))
+	}
+	if q.ReturnFormat != "" {
+		parts = append(parts, "RETURN "+q.ReturnFormat.ToSurql())
+	}
+	return strings.Join(parts, " "), nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared rendering helpers
+// ---------------------------------------------------------------------------
+
+func joinConditions(conds []string) string {
+	wrapped := make([]string, len(conds))
+	for i, c := range conds {
+		wrapped[i] = "(" + c + ")"
+	}
+	return strings.Join(wrapped, " AND ")
+}
+
+// renderDataObject renders a map as `{k: v, ...}` with keys sorted so
+// that the output is deterministic across runs.
+func renderDataObject(m map[string]any) string {
+	keys := sortedKeys(m)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+": "+quoteValueExpr(m[k]))
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func renderVectorLiteral(vec []float64) string {
+	parts := make([]string, len(vec))
+	for i, v := range vec {
+		parts[i] = formatFloat(v)
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+func formatFloat(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}
+
+// validateDataKeys checks every key in a user-supplied map is a safe
+// identifier.
+func validateDataKeys(data map[string]any) error {
+	for k := range data {
+		if err := validateIdentifier(k, "field name"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// relateEndpoint normalizes a from/to endpoint into its string form.
+func relateEndpoint(v any) (string, error) {
+	switch x := v.(type) {
+	case string:
+		if x == "" {
+			return "", surqlerrors.New(surqlerrors.ErrValidation, "relate endpoint cannot be empty")
+		}
+		return x, nil
+	case types.RecordID:
+		return x.String(), nil
+	case fmt.Stringer:
+		s := x.String()
+		if s == "" {
+			return "", surqlerrors.New(surqlerrors.ErrValidation, "relate endpoint cannot be empty")
+		}
+		return s, nil
+	case nil:
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "relate endpoint cannot be nil")
+	default:
+		return "", surqlerrors.Newf(surqlerrors.ErrValidation,
+			"relate endpoint must be string or types.RecordID, got %T", v)
+	}
+}

--- a/pkg/surql/query/builder_test.go
+++ b/pkg/surql/query/builder_test.go
@@ -1,0 +1,514 @@
+package query
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/types"
+)
+
+// mustFrom is a shorthand for `Query{}.Select(fields).FromTable(t)` that
+// returns the Query directly (fatal on error).
+func mustFrom(t *testing.T, fields []string, table string) Query {
+	t.Helper()
+	q, err := Query{}.Select(fields).FromTable(table)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return q
+}
+
+func TestQuery_ZeroValueFailsToRender(t *testing.T) {
+	if _, err := (Query{}).ToSurql(); err == nil {
+		t.Fatal("expected error for empty operation")
+	} else if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestSelect_AllFields(t *testing.T) {
+	q := mustFrom(t, nil, "user")
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "SELECT * FROM user"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestSelect_SpecificFields(t *testing.T) {
+	q := mustFrom(t, []string{"name", "email"}, "user")
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "SELECT name, email FROM user"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSelect_WhereStringAndOperator(t *testing.T) {
+	q, err := Query{}.Select(nil).FromTable("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.Where("age > 18")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.Where(types.EqOp("status", "active"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM user WHERE (age > 18) AND (status = 'active')"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSelect_OrderByAsc(t *testing.T) {
+	q := mustFrom(t, nil, "user")
+	q, err := q.OrderBy("name", "asc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM user ORDER BY name ASC"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestOrderBy_InvalidDirection(t *testing.T) {
+	q := Query{}.Select(nil)
+	if _, err := q.OrderBy("name", "sideways"); err == nil {
+		t.Fatal("expected validation error")
+	} else if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestSelect_GroupBy(t *testing.T) {
+	q := mustFrom(t, []string{"status", "COUNT(*)"}, "user").
+		GroupBy("status")
+	got, _ := q.ToSurql()
+	if want := "SELECT status, COUNT(*) FROM user GROUP BY status"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSelect_GroupAll(t *testing.T) {
+	q := mustFrom(t, []string{"count()"}, "user").GroupAll()
+	got, _ := q.ToSurql()
+	if want := "SELECT count() FROM user GROUP ALL"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSelect_LimitOffset(t *testing.T) {
+	q := mustFrom(t, nil, "user")
+	q, err := q.Limit(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.Offset(20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM user LIMIT 10 START 20"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestLimit_NegativeRejected(t *testing.T) {
+	if _, err := (Query{}).Limit(-1); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestOffset_NegativeRejected(t *testing.T) {
+	if _, err := (Query{}).Offset(-1); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestInsert_Basic(t *testing.T) {
+	q, err := Query{}.Insert("user", map[string]any{"name": "Alice", "age": 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	// Keys are sorted deterministically.
+	if want := "CREATE user CONTENT {age: 30, name: 'Alice'}"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestInsert_InvalidTableRejected(t *testing.T) {
+	if _, err := (Query{}).Insert("1bad", map[string]any{"a": 1}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestInsert_InvalidFieldRejected(t *testing.T) {
+	if _, err := (Query{}).Insert("user", map[string]any{"bad field": 1}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestInsert_ReturnFull(t *testing.T) {
+	q, err := Query{}.Insert("user", map[string]any{"name": "Bob"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ReturnFull().ToSurql()
+	if want := "CREATE user CONTENT {name: 'Bob'} RETURN FULL"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestUpdate_SetAndWhere(t *testing.T) {
+	q, err := Query{}.Update("user", map[string]any{"status": "active"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.Where("last_login > '2024-01-01'")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "UPDATE user SET status = 'active' WHERE (last_login > '2024-01-01')"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestUpdate_ReturnDiff(t *testing.T) {
+	q, err := Query{}.Update("user:alice", map[string]any{"age": 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ReturnDiff().ToSurql()
+	if want := "UPDATE user:alice SET age = 30 RETURN DIFF"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestUpsert_Basic(t *testing.T) {
+	q, err := Query{}.Upsert("user:alice", map[string]any{"name": "Alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "UPSERT user:alice CONTENT {name: 'Alice'}"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestDelete_WithWhere(t *testing.T) {
+	q, err := Query{}.Delete("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.Where("age < 18")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "DELETE user WHERE (age < 18)"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestDelete_ReturnBefore(t *testing.T) {
+	q, err := Query{}.Delete("user:alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ReturnBefore().ToSurql()
+	if want := "DELETE user:alice RETURN BEFORE"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRelate_StringEndpoints(t *testing.T) {
+	q, err := Query{}.Relate("likes", "user:alice", "post:123", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "RELATE user:alice->likes->post:123"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRelate_WithDataAndReturn(t *testing.T) {
+	q, err := Query{}.Relate("likes", "user:a", "post:1", map[string]any{"since": "2024-01-01"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ReturnAfter().ToSurql()
+	if want := "RELATE user:a->likes->post:1 CONTENT {since: '2024-01-01'} RETURN AFTER"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRelate_RecordIDEndpoints(t *testing.T) {
+	from, _ := types.NewStringRecordID("user", "alice")
+	to, _ := types.NewIntRecordID("post", 42)
+	q, err := Query{}.Relate("likes", from, to, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "RELATE user:alice->likes->post:42"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRelate_InvalidEdgeTable(t *testing.T) {
+	if _, err := (Query{}).Relate("1bad", "user:a", "post:1", nil); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestImmutability_ChainingReturnsFreshQuery(t *testing.T) {
+	base := Query{}.Select(nil)
+	a, err := base.FromTable("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := base.FromTable("post")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.TableName == b.TableName {
+		t.Fatalf("expected independent tables, both %q", a.TableName)
+	}
+	if base.TableName != "" {
+		t.Fatalf("base mutated to %q", base.TableName)
+	}
+}
+
+func TestImmutability_FieldsSliceSafety(t *testing.T) {
+	src := []string{"id"}
+	q := Query{}.Select(src)
+	src[0] = "MUTATED"
+	if q.Fields[0] != "id" {
+		t.Fatalf("caller mutation leaked, got %q", q.Fields[0])
+	}
+}
+
+func TestImmutability_DataMapSafety(t *testing.T) {
+	data := map[string]any{"name": "Alice"}
+	q, err := Query{}.Insert("user", data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data["name"] = "Bob"
+	if q.InsertData["name"] != "Alice" {
+		t.Fatalf("caller mutation leaked, got %q", q.InsertData["name"])
+	}
+}
+
+func TestVectorSearch_NoThreshold(t *testing.T) {
+	q, err := Query{}.Select(nil).FromTable("documents")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.VectorSearch("embedding", []float64{0.1, 0.2, 0.3}, 10, DistanceCosine, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM documents WHERE embedding <|10,COSINE|> [0.1, 0.2, 0.3]"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestVectorSearch_WithThreshold(t *testing.T) {
+	thr := 0.7
+	q, err := Query{}.Select(nil).FromTable("docs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.VectorSearch("embedding", []float64{1, 2}, 5, DistanceEuclidean, &thr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, "<|5,EUCLIDEAN,0.7|>") {
+		t.Errorf("missing threshold operator in %q", got)
+	}
+}
+
+func TestVectorSearch_EmptyVectorRejected(t *testing.T) {
+	q := Query{}.Select(nil)
+	if _, err := q.VectorSearch("e", nil, 3, DistanceCosine, nil); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestVectorSearch_KMustBePositive(t *testing.T) {
+	q := Query{}.Select(nil)
+	if _, err := q.VectorSearch("e", []float64{1}, 0, DistanceCosine, nil); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestHint_Composition(t *testing.T) {
+	q := mustFrom(t, nil, "user")
+	timeout, err := NewTimeoutHint(30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := q.WithHints(timeout, ExplainShort()).ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(out, "/* TIMEOUT 30s */ /* EXPLAIN */\nSELECT") {
+		t.Errorf("hint prefix missing in %q", out)
+	}
+}
+
+func TestHint_IndexConvenienceRequiresTable(t *testing.T) {
+	if _, err := (Query{}.Select(nil)).ForceIndex("idx_a"); err == nil {
+		t.Fatal("expected error without table")
+	}
+}
+
+func TestHint_UseIndex(t *testing.T) {
+	q, err := (mustFrom(t, nil, "user")).UseIndex("email_idx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, "/* USE INDEX user.email_idx */") {
+		t.Errorf("hint missing in %q", got)
+	}
+}
+
+func TestFromTable_InvalidRejected(t *testing.T) {
+	if _, err := (Query{}).FromTable("1bad"); err == nil {
+		t.Fatal("expected error")
+	}
+	if _, err := (Query{}).FromTable("a-b"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFromTable_WithRecordID(t *testing.T) {
+	q, err := Query{}.Select(nil).FromTable("user:alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM user:alice"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestTraverse_AppendsToFrom(t *testing.T) {
+	q := mustFrom(t, nil, "user:alice").Traverse("->likes->post")
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM user:alice->likes->post"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSimilarityScore_AddsField(t *testing.T) {
+	q := mustFrom(t, []string{"id"}, "chunk").
+		SimilarityScore("embedding", []float64{0.1, 0.2}, DistanceCosine, "score")
+	got, _ := q.ToSurql()
+	want := "SELECT id, vector::similarity::cosine(embedding, [0.1, 0.2]) AS score FROM chunk"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestUnsupportedOperation_Rendered(t *testing.T) {
+	q := Query{Operation: Operation("BOGUS")}
+	if _, err := q.ToSurql(); err == nil {
+		t.Fatal("expected error for unsupported op")
+	}
+}
+
+func TestUpdate_WithoutDataFails(t *testing.T) {
+	q := Query{Operation: OpUpdate, TableName: "user"}
+	if _, err := q.ToSurql(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestInsert_WithoutDataFails(t *testing.T) {
+	q := Query{Operation: OpInsert, TableName: "user"}
+	if _, err := q.ToSurql(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRelate_MissingEndpointsFails(t *testing.T) {
+	q := Query{Operation: OpRelate, TableName: "likes"}
+	if _, err := q.ToSurql(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestJoin_AppendsRawClause(t *testing.T) {
+	q := mustFrom(t, nil, "user").
+		Join("JOIN post ON user.id = post.author")
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, "JOIN post ON user.id = post.author") {
+		t.Errorf("join missing: %q", got)
+	}
+}
+
+func TestReturnFormat_ToSurql(t *testing.T) {
+	cases := map[ReturnFormat]string{
+		ReturnNone:   "NONE",
+		ReturnDiff:   "DIFF",
+		ReturnFull:   "FULL",
+		ReturnBefore: "BEFORE",
+		ReturnAfter:  "AFTER",
+	}
+	for f, want := range cases {
+		if got := f.ToSurql(); got != want {
+			t.Errorf("%v: got %q want %q", f, got, want)
+		}
+	}
+}
+
+func TestWhere_NilRejected(t *testing.T) {
+	q := Query{}.Select(nil)
+	if _, err := q.Where(nil); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestWhere_UnsupportedTypeRejected(t *testing.T) {
+	q := Query{}.Select(nil)
+	if _, err := q.Where(123); err == nil {
+		t.Fatal("expected error for int condition")
+	}
+}
+
+func TestQuoteValue_EscapesSpecialChars(t *testing.T) {
+	q, err := Query{}.Insert("user", map[string]any{"name": "O'Brien"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, `O\'Brien`) {
+		t.Errorf("escape missing: %q", got)
+	}
+}
+
+func TestExplain_Hint(t *testing.T) {
+	q := mustFrom(t, nil, "user").Explain(true)
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, "/* EXPLAIN FULL */") {
+		t.Errorf("explain full missing: %q", got)
+	}
+}

--- a/pkg/surql/query/doc.go
+++ b/pkg/surql/query/doc.go
@@ -1,12 +1,19 @@
 // Package query provides query construction and result handling for the
 // surql-go library. It is a 1:1 port of surql-py/src/surql/query/.
 //
-// This increment exposes the hints API (IndexHint, ParallelHint, TimeoutHint,
-// FetchHint, ExplainHint) and the result wrappers (QueryResult, RecordResult,
-// ListResult, CountResult, AggregateResult, PageInfo, PaginatedResult) plus
-// the raw-response extraction helpers (ExtractResult, ExtractOne,
-// ExtractScalar, HasResults).
+// This increment exposes:
+//   - the hints API (IndexHint, ParallelHint, TimeoutHint, FetchHint, ExplainHint)
+//   - the result wrappers (QueryResult, RecordResult, ListResult, CountResult,
+//     AggregateResult, PageInfo, PaginatedResult) plus the raw-response
+//     extraction helpers (ExtractResult, ExtractOne, ExtractScalar, HasResults)
+//   - typed SurrealQL expression helpers (Field, Value, Raw, Func, and function
+//     builders such as Count, MathMean, ArrayContains, Concat, ...)
+//   - the immutable fluent Query builder with SELECT / INSERT / UPDATE /
+//     UPSERT / DELETE / RELATE operations, graph traversal, vector search,
+//     return-format, and optimization hints
+//   - standalone helper constructors (Select, FromTable, Insert, Update,
+//     Upsert, Delete, Relate, VectorSearchQuery, SimilaritySearchQuery).
 //
-// Subsequent increments add the immutable Query builder, expressions,
-// typed/batch/graph CRUD, and the async executor.
+// Subsequent increments add typed/batch/graph CRUD helpers and the async
+// executor.
 package query

--- a/pkg/surql/query/helpers.go
+++ b/pkg/surql/query/helpers.go
@@ -1,0 +1,202 @@
+package query
+
+import (
+	"regexp"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// ReturnFormat selects the data returned by a mutation.
+//
+// Mirrors the Python `ReturnFormat` enum: NONE returns nothing, DIFF
+// returns only changed fields, FULL returns the entire record, and
+// BEFORE / AFTER capture state around the write.
+type ReturnFormat string
+
+const (
+	// ReturnNone omits the record body from the response.
+	ReturnNone ReturnFormat = "NONE"
+	// ReturnDiff emits just the fields that changed.
+	ReturnDiff ReturnFormat = "DIFF"
+	// ReturnFull emits the full record.
+	ReturnFull ReturnFormat = "FULL"
+	// ReturnBefore emits the record state before the write.
+	ReturnBefore ReturnFormat = "BEFORE"
+	// ReturnAfter emits the record state after the write (SurrealDB default).
+	ReturnAfter ReturnFormat = "AFTER"
+)
+
+// ToSurql renders the format as its SurrealQL keyword.
+func (f ReturnFormat) ToSurql() string { return string(f) }
+
+// String implements fmt.Stringer.
+func (f ReturnFormat) String() string { return string(f) }
+
+// VectorDistanceType names a vector-similarity metric.
+//
+// Mirrors the Python `VectorDistanceType` literal. MAHALANOBIS is
+// included for parity even though the surql-py public surface only
+// lists 8 metrics — the generator and SurrealDB both accept it.
+type VectorDistanceType string
+
+const (
+	// DistanceCosine is cosine similarity.
+	DistanceCosine VectorDistanceType = "COSINE"
+	// DistanceEuclidean is L2 distance.
+	DistanceEuclidean VectorDistanceType = "EUCLIDEAN"
+	// DistanceManhattan is L1 distance.
+	DistanceManhattan VectorDistanceType = "MANHATTAN"
+	// DistanceChebyshev is L-infinity distance.
+	DistanceChebyshev VectorDistanceType = "CHEBYSHEV"
+	// DistanceMinkowski is generalized Lp distance.
+	DistanceMinkowski VectorDistanceType = "MINKOWSKI"
+	// DistanceHamming is hamming distance.
+	DistanceHamming VectorDistanceType = "HAMMING"
+	// DistanceJaccard is jaccard distance.
+	DistanceJaccard VectorDistanceType = "JACCARD"
+	// DistancePearson is pearson correlation distance.
+	DistancePearson VectorDistanceType = "PEARSON"
+	// DistanceMahalanobis is mahalanobis distance (parity extension).
+	DistanceMahalanobis VectorDistanceType = "MAHALANOBIS"
+)
+
+// identifierPattern matches a safe SurrealDB identifier.
+var identifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// validateIdentifier checks that a table / field / edge name is safe to
+// splice into a generated SurrealQL string.
+func validateIdentifier(name, context string) error {
+	if name == "" {
+		return surqlerrors.Newf(surqlerrors.ErrValidation, "%s cannot be empty", capitalize(context))
+	}
+	if !identifierPattern.MatchString(name) {
+		return surqlerrors.Newf(
+			surqlerrors.ErrValidation,
+			"Invalid %s: %q. Must contain only alphanumeric characters and underscores, and cannot start with a digit",
+			context, name,
+		)
+	}
+	return nil
+}
+
+// splitTablePart peels off the `table:id` prefix so we can validate just
+// the table portion of a target string.
+func splitTablePart(target string) string {
+	if idx := strings.Index(target, ":"); idx >= 0 {
+		return target[:idx]
+	}
+	return target
+}
+
+// capitalize upper-cases the first rune of s.
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// ---------------------------------------------------------------------------
+// Standalone helper constructors — mirror the free functions in helpers.py.
+// Each produces a fresh Query with the relevant state set.
+// ---------------------------------------------------------------------------
+
+// Select starts a SELECT query with the given fields. Pass nil for `SELECT *`.
+func Select(fields []string) Query {
+	return Query{}.Select(fields)
+}
+
+// FromTable builds a Query whose target is the given table.
+func FromTable(table string) (Query, error) {
+	return Query{}.FromTable(table)
+}
+
+// Where adds a WHERE condition to an existing query. The condition can
+// be a raw string or any value implementing `types.Operator`.
+func Where(q Query, condition any) (Query, error) {
+	return q.Where(condition)
+}
+
+// OrderBy adds an ORDER BY clause to an existing query.
+func OrderBy(q Query, field, direction string) (Query, error) {
+	return q.OrderBy(field, direction)
+}
+
+// Limit adds a LIMIT clause to an existing query.
+func Limit(q Query, n int) (Query, error) {
+	return q.Limit(n)
+}
+
+// Offset adds an OFFSET clause to an existing query.
+func Offset(q Query, n int) (Query, error) {
+	return q.Offset(n)
+}
+
+// Insert creates an INSERT query.
+func Insert(table string, data map[string]any) (Query, error) {
+	return Query{}.Insert(table, data)
+}
+
+// Update creates an UPDATE query.
+func Update(target string, data map[string]any) (Query, error) {
+	return Query{}.Update(target, data)
+}
+
+// Upsert creates an UPSERT query.
+func Upsert(target string, data map[string]any) (Query, error) {
+	return Query{}.Upsert(target, data)
+}
+
+// Delete creates a DELETE query.
+func Delete(target string) (Query, error) {
+	return Query{}.Delete(target)
+}
+
+// Relate creates a RELATE query for the given edge + endpoints.
+//
+// `from` and `to` may be `string` or `types.RecordID`.
+func Relate(edgeTable string, from, to any, data map[string]any) (Query, error) {
+	return Query{}.Relate(edgeTable, from, to, data)
+}
+
+// VectorSearchQuery is the convenience builder: `SELECT ... FROM table
+// WHERE field <|k,distance|> vector`.
+func VectorSearchQuery(
+	table, field string,
+	vector []float64,
+	k int,
+	distance VectorDistanceType,
+	fields []string,
+	threshold *float64,
+) (Query, error) {
+	q := Select(fields)
+	q, err := q.FromTable(table)
+	if err != nil {
+		return Query{}, err
+	}
+	return q.VectorSearch(field, vector, k, distance, threshold)
+}
+
+// SimilaritySearchQuery mirrors `similarity_search_query`: combines a
+// vector search clause with a similarity score field in the projection.
+func SimilaritySearchQuery(
+	table, field string,
+	vector []float64,
+	k int,
+	distance VectorDistanceType,
+	threshold *float64,
+	fields []string,
+	alias string,
+) (Query, error) {
+	q := Select(fields)
+	q, err := q.FromTable(table)
+	if err != nil {
+		return Query{}, err
+	}
+	if alias == "" {
+		alias = "similarity"
+	}
+	q = q.SimilarityScore(field, vector, distance, alias)
+	return q.VectorSearch(field, vector, k, distance, threshold)
+}

--- a/pkg/surql/query/helpers_test.go
+++ b/pkg/surql/query/helpers_test.go
@@ -1,0 +1,246 @@
+package query
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestHelper_Select(t *testing.T) {
+	q := Select(nil)
+	if q.Operation != OpSelect {
+		t.Errorf("got %v", q.Operation)
+	}
+	if len(q.Fields) != 1 || q.Fields[0] != "*" {
+		t.Errorf("fields: %v", q.Fields)
+	}
+}
+
+func TestHelper_SelectWithFields(t *testing.T) {
+	q := Select([]string{"a", "b"})
+	if len(q.Fields) != 2 || q.Fields[0] != "a" || q.Fields[1] != "b" {
+		t.Errorf("fields: %v", q.Fields)
+	}
+}
+
+func TestHelper_FromTable(t *testing.T) {
+	q, err := FromTable("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q.TableName != "user" {
+		t.Errorf("got %q", q.TableName)
+	}
+}
+
+func TestHelper_FromTable_Invalid(t *testing.T) {
+	if _, err := FromTable(""); err == nil {
+		t.Fatal("expected empty-table error")
+	} else if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+	if _, err := FromTable("1bad"); err == nil {
+		t.Fatal("expected syntax error")
+	}
+}
+
+func TestHelper_Where(t *testing.T) {
+	q, err := FromTable("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q = q.Select(nil)
+	q, err = Where(q, "age > 18")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM user WHERE (age > 18)"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestHelper_OrderBy(t *testing.T) {
+	q, _ := Select(nil).FromTable("user")
+	q, err := OrderBy(q, "name", "DESC")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM user ORDER BY name DESC"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestHelper_Limit(t *testing.T) {
+	q, _ := Select(nil).FromTable("user")
+	q, err := Limit(q, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q.LimitValue == nil || *q.LimitValue != 5 {
+		t.Errorf("limit: %v", q.LimitValue)
+	}
+}
+
+func TestHelper_Offset(t *testing.T) {
+	q, _ := Select(nil).FromTable("user")
+	q, err := Offset(q, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q.OffsetValue == nil || *q.OffsetValue != 3 {
+		t.Errorf("offset: %v", q.OffsetValue)
+	}
+}
+
+func TestHelper_Insert(t *testing.T) {
+	q, err := Insert("user", map[string]any{"name": "Alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q.Operation != OpInsert {
+		t.Errorf("op: %v", q.Operation)
+	}
+	if q.TableName != "user" {
+		t.Errorf("table: %q", q.TableName)
+	}
+}
+
+func TestHelper_Update(t *testing.T) {
+	q, err := Update("user:alice", map[string]any{"age": 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "UPDATE user:alice SET age = 30"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestHelper_Upsert(t *testing.T) {
+	q, err := Upsert("user:alice", map[string]any{"status": "active"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "UPSERT user:alice CONTENT {status: 'active'}"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestHelper_Delete(t *testing.T) {
+	q, err := Delete("user:alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "DELETE user:alice"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestHelper_Relate(t *testing.T) {
+	q, err := Relate("likes", "user:a", "post:1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "RELATE user:a->likes->post:1"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestHelper_VectorSearchQuery(t *testing.T) {
+	q, err := VectorSearchQuery(
+		"documents", "embedding", []float64{0.1, 0.2, 0.3}, 10,
+		DistanceCosine, nil, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, "<|10,COSINE|>") {
+		t.Errorf("missing vector op: %q", got)
+	}
+}
+
+func TestHelper_VectorSearchQuery_WithThreshold(t *testing.T) {
+	thr := 0.5
+	q, err := VectorSearchQuery(
+		"documents", "embedding", []float64{0.1, 0.2, 0.3}, 10,
+		DistanceCosine, []string{"id", "text"}, &thr,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, "<|10,COSINE,0.5|>") || !strings.Contains(got, "SELECT id, text") {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestHelper_SimilaritySearchQuery(t *testing.T) {
+	q, err := SimilaritySearchQuery(
+		"chunk", "embedding", []float64{0.1, 0.2}, 5,
+		DistanceCosine, nil, []string{"id"}, "score",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, "vector::similarity::cosine(embedding, [0.1, 0.2]) AS score") {
+		t.Errorf("missing similarity projection: %q", got)
+	}
+	if !strings.Contains(got, "<|5,COSINE|>") {
+		t.Errorf("missing vector operator: %q", got)
+	}
+}
+
+func TestReturnFormat_Values(t *testing.T) {
+	if ReturnNone.String() != "NONE" {
+		t.Error("none")
+	}
+	if ReturnAfter.ToSurql() != "AFTER" {
+		t.Error("after")
+	}
+}
+
+func TestVectorDistance_Constants(t *testing.T) {
+	cases := []VectorDistanceType{
+		DistanceCosine, DistanceEuclidean, DistanceManhattan, DistanceChebyshev,
+		DistanceMinkowski, DistanceHamming, DistanceJaccard, DistancePearson,
+		DistanceMahalanobis,
+	}
+	for _, c := range cases {
+		if string(c) == "" {
+			t.Errorf("empty distance constant")
+		}
+	}
+}
+
+func TestValidateIdentifier_Cases(t *testing.T) {
+	valid := []string{"user", "_hidden", "a1", "user_table"}
+	for _, v := range valid {
+		if err := validateIdentifier(v, "test"); err != nil {
+			t.Errorf("valid %q rejected: %v", v, err)
+		}
+	}
+	invalid := []string{"", "1user", "user-table", "user.name", "user table"}
+	for _, v := range invalid {
+		if err := validateIdentifier(v, "test"); err == nil {
+			t.Errorf("invalid %q accepted", v)
+		}
+	}
+}
+
+func TestSplitTablePart(t *testing.T) {
+	if splitTablePart("user") != "user" {
+		t.Error("plain")
+	}
+	if splitTablePart("user:alice") != "user" {
+		t.Error("record id")
+	}
+}


### PR DESCRIPTION
Closes #9.

## Summary
Port surql-py/src/surql/query/{builder,helpers}.py — the core immutable Query builder and its standalone helper constructors.

- **\`query/builder.go\`**: \`Query\` struct with an immutable fluent API (value-receiver copy-and-mutate). Fields match surql-py (Operation, TableName, Fields, Conditions, OrderFields, GroupFields, GroupAllFlag, LimitValue/OffsetValue, Insert/Update/Relate data, JoinClauses, GraphTraversal, ReturnFormat, vector search fields, Hints). Methods: \`Select\`, \`FromTable\`, \`Where\` (accepts string / types.Operator / nil), \`OrderBy\` (validates ASC/DESC), \`GroupBy\`, \`GroupAll\`, \`Limit\`, \`Offset\`, \`Insert\`, \`Update\`, \`Upsert\`, \`Delete\`, \`Relate\`, \`Traverse\`, \`Join\`, \`VectorSearch\`, \`ReturnFormat\`, \`Hint\`, \`ToSurql\`.
- **\`query/helpers.go\`**: \`ReturnFormat\` + \`VectorDistanceType\` (9 variants incl. Mahalanobis), standalone constructor functions (\`Select\`, \`FromTable\`, \`Where\`, \`OrderBy\`, \`Limit\`, \`Offset\`, \`Insert\`, \`Update\`, \`Upsert\`, \`Delete\`, \`Relate\`, \`VectorSearchQuery\`).
- **\`query/doc.go\`**: updated package-level godoc.

## Deviations
- Map rendering sorts keys alphabetically — Python dict preserves insertion order, Go maps don't. Tests match the sorted output.
- No generic \`Query[T]\` — Python's phantom param was runtime-inert.
- Validating methods return \`(Query, error)\`; non-validating ones return just \`Query\`.

## Test plan
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./... -race\` — **68 new tests, 117 total in query pkg, all green**
- [ ] CI green