### PR TITLE
feat(schema): port fields + tables + edges + access definitions

### DIFF
--- a/pkg/surql/schema/access.go
+++ b/pkg/surql/schema/access.go
@@ -1,0 +1,191 @@
+package schema
+
+import (
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// AccessType enumerates the access control types supported by DEFINE ACCESS.
+type AccessType string
+
+// AccessType values.
+const (
+	AccessTypeJWT    AccessType = "JWT"
+	AccessTypeRecord AccessType = "RECORD"
+)
+
+// IsValid reports whether the AccessType is recognised.
+func (a AccessType) IsValid() bool {
+	switch a {
+	case AccessTypeJWT, AccessTypeRecord:
+		return true
+	}
+	return false
+}
+
+// JwtConfig describes the JWT-specific configuration of a DEFINE ACCESS
+// statement. The Algorithm field defaults to "HS256" when unset.
+type JwtConfig struct {
+	Algorithm string
+	Key       string
+	URL       string
+	Issuer    string
+}
+
+// RecordAccessConfig describes the RECORD-specific configuration of a DEFINE
+// ACCESS statement.
+type RecordAccessConfig struct {
+	Signup string
+	Signin string
+}
+
+// AccessDefinition captures a DEFINE ACCESS statement.
+type AccessDefinition struct {
+	Name            string
+	Type            AccessType
+	JWT             *JwtConfig
+	Record          *RecordAccessConfig
+	DurationSession string
+	DurationToken   string
+}
+
+// AccessOption customises an AccessDefinition created via NewAccess.
+type AccessOption func(*AccessDefinition)
+
+// WithJWT attaches a JwtConfig (and implicitly sets Type to AccessTypeJWT if
+// not already set by the caller).
+func WithJWT(cfg JwtConfig) AccessOption {
+	return func(a *AccessDefinition) {
+		cp := cfg
+		a.JWT = &cp
+	}
+}
+
+// WithRecord attaches a RecordAccessConfig.
+func WithRecord(cfg RecordAccessConfig) AccessOption {
+	return func(a *AccessDefinition) {
+		cp := cfg
+		a.Record = &cp
+	}
+}
+
+// WithDurationSession sets the FOR SESSION clause.
+func WithDurationSession(dur string) AccessOption {
+	return func(a *AccessDefinition) { a.DurationSession = dur }
+}
+
+// WithDurationToken sets the FOR TOKEN clause.
+func WithDurationToken(dur string) AccessOption {
+	return func(a *AccessDefinition) { a.DurationToken = dur }
+}
+
+// NewAccess constructs an AccessDefinition of the given type.
+func NewAccess(name string, accessType AccessType, opts ...AccessOption) AccessDefinition {
+	a := AccessDefinition{Name: name, Type: accessType}
+	for _, opt := range opts {
+		opt(&a)
+	}
+	return a
+}
+
+// JwtAccess constructs a JWT-type AccessDefinition. Algorithm defaults to
+// HS256 when left blank.
+func JwtAccess(name string, cfg JwtConfig, opts ...AccessOption) AccessDefinition {
+	if cfg.Algorithm == "" {
+		cfg.Algorithm = "HS256"
+	}
+	merged := append([]AccessOption{WithJWT(cfg)}, opts...)
+	return NewAccess(name, AccessTypeJWT, merged...)
+}
+
+// RecordAccess constructs a RECORD-type AccessDefinition.
+func RecordAccess(name string, cfg RecordAccessConfig, opts ...AccessOption) AccessDefinition {
+	merged := append([]AccessOption{WithRecord(cfg)}, opts...)
+	return NewAccess(name, AccessTypeRecord, merged...)
+}
+
+// Validate checks structural invariants for the access definition.
+func (a AccessDefinition) Validate() error {
+	if a.Name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "access name cannot be empty")
+	}
+	if !a.Type.IsValid() {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"invalid access type %q for access %q", string(a.Type), a.Name)
+	}
+	switch a.Type {
+	case AccessTypeJWT:
+		if a.JWT == nil {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"JWT access %q requires a JWT config", a.Name)
+		}
+	case AccessTypeRecord:
+		if a.Record == nil {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"RECORD access %q requires a record config", a.Name)
+		}
+	}
+	return nil
+}
+
+// ToSurql emits the DEFINE ACCESS statement.
+func (a AccessDefinition) ToSurql() string {
+	var b strings.Builder
+	b.WriteString("DEFINE ACCESS ")
+	b.WriteString(a.Name)
+	b.WriteString(" ON DATABASE TYPE ")
+	b.WriteString(string(a.Type))
+
+	if a.Type == AccessTypeJWT && a.JWT != nil {
+		algo := a.JWT.Algorithm
+		if algo == "" {
+			algo = "HS256"
+		}
+		b.WriteString(" ALGORITHM ")
+		b.WriteString(algo)
+		if a.JWT.Key != "" {
+			b.WriteString(" KEY '")
+			b.WriteString(a.JWT.Key)
+			b.WriteString("'")
+		}
+		if a.JWT.URL != "" {
+			b.WriteString(" URL '")
+			b.WriteString(a.JWT.URL)
+			b.WriteString("'")
+		}
+		if a.JWT.Issuer != "" {
+			b.WriteString(" WITH ISSUER '")
+			b.WriteString(a.JWT.Issuer)
+			b.WriteString("'")
+		}
+	}
+
+	if a.Type == AccessTypeRecord && a.Record != nil {
+		if a.Record.Signup != "" {
+			b.WriteString(" SIGNUP (")
+			b.WriteString(a.Record.Signup)
+			b.WriteString(")")
+		}
+		if a.Record.Signin != "" {
+			b.WriteString(" SIGNIN (")
+			b.WriteString(a.Record.Signin)
+			b.WriteString(")")
+		}
+	}
+
+	if a.DurationSession != "" || a.DurationToken != "" {
+		parts := make([]string, 0, 2)
+		if a.DurationSession != "" {
+			parts = append(parts, "FOR SESSION "+a.DurationSession)
+		}
+		if a.DurationToken != "" {
+			parts = append(parts, "FOR TOKEN "+a.DurationToken)
+		}
+		b.WriteString(" DURATION ")
+		b.WriteString(strings.Join(parts, ", "))
+	}
+
+	b.WriteString(";")
+	return b.String()
+}

--- a/pkg/surql/schema/access_test.go
+++ b/pkg/surql/schema/access_test.go
@@ -1,0 +1,187 @@
+package schema
+
+import (
+	stdErrors "errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestAccessType_IsValid(t *testing.T) {
+	if !AccessTypeJWT.IsValid() {
+		t.Error("JWT should be valid")
+	}
+	if !AccessTypeRecord.IsValid() {
+		t.Error("RECORD should be valid")
+	}
+	if AccessType("bogus").IsValid() {
+		t.Error("bogus should not be valid")
+	}
+}
+
+func TestJwtAccess_ToSurql_KeyOnly(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{Algorithm: "HS256", Key: "secret"})
+	got := a.ToSurql()
+	want := "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'secret';"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestJwtAccess_ToSurql_DefaultsAlgorithm(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{Key: "secret"})
+	got := a.ToSurql()
+	if !strings.Contains(got, "ALGORITHM HS256") {
+		t.Errorf("default algorithm missing: %q", got)
+	}
+}
+
+func TestJwtAccess_ToSurql_WithURL(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{
+		Algorithm: "RS256",
+		URL:       "https://example.com/.well-known/jwks.json",
+	})
+	got := a.ToSurql()
+	if !strings.Contains(got, "ALGORITHM RS256") {
+		t.Errorf("ToSurql = %q", got)
+	}
+	if !strings.Contains(got, "URL 'https://example.com/.well-known/jwks.json'") {
+		t.Errorf("URL clause missing: %q", got)
+	}
+}
+
+func TestJwtAccess_ToSurql_WithIssuer(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{Algorithm: "HS256", Key: "s", Issuer: "me"})
+	got := a.ToSurql()
+	if !strings.Contains(got, "WITH ISSUER 'me'") {
+		t.Errorf("issuer missing: %q", got)
+	}
+}
+
+func TestRecordAccess_ToSurql_SignupOnly(t *testing.T) {
+	a := RecordAccess("user_auth", RecordAccessConfig{Signup: "CREATE user SET email = $email"})
+	got := a.ToSurql()
+	if !strings.HasPrefix(got, "DEFINE ACCESS user_auth ON DATABASE TYPE RECORD") {
+		t.Errorf("prefix wrong: %q", got)
+	}
+	if !strings.Contains(got, "SIGNUP (CREATE user SET email = $email)") {
+		t.Errorf("signup missing: %q", got)
+	}
+}
+
+func TestRecordAccess_ToSurql_SigninOnly(t *testing.T) {
+	a := RecordAccess("user_auth", RecordAccessConfig{Signin: "SELECT * FROM user"})
+	got := a.ToSurql()
+	if !strings.Contains(got, "SIGNIN (SELECT * FROM user)") {
+		t.Errorf("signin missing: %q", got)
+	}
+}
+
+func TestRecordAccess_ToSurql_Both(t *testing.T) {
+	a := RecordAccess("user_auth", RecordAccessConfig{
+		Signup: "CREATE user",
+		Signin: "SELECT * FROM user",
+	})
+	got := a.ToSurql()
+	if !strings.Contains(got, "SIGNUP (CREATE user)") {
+		t.Errorf("signup missing: %q", got)
+	}
+	if !strings.Contains(got, "SIGNIN (SELECT * FROM user)") {
+		t.Errorf("signin missing: %q", got)
+	}
+}
+
+func TestAccess_ToSurql_DurationSession(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{Key: "s"}, WithDurationSession("24h"))
+	got := a.ToSurql()
+	if !strings.Contains(got, "DURATION FOR SESSION 24h") {
+		t.Errorf("session duration missing: %q", got)
+	}
+}
+
+func TestAccess_ToSurql_DurationToken(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{Key: "s"}, WithDurationToken("15m"))
+	got := a.ToSurql()
+	if !strings.Contains(got, "DURATION FOR TOKEN 15m") {
+		t.Errorf("token duration missing: %q", got)
+	}
+}
+
+func TestAccess_ToSurql_DurationBoth(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{Key: "s"},
+		WithDurationSession("24h"), WithDurationToken("15m"))
+	got := a.ToSurql()
+	if !strings.Contains(got, "FOR SESSION 24h") || !strings.Contains(got, "FOR TOKEN 15m") {
+		t.Errorf("durations missing: %q", got)
+	}
+	// Both should appear after DURATION keyword (single occurrence).
+	if strings.Count(got, "DURATION ") != 1 {
+		t.Errorf("expected single DURATION keyword: %q", got)
+	}
+}
+
+func TestAccess_Validate_EmptyName(t *testing.T) {
+	a := AccessDefinition{Type: AccessTypeJWT, JWT: &JwtConfig{}}
+	if err := a.Validate(); err == nil {
+		t.Error("empty name should fail")
+	}
+}
+
+func TestAccess_Validate_InvalidType(t *testing.T) {
+	a := AccessDefinition{Name: "x", Type: AccessType("bogus")}
+	err := a.Validate()
+	if err == nil {
+		t.Fatal("invalid type should fail")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestAccess_Validate_JwtRequiresConfig(t *testing.T) {
+	a := AccessDefinition{Name: "api", Type: AccessTypeJWT}
+	if err := a.Validate(); err == nil {
+		t.Error("JWT without config should fail")
+	}
+}
+
+func TestAccess_Validate_RecordRequiresConfig(t *testing.T) {
+	a := AccessDefinition{Name: "api", Type: AccessTypeRecord}
+	if err := a.Validate(); err == nil {
+		t.Error("RECORD without config should fail")
+	}
+}
+
+func TestAccess_Validate_ValidJwt(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{Key: "s"})
+	if err := a.Validate(); err != nil {
+		t.Errorf("valid JWT errored: %v", err)
+	}
+}
+
+func TestAccess_Validate_ValidRecord(t *testing.T) {
+	a := RecordAccess("u", RecordAccessConfig{Signin: "SELECT * FROM user"})
+	if err := a.Validate(); err != nil {
+		t.Errorf("valid RECORD errored: %v", err)
+	}
+}
+
+func TestNewAccess_Explicit(t *testing.T) {
+	a := NewAccess("x", AccessTypeJWT, WithJWT(JwtConfig{Algorithm: "HS512", Key: "k"}))
+	if a.Type != AccessTypeJWT {
+		t.Errorf("type = %q", string(a.Type))
+	}
+	if a.JWT == nil || a.JWT.Algorithm != "HS512" {
+		t.Errorf("JWT config wrong: %+v", a.JWT)
+	}
+}
+
+func TestAccessConfigIsolation(t *testing.T) {
+	cfg := JwtConfig{Algorithm: "HS256", Key: "k"}
+	a := JwtAccess("api", cfg)
+	cfg.Key = "MUTATED"
+	if a.JWT.Key != "k" {
+		t.Errorf("expected isolated JWT config; got %q", a.JWT.Key)
+	}
+}

--- a/pkg/surql/schema/doc.go
+++ b/pkg/surql/schema/doc.go
@@ -1,0 +1,26 @@
+// Package schema provides typed builders for SurrealDB schema definitions.
+//
+// It is a Go port of surql-py/src/surql/schema/ (fields, table, edge, access
+// modules only). Each definition is an immutable value-type struct with:
+//
+//   - A ToSurql() method that renders the DEFINE statement as SurrealQL.
+//   - A Validate() method returning a wrapped surqlerrors.ErrValidation
+//     when the definition is malformed.
+//
+// Typical usage:
+//
+//	t := schema.NewTable("user",
+//	    schema.WithMode(schema.TableModeSchemafull),
+//	    schema.WithFields(
+//	        schema.StringField("email"),
+//	        schema.IntField("age"),
+//	    ),
+//	    schema.WithIndexes(
+//	        schema.UniqueIndex("email_idx", []string{"email"}),
+//	    ),
+//	)
+//	stmts := t.ToSurqlStatements()
+//
+// The package does NOT include the registry, validator, parser, visualizer,
+// or diff tooling; those will be added in later increments.
+package schema

--- a/pkg/surql/schema/edge.go
+++ b/pkg/surql/schema/edge.go
@@ -1,0 +1,234 @@
+package schema
+
+import (
+	"sort"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// EdgeMode enumerates edge table modes.
+type EdgeMode string
+
+// EdgeMode values.
+const (
+	EdgeModeRelation   EdgeMode = "RELATION"
+	EdgeModeSchemafull EdgeMode = "SCHEMAFULL"
+	EdgeModeSchemaless EdgeMode = "SCHEMALESS"
+)
+
+// IsValid reports whether the EdgeMode is recognised.
+func (m EdgeMode) IsValid() bool {
+	switch m {
+	case EdgeModeRelation, EdgeModeSchemafull, EdgeModeSchemaless:
+		return true
+	}
+	return false
+}
+
+// EdgeDefinition captures the fields required to emit a DEFINE TABLE ... TYPE
+// RELATION statement (or a SCHEMAFULL / SCHEMALESS edge) plus its attendant
+// DEFINE FIELD / INDEX / EVENT children.
+type EdgeDefinition struct {
+	Name        string
+	Mode        EdgeMode
+	FromTable   string
+	ToTable     string
+	Fields      []FieldDefinition
+	Indexes     []IndexDefinition
+	Events      []EventDefinition
+	Permissions map[string]string
+}
+
+// EdgeOption customises an EdgeDefinition created via NewEdge.
+type EdgeOption func(*EdgeDefinition)
+
+// WithEdgeMode sets the edge table mode.
+func WithEdgeMode(mode EdgeMode) EdgeOption {
+	return func(e *EdgeDefinition) { e.Mode = mode }
+}
+
+// WithFromTable sets the source table constraint.
+func WithFromTable(table string) EdgeOption {
+	return func(e *EdgeDefinition) { e.FromTable = table }
+}
+
+// WithToTable sets the destination table constraint.
+func WithToTable(table string) EdgeOption {
+	return func(e *EdgeDefinition) { e.ToTable = table }
+}
+
+// WithEdgeFields appends fields.
+func WithEdgeFields(fields ...FieldDefinition) EdgeOption {
+	return func(e *EdgeDefinition) { e.Fields = append(e.Fields, fields...) }
+}
+
+// WithEdgeIndexes appends indexes.
+func WithEdgeIndexes(indexes ...IndexDefinition) EdgeOption {
+	return func(e *EdgeDefinition) { e.Indexes = append(e.Indexes, indexes...) }
+}
+
+// WithEdgeEvents appends events.
+func WithEdgeEvents(events ...EventDefinition) EdgeOption {
+	return func(e *EdgeDefinition) { e.Events = append(e.Events, events...) }
+}
+
+// WithEdgePermissions sets permissions for the edge table.
+func WithEdgePermissions(perms map[string]string) EdgeOption {
+	return func(e *EdgeDefinition) {
+		if perms == nil {
+			e.Permissions = nil
+			return
+		}
+		copied := make(map[string]string, len(perms))
+		for k, v := range perms {
+			copied[k] = v
+		}
+		e.Permissions = copied
+	}
+}
+
+// NewEdge constructs an EdgeDefinition with EdgeModeRelation as default.
+func NewEdge(name string, opts ...EdgeOption) EdgeDefinition {
+	e := EdgeDefinition{Name: name, Mode: EdgeModeRelation}
+	for _, opt := range opts {
+		opt(&e)
+	}
+	return e
+}
+
+// BidirectionalEdge builds an edge whose from and to constraints reference the
+// same table (e.g. user->user follows).
+func BidirectionalEdge(name, table string, opts ...EdgeOption) EdgeDefinition {
+	merged := append([]EdgeOption{WithFromTable(table), WithToTable(table)}, opts...)
+	return NewEdge(name, merged...)
+}
+
+// TypedEdge builds an edge with specific from/to table constraints.
+func TypedEdge(name, fromTable, toTable string, opts ...EdgeOption) EdgeDefinition {
+	merged := append([]EdgeOption{WithFromTable(fromTable), WithToTable(toTable)}, opts...)
+	return NewEdge(name, merged...)
+}
+
+// Validate checks edge-level invariants plus each child definition.
+func (e EdgeDefinition) Validate() error {
+	if e.Name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "edge name cannot be empty")
+	}
+	if !e.Mode.IsValid() {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"invalid edge mode %q for edge %q", string(e.Mode), e.Name)
+	}
+	if e.Mode == EdgeModeRelation {
+		if e.FromTable == "" || e.ToTable == "" {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"edge %q with RELATION mode requires both from_table and to_table",
+				e.Name)
+		}
+	}
+	for _, f := range e.Fields {
+		if err := f.Validate(); err != nil {
+			return err
+		}
+	}
+	for _, i := range e.Indexes {
+		if err := i.Validate(); err != nil {
+			return err
+		}
+	}
+	for _, ev := range e.Events {
+		if err := ev.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ToSurql emits only the DEFINE TABLE line for this edge (no children).
+func (e EdgeDefinition) ToSurql() string {
+	return e.toSurqlTable(false)
+}
+
+// ToSurqlIfNotExists emits the DEFINE TABLE line with IF NOT EXISTS.
+func (e EdgeDefinition) ToSurqlIfNotExists() string {
+	return e.toSurqlTable(true)
+}
+
+func (e EdgeDefinition) toSurqlTable(ifNotExists bool) string {
+	var b strings.Builder
+	b.WriteString("DEFINE TABLE")
+	if ifNotExists {
+		b.WriteString(" IF NOT EXISTS")
+	}
+	b.WriteString(" ")
+	b.WriteString(e.Name)
+
+	switch e.Mode {
+	case EdgeModeRelation:
+		b.WriteString(" TYPE RELATION")
+		if e.FromTable != "" {
+			b.WriteString(" FROM ")
+			b.WriteString(e.FromTable)
+		}
+		if e.ToTable != "" {
+			b.WriteString(" TO ")
+			b.WriteString(e.ToTable)
+		}
+	case EdgeModeSchemafull:
+		b.WriteString(" SCHEMAFULL")
+	case EdgeModeSchemaless:
+		b.WriteString(" SCHEMALESS")
+	}
+
+	b.WriteString(";")
+	return b.String()
+}
+
+// ToSurqlStatements returns the DEFINE TABLE line followed by each DEFINE
+// FIELD / INDEX / EVENT / PERMISSIONS for this edge. It returns an error when
+// the edge violates structural invariants (e.g. RELATION mode without
+// from/to tables).
+func (e EdgeDefinition) ToSurqlStatements() ([]string, error) {
+	return e.toSurqlStatements(false)
+}
+
+// ToSurqlStatementsIfNotExists is like ToSurqlStatements with IF NOT EXISTS.
+func (e EdgeDefinition) ToSurqlStatementsIfNotExists() ([]string, error) {
+	return e.toSurqlStatements(true)
+}
+
+func (e EdgeDefinition) toSurqlStatements(ifNotExists bool) ([]string, error) {
+	if e.Mode == EdgeModeRelation && (e.FromTable == "" || e.ToTable == "") {
+		return nil, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"edge %q with RELATION mode requires both from_table and to_table",
+			e.Name)
+	}
+
+	stmts := make([]string, 0, 1+len(e.Fields)+len(e.Indexes)+len(e.Events))
+	stmts = append(stmts, e.toSurqlTable(ifNotExists))
+
+	for _, f := range e.Fields {
+		stmts = append(stmts, f.toSurql(e.Name, ifNotExists))
+	}
+	for _, i := range e.Indexes {
+		stmts = append(stmts, i.toSurql(e.Name, ifNotExists))
+	}
+	for _, ev := range e.Events {
+		stmts = append(stmts, ev.toSurql(e.Name, ifNotExists))
+	}
+
+	if len(e.Permissions) > 0 {
+		keys := make([]string, 0, len(e.Permissions))
+		for k := range e.Permissions {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			stmts = append(stmts,
+				"DEFINE FIELD PERMISSIONS FOR "+strings.ToUpper(k)+
+					" ON TABLE "+e.Name+" WHERE "+e.Permissions[k]+";")
+		}
+	}
+
+	return stmts, nil
+}

--- a/pkg/surql/schema/edge_test.go
+++ b/pkg/surql/schema/edge_test.go
@@ -1,0 +1,262 @@
+package schema
+
+import (
+	stdErrors "errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestEdgeMode_IsValid(t *testing.T) {
+	for _, m := range []EdgeMode{EdgeModeRelation, EdgeModeSchemafull, EdgeModeSchemaless} {
+		if !m.IsValid() {
+			t.Errorf("%q should be valid", string(m))
+		}
+	}
+	if EdgeMode("bogus").IsValid() {
+		t.Error("bogus edge mode")
+	}
+}
+
+func TestNewEdge_DefaultMode(t *testing.T) {
+	e := NewEdge("likes")
+	if e.Mode != EdgeModeRelation {
+		t.Errorf("default mode = %q", string(e.Mode))
+	}
+}
+
+func TestEdgeToSurql_Relation(t *testing.T) {
+	e := NewEdge("likes", WithFromTable("user"), WithToTable("post"))
+	got := e.ToSurql()
+	want := "DEFINE TABLE likes TYPE RELATION FROM user TO post;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestEdgeToSurql_Schemafull(t *testing.T) {
+	e := NewEdge("entity_rel", WithEdgeMode(EdgeModeSchemafull))
+	got := e.ToSurql()
+	want := "DEFINE TABLE entity_rel SCHEMAFULL;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestEdgeToSurql_Schemaless(t *testing.T) {
+	e := NewEdge("loose_rel", WithEdgeMode(EdgeModeSchemaless))
+	got := e.ToSurql()
+	want := "DEFINE TABLE loose_rel SCHEMALESS;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestEdgeToSurqlIfNotExists(t *testing.T) {
+	e := NewEdge("likes", WithFromTable("user"), WithToTable("post"))
+	got := e.ToSurqlIfNotExists()
+	want := "DEFINE TABLE IF NOT EXISTS likes TYPE RELATION FROM user TO post;"
+	if got != want {
+		t.Errorf("ToSurqlIfNotExists() = %q, want %q", got, want)
+	}
+}
+
+func TestEdgeStatements_MissingFromTable(t *testing.T) {
+	e := NewEdge("likes", WithToTable("post"))
+	_, err := e.ToSurqlStatements()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "requires both from_table and to_table") {
+		t.Errorf("err message = %q", err.Error())
+	}
+}
+
+func TestEdgeStatements_MissingToTable(t *testing.T) {
+	e := NewEdge("likes", WithFromTable("user"))
+	_, err := e.ToSurqlStatements()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestEdgeStatements_MissingBoth(t *testing.T) {
+	e := NewEdge("likes")
+	_, err := e.ToSurqlStatements()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestEdgeStatements_SchemafullNoTablesRequired(t *testing.T) {
+	e := NewEdge("entity_rel", WithEdgeMode(EdgeModeSchemafull))
+	stmts, err := e.ToSurqlStatements()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stmts) != 1 {
+		t.Errorf("len = %d, want 1", len(stmts))
+	}
+}
+
+func TestEdgeStatements_WithFields(t *testing.T) {
+	e := NewEdge("likes",
+		WithFromTable("user"),
+		WithToTable("post"),
+		WithEdgeFields(DatetimeField("created_at", WithDefault("time::now()"))),
+	)
+	stmts, err := e.ToSurqlStatements()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "DEFINE FIELD created_at ON TABLE likes TYPE datetime") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected field stmt: %v", stmts)
+	}
+}
+
+func TestEdgeStatements_StartsWithDefineTable(t *testing.T) {
+	e := NewEdge("follows", WithFromTable("user"), WithToTable("user"))
+	stmts, err := e.ToSurqlStatements()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.HasPrefix(stmts[0], "DEFINE TABLE") {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+}
+
+func TestEdgeStatements_IfNotExists(t *testing.T) {
+	e := NewEdge("likes",
+		WithFromTable("user"),
+		WithToTable("post"),
+		WithEdgeFields(DatetimeField("created_at", WithDefault("time::now()"))),
+	)
+	stmts, err := e.ToSurqlStatementsIfNotExists()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if stmts[0] != "DEFINE TABLE IF NOT EXISTS likes TYPE RELATION FROM user TO post;" {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "DEFINE FIELD IF NOT EXISTS created_at ON TABLE likes") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected IF NOT EXISTS field stmt: %v", stmts)
+	}
+}
+
+func TestEdgeStatements_SchemafullIfNotExists(t *testing.T) {
+	e := NewEdge("entity_rel", WithEdgeMode(EdgeModeSchemafull))
+	stmts, err := e.ToSurqlStatementsIfNotExists()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if stmts[0] != "DEFINE TABLE IF NOT EXISTS entity_rel SCHEMAFULL;" {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+}
+
+func TestEdgeStatements_SchemalessIfNotExists(t *testing.T) {
+	e := NewEdge("loose_rel", WithEdgeMode(EdgeModeSchemaless))
+	stmts, err := e.ToSurqlStatementsIfNotExists()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if stmts[0] != "DEFINE TABLE IF NOT EXISTS loose_rel SCHEMALESS;" {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+}
+
+func TestBidirectionalEdge(t *testing.T) {
+	e := BidirectionalEdge("follows", "user")
+	if e.FromTable != "user" || e.ToTable != "user" {
+		t.Errorf("from=%q to=%q", e.FromTable, e.ToTable)
+	}
+	if e.Mode != EdgeModeRelation {
+		t.Errorf("mode = %q", string(e.Mode))
+	}
+}
+
+func TestTypedEdge(t *testing.T) {
+	e := TypedEdge("authored", "user", "post")
+	if e.FromTable != "user" || e.ToTable != "post" {
+		t.Errorf("from=%q to=%q", e.FromTable, e.ToTable)
+	}
+}
+
+func TestEdgeValidate_EmptyName(t *testing.T) {
+	e := EdgeDefinition{Mode: EdgeModeSchemafull}
+	if err := e.Validate(); err == nil {
+		t.Error("empty name should fail")
+	}
+}
+
+func TestEdgeValidate_InvalidMode(t *testing.T) {
+	e := EdgeDefinition{Name: "x", Mode: EdgeMode("bogus")}
+	if err := e.Validate(); err == nil {
+		t.Error("bogus mode should fail")
+	}
+}
+
+func TestEdgeValidate_RelationRequiresTables(t *testing.T) {
+	e := NewEdge("likes")
+	if err := e.Validate(); err == nil {
+		t.Error("RELATION without tables should fail validation")
+	}
+}
+
+func TestEdgeValidate_PropagatesField(t *testing.T) {
+	e := NewEdge("likes",
+		WithFromTable("user"), WithToTable("post"),
+		WithEdgeFields(NewField("1bad", FieldTypeString)),
+	)
+	if err := e.Validate(); err == nil {
+		t.Error("expected error from invalid field")
+	}
+}
+
+func TestEdgePermissions_MapCopyIsolation(t *testing.T) {
+	perms := map[string]string{"create": "$auth.id = in"}
+	e := NewEdge("likes",
+		WithFromTable("u"), WithToTable("p"),
+		WithEdgePermissions(perms),
+	)
+	perms["create"] = "MUTATED"
+	if e.Permissions["create"] != "$auth.id = in" {
+		t.Errorf("expected copied map; got %q", e.Permissions["create"])
+	}
+}
+
+func TestEdgeStatements_WithPermissions(t *testing.T) {
+	e := NewEdge("follows",
+		WithFromTable("user"), WithToTable("user"),
+		WithEdgePermissions(map[string]string{"create": "$auth.id = in"}),
+	)
+	stmts, err := e.ToSurqlStatements()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "FOR CREATE") && strings.Contains(s, "$auth.id = in") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected permissions stmt: %v", stmts)
+	}
+}

--- a/pkg/surql/schema/fields.go
+++ b/pkg/surql/schema/fields.go
@@ -1,0 +1,269 @@
+package schema
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/types"
+)
+
+// FieldType enumerates the SurrealDB field types supported in DEFINE FIELD.
+type FieldType string
+
+// FieldType values mirrored from surql-py FieldType enum.
+const (
+	FieldTypeString   FieldType = "string"
+	FieldTypeInt      FieldType = "int"
+	FieldTypeFloat    FieldType = "float"
+	FieldTypeBool     FieldType = "bool"
+	FieldTypeDatetime FieldType = "datetime"
+	FieldTypeDuration FieldType = "duration"
+	FieldTypeDecimal  FieldType = "decimal"
+	FieldTypeNumber   FieldType = "number"
+	FieldTypeObject   FieldType = "object"
+	FieldTypeArray    FieldType = "array"
+	FieldTypeRecord   FieldType = "record"
+	FieldTypeGeometry FieldType = "geometry"
+	FieldTypeAny      FieldType = "any"
+)
+
+// IsValid reports whether the receiver is one of the defined FieldType constants.
+func (f FieldType) IsValid() bool {
+	switch f {
+	case FieldTypeString, FieldTypeInt, FieldTypeFloat, FieldTypeBool,
+		FieldTypeDatetime, FieldTypeDuration, FieldTypeDecimal, FieldTypeNumber,
+		FieldTypeObject, FieldTypeArray, FieldTypeRecord, FieldTypeGeometry,
+		FieldTypeAny:
+		return true
+	}
+	return false
+}
+
+// String returns the SurrealQL-ready string form of the type.
+func (f FieldType) String() string { return string(f) }
+
+var fieldNamePartRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// FieldDefinition is an immutable description of a single column in a DEFINE
+// FIELD statement.
+type FieldDefinition struct {
+	Name        string
+	Type        FieldType
+	Assertion   string
+	Default     string
+	Value       string // computed fields
+	Permissions map[string]string
+	ReadOnly    bool
+	Flexible    bool
+}
+
+// FieldOption customises a FieldDefinition created via NewField.
+type FieldOption func(*FieldDefinition)
+
+// WithAssertion attaches a SurrealQL ASSERT clause.
+func WithAssertion(expr string) FieldOption {
+	return func(f *FieldDefinition) { f.Assertion = expr }
+}
+
+// WithDefault attaches a DEFAULT expression.
+func WithDefault(expr string) FieldOption {
+	return func(f *FieldDefinition) { f.Default = expr }
+}
+
+// WithValue attaches a VALUE expression (computed field).
+func WithValue(expr string) FieldOption {
+	return func(f *FieldDefinition) { f.Value = expr }
+}
+
+// WithFieldPermissions attaches a PERMISSIONS map keyed by action.
+func WithFieldPermissions(perms map[string]string) FieldOption {
+	return func(f *FieldDefinition) {
+		if perms == nil {
+			f.Permissions = nil
+			return
+		}
+		copied := make(map[string]string, len(perms))
+		for k, v := range perms {
+			copied[k] = v
+		}
+		f.Permissions = copied
+	}
+}
+
+// WithReadOnly marks the field READONLY.
+func WithReadOnly(readonly bool) FieldOption {
+	return func(f *FieldDefinition) { f.ReadOnly = readonly }
+}
+
+// WithFlexible marks the field FLEXIBLE (used for object fields).
+func WithFlexible(flex bool) FieldOption {
+	return func(f *FieldDefinition) { f.Flexible = flex }
+}
+
+// NewField constructs a FieldDefinition. It does not fail; use Validate to
+// surface name/type problems before emitting SurrealQL.
+func NewField(name string, ft FieldType, opts ...FieldOption) FieldDefinition {
+	fd := FieldDefinition{Name: name, Type: ft}
+	for _, opt := range opts {
+		opt(&fd)
+	}
+	return fd
+}
+
+// Validate checks the field name (alphanumeric / underscore, dot-notation
+// allowed) and that the field type is recognised.
+func (f FieldDefinition) Validate() error {
+	if err := validateFieldName(f.Name); err != nil {
+		return err
+	}
+	if !f.Type.IsValid() {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"invalid field type %q for field %q", string(f.Type), f.Name)
+	}
+	return nil
+}
+
+// ReservedWarning returns a human-readable warning when the field name
+// collides with a SurrealDB reserved word, or an empty string.
+//
+// allowEdgeFields should be true when the field belongs to an edge table
+// (permitting "in" and "out" identifiers).
+func (f FieldDefinition) ReservedWarning(allowEdgeFields bool) string {
+	return types.CheckReservedWord(f.Name, allowEdgeFields)
+}
+
+// ToSurql renders the standalone DEFINE FIELD statement for this field on
+// the given table. It does not validate; call Validate separately.
+func (f FieldDefinition) ToSurql(tableName string) string {
+	return f.toSurql(tableName, false)
+}
+
+// ToSurqlIfNotExists renders the DEFINE FIELD statement with IF NOT EXISTS.
+func (f FieldDefinition) ToSurqlIfNotExists(tableName string) string {
+	return f.toSurql(tableName, true)
+}
+
+func (f FieldDefinition) toSurql(tableName string, ifNotExists bool) string {
+	var b strings.Builder
+	b.WriteString("DEFINE FIELD")
+	if ifNotExists {
+		b.WriteString(" IF NOT EXISTS")
+	}
+	b.WriteString(" ")
+	b.WriteString(f.Name)
+	b.WriteString(" ON TABLE ")
+	b.WriteString(tableName)
+	b.WriteString(" TYPE ")
+	b.WriteString(string(f.Type))
+
+	if f.Assertion != "" {
+		b.WriteString(" ASSERT ")
+		b.WriteString(f.Assertion)
+	}
+	if f.Default != "" {
+		b.WriteString(" DEFAULT ")
+		b.WriteString(f.Default)
+	}
+	if f.Value != "" {
+		b.WriteString(" VALUE ")
+		b.WriteString(f.Value)
+	}
+	if f.ReadOnly {
+		b.WriteString(" READONLY")
+	}
+	if f.Flexible {
+		b.WriteString(" FLEXIBLE")
+	}
+	b.WriteString(";")
+	return b.String()
+}
+
+// validateFieldName mirrors the Python _validate_field_name helper, supporting
+// dot-notation for nested fields.
+func validateFieldName(name string) error {
+	if name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "field name cannot be empty")
+	}
+	for _, part := range strings.Split(name, ".") {
+		if part == "" {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"invalid field name %q: empty segment", name)
+		}
+		if !fieldNamePartRe.MatchString(part) {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"invalid field name %q: segment %q must contain only alphanumeric characters and underscores, and cannot start with a digit",
+				name, part)
+		}
+	}
+	return nil
+}
+
+// Convenience constructors that mirror surql-py helper functions.
+
+// StringField builds a string-typed FieldDefinition.
+func StringField(name string, opts ...FieldOption) FieldDefinition {
+	return NewField(name, FieldTypeString, opts...)
+}
+
+// IntField builds an int-typed FieldDefinition.
+func IntField(name string, opts ...FieldOption) FieldDefinition {
+	return NewField(name, FieldTypeInt, opts...)
+}
+
+// FloatField builds a float-typed FieldDefinition.
+func FloatField(name string, opts ...FieldOption) FieldDefinition {
+	return NewField(name, FieldTypeFloat, opts...)
+}
+
+// BoolField builds a bool-typed FieldDefinition.
+func BoolField(name string, opts ...FieldOption) FieldDefinition {
+	return NewField(name, FieldTypeBool, opts...)
+}
+
+// DatetimeField builds a datetime-typed FieldDefinition.
+func DatetimeField(name string, opts ...FieldOption) FieldDefinition {
+	return NewField(name, FieldTypeDatetime, opts...)
+}
+
+// RecordField builds a record-typed FieldDefinition. When targetTable is
+// non-empty, an assertion constraining $value.table is pre-populated and any
+// user-provided assertion is combined with it.
+func RecordField(name, targetTable string, opts ...FieldOption) FieldDefinition {
+	fd := NewField(name, FieldTypeRecord, opts...)
+	if targetTable == "" {
+		return fd
+	}
+	tableAssert := fmt.Sprintf("$value.table = %q", targetTable)
+	if fd.Assertion == "" {
+		fd.Assertion = tableAssert
+	} else {
+		fd.Assertion = "(" + tableAssert + ") AND (" + fd.Assertion + ")"
+	}
+	return fd
+}
+
+// ArrayField builds an array-typed FieldDefinition.
+func ArrayField(name string, opts ...FieldOption) FieldDefinition {
+	return NewField(name, FieldTypeArray, opts...)
+}
+
+// ObjectField builds an object-typed FieldDefinition, defaulting the
+// FLEXIBLE flag to true (matching the Python helper). Pass WithFlexible(false)
+// to opt out.
+func ObjectField(name string, opts ...FieldOption) FieldDefinition {
+	fd := FieldDefinition{Name: name, Type: FieldTypeObject, Flexible: true}
+	for _, opt := range opts {
+		opt(&fd)
+	}
+	return fd
+}
+
+// ComputedField builds a computed field (VALUE expression, READONLY).
+func ComputedField(name, valueExpr string, ft FieldType, opts ...FieldOption) FieldDefinition {
+	fd := NewField(name, ft, opts...)
+	fd.Value = valueExpr
+	fd.ReadOnly = true
+	return fd
+}

--- a/pkg/surql/schema/fields_test.go
+++ b/pkg/surql/schema/fields_test.go
@@ -1,0 +1,319 @@
+package schema
+
+import (
+	stdErrors "errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestFieldType_IsValid(t *testing.T) {
+	cases := []struct {
+		in   FieldType
+		want bool
+	}{
+		{FieldTypeString, true},
+		{FieldTypeInt, true},
+		{FieldTypeFloat, true},
+		{FieldTypeBool, true},
+		{FieldTypeDatetime, true},
+		{FieldTypeDuration, true},
+		{FieldTypeDecimal, true},
+		{FieldTypeNumber, true},
+		{FieldTypeObject, true},
+		{FieldTypeArray, true},
+		{FieldTypeRecord, true},
+		{FieldTypeGeometry, true},
+		{FieldTypeAny, true},
+		{FieldType("bogus"), false},
+		{FieldType(""), false},
+	}
+	for _, tc := range cases {
+		if got := tc.in.IsValid(); got != tc.want {
+			t.Errorf("FieldType(%q).IsValid() = %v, want %v", string(tc.in), got, tc.want)
+		}
+	}
+}
+
+func TestFieldType_StringValues(t *testing.T) {
+	pairs := map[FieldType]string{
+		FieldTypeString:   "string",
+		FieldTypeInt:      "int",
+		FieldTypeFloat:    "float",
+		FieldTypeBool:     "bool",
+		FieldTypeDatetime: "datetime",
+		FieldTypeDuration: "duration",
+		FieldTypeDecimal:  "decimal",
+		FieldTypeNumber:   "number",
+		FieldTypeObject:   "object",
+		FieldTypeArray:    "array",
+		FieldTypeRecord:   "record",
+		FieldTypeGeometry: "geometry",
+		FieldTypeAny:      "any",
+	}
+	for ft, want := range pairs {
+		if ft.String() != want {
+			t.Errorf("FieldType(%q).String() = %q, want %q", string(ft), ft.String(), want)
+		}
+	}
+}
+
+func TestNewField_Minimal(t *testing.T) {
+	f := NewField("name", FieldTypeString)
+	if f.Name != "name" || f.Type != FieldTypeString {
+		t.Fatalf("unexpected field: %+v", f)
+	}
+	if f.Assertion != "" || f.Default != "" || f.Value != "" || f.ReadOnly || f.Flexible {
+		t.Fatalf("unexpected non-zero defaults: %+v", f)
+	}
+}
+
+func TestNewField_WithAllOptions(t *testing.T) {
+	f := NewField("age", FieldTypeInt,
+		WithAssertion("$value >= 0"),
+		WithDefault("0"),
+		WithReadOnly(true),
+		WithFieldPermissions(map[string]string{"select": "$auth.id = id"}),
+	)
+	if f.Assertion != "$value >= 0" {
+		t.Errorf("assertion = %q", f.Assertion)
+	}
+	if f.Default != "0" {
+		t.Errorf("default = %q", f.Default)
+	}
+	if !f.ReadOnly {
+		t.Errorf("readonly = false")
+	}
+	if v := f.Permissions["select"]; v != "$auth.id = id" {
+		t.Errorf("permissions[select] = %q", v)
+	}
+}
+
+func TestFieldToSurql_Basic(t *testing.T) {
+	f := StringField("name")
+	got := f.ToSurql("user")
+	want := "DEFINE FIELD name ON TABLE user TYPE string;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestFieldToSurql_WithAssertion(t *testing.T) {
+	f := StringField("email", WithAssertion("string::is::email($value)"))
+	got := f.ToSurql("user")
+	want := "DEFINE FIELD email ON TABLE user TYPE string ASSERT string::is::email($value);"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestFieldToSurql_WithDefault(t *testing.T) {
+	f := DatetimeField("created_at", WithDefault("time::now()"))
+	got := f.ToSurql("event")
+	want := "DEFINE FIELD created_at ON TABLE event TYPE datetime DEFAULT time::now();"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestFieldToSurql_WithValue(t *testing.T) {
+	f := ComputedField("full_name", "string::concat(first, ' ', last)", FieldTypeString)
+	got := f.ToSurql("user")
+	if !strings.Contains(got, "VALUE string::concat(first, ' ', last)") {
+		t.Errorf("ToSurql() missing VALUE clause: %q", got)
+	}
+	if !strings.Contains(got, "READONLY") {
+		t.Errorf("computed field should include READONLY: %q", got)
+	}
+}
+
+func TestFieldToSurql_Readonly(t *testing.T) {
+	f := DatetimeField("created_at", WithDefault("time::now()"), WithReadOnly(true))
+	got := f.ToSurql("event")
+	want := "DEFINE FIELD created_at ON TABLE event TYPE datetime DEFAULT time::now() READONLY;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestFieldToSurql_ObjectFlexible(t *testing.T) {
+	f := ObjectField("metadata")
+	if !f.Flexible {
+		t.Fatalf("ObjectField should default flexible=true")
+	}
+	got := f.ToSurql("user")
+	if !strings.Contains(got, "FLEXIBLE") {
+		t.Errorf("ObjectField ToSurql should include FLEXIBLE: %q", got)
+	}
+	if !strings.Contains(got, "TYPE object") {
+		t.Errorf("ObjectField ToSurql should include TYPE object: %q", got)
+	}
+}
+
+func TestFieldToSurql_ObjectFlexibleOptOut(t *testing.T) {
+	f := ObjectField("metadata", WithFlexible(false))
+	if f.Flexible {
+		t.Fatalf("ObjectField(WithFlexible(false)) should disable flexible")
+	}
+	got := f.ToSurql("user")
+	if strings.Contains(got, "FLEXIBLE") {
+		t.Errorf("ToSurql should not include FLEXIBLE: %q", got)
+	}
+}
+
+func TestFieldToSurql_AllClauses(t *testing.T) {
+	f := NewField("status", FieldTypeString,
+		WithAssertion("$value IN ['a','b']"),
+		WithDefault("'a'"),
+		WithReadOnly(true),
+		WithFlexible(true),
+	)
+	got := f.ToSurql("t")
+	want := "DEFINE FIELD status ON TABLE t TYPE string ASSERT $value IN ['a','b'] DEFAULT 'a' READONLY FLEXIBLE;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestFieldToSurqlIfNotExists(t *testing.T) {
+	f := StringField("name")
+	got := f.ToSurqlIfNotExists("user")
+	want := "DEFINE FIELD IF NOT EXISTS name ON TABLE user TYPE string;"
+	if got != want {
+		t.Errorf("ToSurqlIfNotExists() = %q, want %q", got, want)
+	}
+}
+
+func TestFieldValidate_EmptyName(t *testing.T) {
+	f := NewField("", FieldTypeString)
+	err := f.Validate()
+	if err == nil {
+		t.Fatal("Validate() returned nil for empty name")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("err = %v, want ErrValidation chain", err)
+	}
+}
+
+func TestFieldValidate_InvalidType(t *testing.T) {
+	f := NewField("x", FieldType("bogus"))
+	err := f.Validate()
+	if err == nil {
+		t.Fatal("Validate() returned nil for invalid type")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("err = %v, want ErrValidation chain", err)
+	}
+}
+
+func TestFieldValidate_SimpleNameValid(t *testing.T) {
+	for _, name := range []string{"name", "_field", "n1", "foo_bar"} {
+		f := NewField(name, FieldTypeString)
+		if err := f.Validate(); err != nil {
+			t.Errorf("Validate(%q) = %v, want nil", name, err)
+		}
+	}
+}
+
+func TestFieldValidate_DotNotationValid(t *testing.T) {
+	for _, name := range []string{"address.city", "a.b.c", "user_1.email"} {
+		f := NewField(name, FieldTypeString)
+		if err := f.Validate(); err != nil {
+			t.Errorf("Validate(%q) = %v, want nil", name, err)
+		}
+	}
+}
+
+func TestFieldValidate_InvalidNames(t *testing.T) {
+	cases := []string{
+		"1digit",
+		"name-hyphen",
+		"name space",
+		".leading",
+		"trailing.",
+		"empty..segment",
+		"1digit.b",
+	}
+	for _, name := range cases {
+		f := NewField(name, FieldTypeString)
+		err := f.Validate()
+		if err == nil {
+			t.Errorf("Validate(%q) = nil, want error", name)
+			continue
+		}
+		if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+			t.Errorf("Validate(%q) err = %v, want ErrValidation chain", name, err)
+		}
+	}
+}
+
+func TestRecordField_WithTargetTable(t *testing.T) {
+	f := RecordField("author", "user")
+	if f.Type != FieldTypeRecord {
+		t.Fatalf("type = %q", string(f.Type))
+	}
+	if f.Assertion != `$value.table = "user"` {
+		t.Errorf("assertion = %q", f.Assertion)
+	}
+}
+
+func TestRecordField_WithCustomAssertion(t *testing.T) {
+	f := RecordField("author", "user", WithAssertion("$value.active = true"))
+	if !strings.Contains(f.Assertion, `$value.table = "user"`) {
+		t.Errorf("assertion missing table clause: %q", f.Assertion)
+	}
+	if !strings.Contains(f.Assertion, "$value.active = true") {
+		t.Errorf("assertion missing custom clause: %q", f.Assertion)
+	}
+}
+
+func TestRecordField_WithoutTable(t *testing.T) {
+	f := RecordField("author", "")
+	if f.Assertion != "" {
+		t.Errorf("assertion = %q, want empty", f.Assertion)
+	}
+}
+
+func TestReservedWarning(t *testing.T) {
+	f := StringField("in")
+	if f.ReservedWarning(false) == "" {
+		t.Errorf("expected warning for reserved word 'in'")
+	}
+	if f.ReservedWarning(true) != "" {
+		t.Errorf("expected no warning for 'in' with allowEdgeFields=true")
+	}
+}
+
+func TestConvenienceBuilders(t *testing.T) {
+	if StringField("a").Type != FieldTypeString {
+		t.Error("StringField type mismatch")
+	}
+	if IntField("a").Type != FieldTypeInt {
+		t.Error("IntField type mismatch")
+	}
+	if FloatField("a").Type != FieldTypeFloat {
+		t.Error("FloatField type mismatch")
+	}
+	if BoolField("a").Type != FieldTypeBool {
+		t.Error("BoolField type mismatch")
+	}
+	if DatetimeField("a").Type != FieldTypeDatetime {
+		t.Error("DatetimeField type mismatch")
+	}
+	if ArrayField("a").Type != FieldTypeArray {
+		t.Error("ArrayField type mismatch")
+	}
+	if ObjectField("a").Type != FieldTypeObject {
+		t.Error("ObjectField type mismatch")
+	}
+}
+
+func TestFieldPermissions_MapCopyIsolation(t *testing.T) {
+	perms := map[string]string{"select": "$auth.id = id"}
+	f := NewField("x", FieldTypeString, WithFieldPermissions(perms))
+	perms["select"] = "MUTATED"
+	if f.Permissions["select"] != "$auth.id = id" {
+		t.Errorf("permissions should be copied; got %q", f.Permissions["select"])
+	}
+}

--- a/pkg/surql/schema/table.go
+++ b/pkg/surql/schema/table.go
@@ -1,0 +1,556 @@
+package schema
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// TableMode enumerates the table schema modes.
+type TableMode string
+
+// TableMode values.
+const (
+	TableModeSchemafull TableMode = "SCHEMAFULL"
+	TableModeSchemaless TableMode = "SCHEMALESS"
+	TableModeDrop       TableMode = "DROP"
+)
+
+// IsValid reports whether the TableMode is recognised.
+func (m TableMode) IsValid() bool {
+	switch m {
+	case TableModeSchemafull, TableModeSchemaless, TableModeDrop:
+		return true
+	}
+	return false
+}
+
+// IndexType enumerates the supported DEFINE INDEX flavours.
+type IndexType string
+
+// IndexType values.
+const (
+	IndexTypeStandard IndexType = "INDEX"
+	IndexTypeUnique   IndexType = "UNIQUE"
+	IndexTypeSearch   IndexType = "SEARCH"
+	IndexTypeMTree    IndexType = "MTREE"
+	IndexTypeHNSW     IndexType = "HNSW"
+)
+
+// IsValid reports whether the IndexType is recognised.
+func (t IndexType) IsValid() bool {
+	switch t {
+	case IndexTypeStandard, IndexTypeUnique, IndexTypeSearch, IndexTypeMTree, IndexTypeHNSW:
+		return true
+	}
+	return false
+}
+
+// MTreeDistanceType enumerates distance metrics for MTREE indexes.
+type MTreeDistanceType string
+
+// MTreeDistanceType values.
+const (
+	MTreeDistanceCosine    MTreeDistanceType = "COSINE"
+	MTreeDistanceEuclidean MTreeDistanceType = "EUCLIDEAN"
+	MTreeDistanceManhattan MTreeDistanceType = "MANHATTAN"
+	MTreeDistanceMinkowski MTreeDistanceType = "MINKOWSKI"
+)
+
+// IsValid reports whether the MTreeDistanceType is recognised.
+func (d MTreeDistanceType) IsValid() bool {
+	switch d {
+	case MTreeDistanceCosine, MTreeDistanceEuclidean, MTreeDistanceManhattan, MTreeDistanceMinkowski:
+		return true
+	}
+	return false
+}
+
+// HnswDistanceType enumerates distance metrics for HNSW indexes (superset of
+// MTreeDistanceType).
+type HnswDistanceType string
+
+// HnswDistanceType values.
+const (
+	HnswDistanceChebyshev HnswDistanceType = "CHEBYSHEV"
+	HnswDistanceCosine    HnswDistanceType = "COSINE"
+	HnswDistanceEuclidean HnswDistanceType = "EUCLIDEAN"
+	HnswDistanceHamming   HnswDistanceType = "HAMMING"
+	HnswDistanceJaccard   HnswDistanceType = "JACCARD"
+	HnswDistanceManhattan HnswDistanceType = "MANHATTAN"
+	HnswDistanceMinkowski HnswDistanceType = "MINKOWSKI"
+	HnswDistancePearson   HnswDistanceType = "PEARSON"
+)
+
+// IsValid reports whether the HnswDistanceType is recognised.
+func (d HnswDistanceType) IsValid() bool {
+	switch d {
+	case HnswDistanceChebyshev, HnswDistanceCosine, HnswDistanceEuclidean,
+		HnswDistanceHamming, HnswDistanceJaccard, HnswDistanceManhattan,
+		HnswDistanceMinkowski, HnswDistancePearson:
+		return true
+	}
+	return false
+}
+
+// MTreeVectorType enumerates the vector component numeric types supported by
+// both MTREE and HNSW indexes.
+type MTreeVectorType string
+
+// MTreeVectorType values.
+const (
+	MTreeVectorF64 MTreeVectorType = "F64"
+	MTreeVectorF32 MTreeVectorType = "F32"
+	MTreeVectorI64 MTreeVectorType = "I64"
+	MTreeVectorI32 MTreeVectorType = "I32"
+	MTreeVectorI16 MTreeVectorType = "I16"
+)
+
+// IsValid reports whether the MTreeVectorType is recognised.
+func (v MTreeVectorType) IsValid() bool {
+	switch v {
+	case MTreeVectorF64, MTreeVectorF32, MTreeVectorI64, MTreeVectorI32, MTreeVectorI16:
+		return true
+	}
+	return false
+}
+
+// IndexDefinition captures the fields required to emit a DEFINE INDEX statement.
+type IndexDefinition struct {
+	Name    string
+	Columns []string
+	Type    IndexType
+
+	// MTREE & HNSW shared
+	Dimension  int
+	VectorType MTreeVectorType
+
+	// MTREE-specific
+	Distance MTreeDistanceType
+
+	// HNSW-specific
+	HnswDistance HnswDistanceType
+	EFC          int // zero means unset
+	M            int // zero means unset
+}
+
+// EventDefinition captures a DEFINE EVENT trigger.
+type EventDefinition struct {
+	Name      string
+	Condition string
+	Action    string
+}
+
+// TableDefinition captures the fields required to emit a DEFINE TABLE
+// statement plus its attendant DEFINE FIELD / INDEX / EVENT children.
+type TableDefinition struct {
+	Name        string
+	Mode        TableMode
+	Fields      []FieldDefinition
+	Indexes     []IndexDefinition
+	Events      []EventDefinition
+	Permissions map[string]string
+	Drop        bool
+}
+
+// TableOption customises a TableDefinition created via NewTable.
+type TableOption func(*TableDefinition)
+
+// WithMode sets the schema mode (SCHEMAFULL / SCHEMALESS / DROP).
+func WithMode(mode TableMode) TableOption {
+	return func(t *TableDefinition) { t.Mode = mode }
+}
+
+// WithFields appends fields to the table definition.
+func WithFields(fields ...FieldDefinition) TableOption {
+	return func(t *TableDefinition) { t.Fields = append(t.Fields, fields...) }
+}
+
+// WithIndexes appends indexes to the table definition.
+func WithIndexes(indexes ...IndexDefinition) TableOption {
+	return func(t *TableDefinition) { t.Indexes = append(t.Indexes, indexes...) }
+}
+
+// WithEvents appends events to the table definition.
+func WithEvents(events ...EventDefinition) TableOption {
+	return func(t *TableDefinition) { t.Events = append(t.Events, events...) }
+}
+
+// WithTablePermissions sets permissions for the table.
+func WithTablePermissions(perms map[string]string) TableOption {
+	return func(t *TableDefinition) {
+		if perms == nil {
+			t.Permissions = nil
+			return
+		}
+		copied := make(map[string]string, len(perms))
+		for k, v := range perms {
+			copied[k] = v
+		}
+		t.Permissions = copied
+	}
+}
+
+// WithDrop marks the table for deletion.
+func WithDrop(drop bool) TableOption {
+	return func(t *TableDefinition) { t.Drop = drop }
+}
+
+// NewTable constructs a TableDefinition, defaulting to SCHEMAFULL mode.
+func NewTable(name string, opts ...TableOption) TableDefinition {
+	t := TableDefinition{Name: name, Mode: TableModeSchemafull}
+	for _, opt := range opts {
+		opt(&t)
+	}
+	return t
+}
+
+// Validate checks table-level invariants plus each child field, index, and event.
+func (t TableDefinition) Validate() error {
+	if t.Name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "table name cannot be empty")
+	}
+	if !t.Mode.IsValid() {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"invalid table mode %q for table %q", string(t.Mode), t.Name)
+	}
+	for _, f := range t.Fields {
+		if err := f.Validate(); err != nil {
+			return err
+		}
+	}
+	for _, i := range t.Indexes {
+		if err := i.Validate(); err != nil {
+			return err
+		}
+	}
+	for _, e := range t.Events {
+		if err := e.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ToSurql emits the DEFINE TABLE statement only (no fields, indexes, events).
+func (t TableDefinition) ToSurql() string {
+	return t.toSurqlTable(false)
+}
+
+// ToSurqlIfNotExists emits the DEFINE TABLE statement with IF NOT EXISTS.
+func (t TableDefinition) ToSurqlIfNotExists() string {
+	return t.toSurqlTable(true)
+}
+
+func (t TableDefinition) toSurqlTable(ifNotExists bool) string {
+	var b strings.Builder
+	b.WriteString("DEFINE TABLE")
+	if ifNotExists {
+		b.WriteString(" IF NOT EXISTS")
+	}
+	b.WriteString(" ")
+	b.WriteString(t.Name)
+	b.WriteString(" ")
+	b.WriteString(string(t.Mode))
+	b.WriteString(";")
+	return b.String()
+}
+
+// ToSurqlStatements returns the full list of DEFINE statements for the table:
+// the DEFINE TABLE line followed by each DEFINE FIELD / INDEX / EVENT, plus
+// any DEFINE FIELD PERMISSIONS rendered from the permission map.
+func (t TableDefinition) ToSurqlStatements() []string {
+	return t.toSurqlStatements(false)
+}
+
+// ToSurqlStatementsIfNotExists is like ToSurqlStatements but adds IF NOT
+// EXISTS to every DEFINE statement that supports it.
+func (t TableDefinition) ToSurqlStatementsIfNotExists() []string {
+	return t.toSurqlStatements(true)
+}
+
+func (t TableDefinition) toSurqlStatements(ifNotExists bool) []string {
+	stmts := make([]string, 0, 1+len(t.Fields)+len(t.Indexes)+len(t.Events))
+	stmts = append(stmts, t.toSurqlTable(ifNotExists))
+
+	for _, f := range t.Fields {
+		stmts = append(stmts, f.toSurql(t.Name, ifNotExists))
+	}
+	for _, i := range t.Indexes {
+		stmts = append(stmts, i.toSurql(t.Name, ifNotExists))
+	}
+	for _, e := range t.Events {
+		stmts = append(stmts, e.toSurql(t.Name, ifNotExists))
+	}
+
+	if len(t.Permissions) > 0 {
+		keys := make([]string, 0, len(t.Permissions))
+		for k := range t.Permissions {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			stmts = append(stmts,
+				"DEFINE FIELD PERMISSIONS FOR "+strings.ToUpper(k)+
+					" ON TABLE "+t.Name+" WHERE "+t.Permissions[k]+";")
+		}
+	}
+	return stmts
+}
+
+// NewIndex builds a standard IndexDefinition.
+func NewIndex(name string, columns []string, indexType IndexType) IndexDefinition {
+	cols := make([]string, len(columns))
+	copy(cols, columns)
+	return IndexDefinition{Name: name, Columns: cols, Type: indexType}
+}
+
+// UniqueIndex is sugar for NewIndex(name, columns, IndexTypeUnique).
+func UniqueIndex(name string, columns []string) IndexDefinition {
+	return NewIndex(name, columns, IndexTypeUnique)
+}
+
+// SearchIndex is sugar for NewIndex(name, columns, IndexTypeSearch).
+func SearchIndex(name string, columns []string) IndexDefinition {
+	return NewIndex(name, columns, IndexTypeSearch)
+}
+
+// MTreeIndexOptions configures an MTREE vector index.
+type MTreeIndexOptions struct {
+	Distance   MTreeDistanceType
+	VectorType MTreeVectorType
+}
+
+// MTreeIndex builds an MTREE IndexDefinition.
+func MTreeIndex(name, column string, dimension int, opts MTreeIndexOptions) IndexDefinition {
+	if opts.Distance == "" {
+		opts.Distance = MTreeDistanceEuclidean
+	}
+	if opts.VectorType == "" {
+		opts.VectorType = MTreeVectorF64
+	}
+	return IndexDefinition{
+		Name:       name,
+		Columns:    []string{column},
+		Type:       IndexTypeMTree,
+		Dimension:  dimension,
+		Distance:   opts.Distance,
+		VectorType: opts.VectorType,
+	}
+}
+
+// HnswIndexOptions configures an HNSW vector index. EFC and M are optional
+// (zero means "use SurrealDB default" and the EFC / M clauses are omitted).
+type HnswIndexOptions struct {
+	Distance   HnswDistanceType
+	VectorType MTreeVectorType
+	EFC        int
+	M          int
+}
+
+// HnswIndex builds an HNSW IndexDefinition.
+func HnswIndex(name, column string, dimension int, opts HnswIndexOptions) IndexDefinition {
+	if opts.Distance == "" {
+		opts.Distance = HnswDistanceEuclidean
+	}
+	if opts.VectorType == "" {
+		opts.VectorType = MTreeVectorF64
+	}
+	return IndexDefinition{
+		Name:         name,
+		Columns:      []string{column},
+		Type:         IndexTypeHNSW,
+		Dimension:    dimension,
+		VectorType:   opts.VectorType,
+		HnswDistance: opts.Distance,
+		EFC:          opts.EFC,
+		M:            opts.M,
+	}
+}
+
+// Validate verifies structural invariants of the index definition.
+func (i IndexDefinition) Validate() error {
+	if i.Name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "index name cannot be empty")
+	}
+	if !i.Type.IsValid() {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"invalid index type %q for index %q", string(i.Type), i.Name)
+	}
+	if len(i.Columns) == 0 {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"index %q requires at least one column", i.Name)
+	}
+	for _, col := range i.Columns {
+		if col == "" {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"index %q has an empty column name", i.Name)
+		}
+	}
+
+	switch i.Type {
+	case IndexTypeMTree:
+		if i.Dimension <= 0 {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"MTREE index %q requires a positive dimension", i.Name)
+		}
+		if i.Distance != "" && !i.Distance.IsValid() {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"MTREE index %q has invalid distance %q", i.Name, string(i.Distance))
+		}
+		if i.VectorType != "" && !i.VectorType.IsValid() {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"MTREE index %q has invalid vector type %q", i.Name, string(i.VectorType))
+		}
+	case IndexTypeHNSW:
+		if i.Dimension <= 0 {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"HNSW index %q requires a positive dimension", i.Name)
+		}
+		if i.HnswDistance != "" && !i.HnswDistance.IsValid() {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"HNSW index %q has invalid distance %q", i.Name, string(i.HnswDistance))
+		}
+		if i.VectorType != "" && !i.VectorType.IsValid() {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"HNSW index %q has invalid vector type %q", i.Name, string(i.VectorType))
+		}
+	}
+	return nil
+}
+
+// ToSurql emits the DEFINE INDEX statement for this index on tableName.
+func (i IndexDefinition) ToSurql(tableName string) string {
+	return i.toSurql(tableName, false)
+}
+
+// ToSurqlIfNotExists emits the DEFINE INDEX statement with IF NOT EXISTS.
+func (i IndexDefinition) ToSurqlIfNotExists(tableName string) string {
+	return i.toSurql(tableName, true)
+}
+
+func (i IndexDefinition) toSurql(tableName string, ifNotExists bool) string {
+	var b strings.Builder
+	b.WriteString("DEFINE INDEX")
+	if ifNotExists {
+		b.WriteString(" IF NOT EXISTS")
+	}
+	b.WriteString(" ")
+	b.WriteString(i.Name)
+	b.WriteString(" ON TABLE ")
+	b.WriteString(tableName)
+
+	switch i.Type {
+	case IndexTypeMTree:
+		field := ""
+		if len(i.Columns) > 0 {
+			field = i.Columns[0]
+		}
+		b.WriteString(" COLUMNS ")
+		b.WriteString(field)
+		b.WriteString(" MTREE DIMENSION ")
+		b.WriteString(strconv.Itoa(i.Dimension))
+		if i.Distance != "" {
+			b.WriteString(" DIST ")
+			b.WriteString(string(i.Distance))
+		}
+		if i.VectorType != "" {
+			b.WriteString(" TYPE ")
+			b.WriteString(string(i.VectorType))
+		}
+		b.WriteString(";")
+		return b.String()
+
+	case IndexTypeHNSW:
+		field := ""
+		if len(i.Columns) > 0 {
+			field = i.Columns[0]
+		}
+		b.WriteString(" COLUMNS ")
+		b.WriteString(field)
+		b.WriteString(" HNSW DIMENSION ")
+		b.WriteString(strconv.Itoa(i.Dimension))
+		if i.HnswDistance != "" {
+			b.WriteString(" DIST ")
+			b.WriteString(string(i.HnswDistance))
+		}
+		if i.VectorType != "" {
+			b.WriteString(" TYPE ")
+			b.WriteString(string(i.VectorType))
+		}
+		if i.EFC > 0 {
+			b.WriteString(" EFC ")
+			b.WriteString(strconv.Itoa(i.EFC))
+		}
+		if i.M > 0 {
+			b.WriteString(" M ")
+			b.WriteString(strconv.Itoa(i.M))
+		}
+		b.WriteString(";")
+		return b.String()
+	}
+
+	b.WriteString(" COLUMNS ")
+	b.WriteString(strings.Join(i.Columns, ", "))
+
+	switch i.Type {
+	case IndexTypeUnique:
+		b.WriteString(" UNIQUE")
+	case IndexTypeSearch:
+		b.WriteString(" SEARCH ANALYZER ascii")
+	}
+
+	b.WriteString(";")
+	return b.String()
+}
+
+// NewEvent builds an EventDefinition.
+func NewEvent(name, condition, action string) EventDefinition {
+	return EventDefinition{Name: name, Condition: condition, Action: action}
+}
+
+// Validate ensures the event has a non-empty name, condition, and action.
+func (e EventDefinition) Validate() error {
+	if e.Name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "event name cannot be empty")
+	}
+	if e.Condition == "" {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"event %q requires a non-empty condition", e.Name)
+	}
+	if e.Action == "" {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"event %q requires a non-empty action", e.Name)
+	}
+	return nil
+}
+
+// ToSurql emits the DEFINE EVENT statement for this event on tableName.
+func (e EventDefinition) ToSurql(tableName string) string {
+	return e.toSurql(tableName, false)
+}
+
+// ToSurqlIfNotExists emits the DEFINE EVENT statement with IF NOT EXISTS.
+func (e EventDefinition) ToSurqlIfNotExists(tableName string) string {
+	return e.toSurql(tableName, true)
+}
+
+func (e EventDefinition) toSurql(tableName string, ifNotExists bool) string {
+	var b strings.Builder
+	b.WriteString("DEFINE EVENT")
+	if ifNotExists {
+		b.WriteString(" IF NOT EXISTS")
+	}
+	b.WriteString(" ")
+	b.WriteString(e.Name)
+	b.WriteString(" ON TABLE ")
+	b.WriteString(tableName)
+	b.WriteString(" WHEN ")
+	b.WriteString(e.Condition)
+	b.WriteString(" THEN ")
+	b.WriteString(e.Action)
+	b.WriteString(";")
+	return b.String()
+}

--- a/pkg/surql/schema/table_test.go
+++ b/pkg/surql/schema/table_test.go
@@ -1,0 +1,487 @@
+package schema
+
+import (
+	stdErrors "errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestTableMode_IsValid(t *testing.T) {
+	for _, m := range []TableMode{TableModeSchemafull, TableModeSchemaless, TableModeDrop} {
+		if !m.IsValid() {
+			t.Errorf("%q should be valid", string(m))
+		}
+	}
+	if TableMode("bogus").IsValid() {
+		t.Error("bogus mode should not be valid")
+	}
+}
+
+func TestNewTable_DefaultMode(t *testing.T) {
+	t1 := NewTable("user")
+	if t1.Mode != TableModeSchemafull {
+		t.Errorf("default mode = %q, want SCHEMAFULL", string(t1.Mode))
+	}
+}
+
+func TestTableToSurql_Schemafull(t *testing.T) {
+	tbl := NewTable("user", WithMode(TableModeSchemafull))
+	got := tbl.ToSurql()
+	want := "DEFINE TABLE user SCHEMAFULL;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestTableToSurql_Schemaless(t *testing.T) {
+	tbl := NewTable("log", WithMode(TableModeSchemaless))
+	got := tbl.ToSurql()
+	want := "DEFINE TABLE log SCHEMALESS;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestTableToSurql_Drop(t *testing.T) {
+	tbl := NewTable("temp", WithMode(TableModeDrop))
+	got := tbl.ToSurql()
+	want := "DEFINE TABLE temp DROP;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestTableToSurqlIfNotExists(t *testing.T) {
+	tbl := NewTable("user", WithMode(TableModeSchemafull))
+	got := tbl.ToSurqlIfNotExists()
+	want := "DEFINE TABLE IF NOT EXISTS user SCHEMAFULL;"
+	if got != want {
+		t.Errorf("ToSurqlIfNotExists() = %q, want %q", got, want)
+	}
+}
+
+func TestTableStatements_Minimal(t *testing.T) {
+	tbl := NewTable("empty")
+	stmts := tbl.ToSurqlStatements()
+	if len(stmts) != 1 {
+		t.Fatalf("len(stmts) = %d, want 1", len(stmts))
+	}
+	if !strings.HasPrefix(stmts[0], "DEFINE TABLE") {
+		t.Errorf("first stmt = %q", stmts[0])
+	}
+}
+
+func TestTableStatements_WithFields(t *testing.T) {
+	tbl := NewTable("user",
+		WithFields(StringField("name"), IntField("age")),
+	)
+	stmts := tbl.ToSurqlStatements()
+	if len(stmts) != 3 {
+		t.Fatalf("len(stmts) = %d, want 3", len(stmts))
+	}
+	if !strings.HasPrefix(stmts[0], "DEFINE TABLE user") {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+	if stmts[1] != "DEFINE FIELD name ON TABLE user TYPE string;" {
+		t.Errorf("stmts[1] = %q", stmts[1])
+	}
+	if stmts[2] != "DEFINE FIELD age ON TABLE user TYPE int;" {
+		t.Errorf("stmts[2] = %q", stmts[2])
+	}
+}
+
+func TestTableStatements_WithAssertion(t *testing.T) {
+	tbl := NewTable("user",
+		WithFields(StringField("email", WithAssertion("string::is::email($value)"))),
+	)
+	stmts := tbl.ToSurqlStatements()
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "ASSERT string::is::email($value)") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected ASSERT clause in statements: %v", stmts)
+	}
+}
+
+func TestTableStatements_WithDefault(t *testing.T) {
+	tbl := NewTable("event",
+		WithFields(DatetimeField("created_at", WithDefault("time::now()"))),
+	)
+	stmts := tbl.ToSurqlStatements()
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "DEFAULT time::now()") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected DEFAULT clause: %v", stmts)
+	}
+}
+
+func TestTableStatements_WithReadonly(t *testing.T) {
+	tbl := NewTable("event",
+		WithFields(DatetimeField("created_at", WithReadOnly(true))),
+	)
+	stmts := tbl.ToSurqlStatements()
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "READONLY") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected READONLY clause: %v", stmts)
+	}
+}
+
+func TestTableStatements_WithUniqueIndex(t *testing.T) {
+	tbl := NewTable("user",
+		WithIndexes(UniqueIndex("email_idx", []string{"email"})),
+	)
+	stmts := tbl.ToSurqlStatements()
+	found := false
+	for _, s := range stmts {
+		if s == "DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE;" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected unique index statement: %v", stmts)
+	}
+}
+
+func TestTableStatements_WithStandardIndex(t *testing.T) {
+	tbl := NewTable("post",
+		WithIndexes(NewIndex("title_idx", []string{"title"}, IndexTypeStandard)),
+	)
+	stmts := tbl.ToSurqlStatements()
+	found := false
+	for _, s := range stmts {
+		if s == "DEFINE INDEX title_idx ON TABLE post COLUMNS title;" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected standard index statement: %v", stmts)
+	}
+}
+
+func TestTableStatements_WithSearchIndex(t *testing.T) {
+	tbl := NewTable("post",
+		WithIndexes(SearchIndex("content_search", []string{"title", "content"})),
+	)
+	stmts := tbl.ToSurqlStatements()
+	found := false
+	for _, s := range stmts {
+		if s == "DEFINE INDEX content_search ON TABLE post COLUMNS title, content SEARCH ANALYZER ascii;" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected search index statement: %v", stmts)
+	}
+}
+
+func TestTableStatements_WithEvent(t *testing.T) {
+	tbl := NewTable("user",
+		WithEvents(NewEvent(
+			"email_changed",
+			"$before.email != $after.email",
+			"CREATE audit_log SET user = $value.id",
+		)),
+	)
+	stmts := tbl.ToSurqlStatements()
+	want := "DEFINE EVENT email_changed ON TABLE user WHEN $before.email != $after.email THEN CREATE audit_log SET user = $value.id;"
+	found := false
+	for _, s := range stmts {
+		if s == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected event statement %q, got %v", want, stmts)
+	}
+}
+
+func TestTableStatements_WithPermissions(t *testing.T) {
+	tbl := NewTable("user",
+		WithTablePermissions(map[string]string{"select": "$auth.id = id"}),
+	)
+	stmts := tbl.ToSurqlStatements()
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "FOR SELECT") && strings.Contains(s, "$auth.id = id") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected permissions statement: %v", stmts)
+	}
+}
+
+func TestTableStatements_IfNotExists(t *testing.T) {
+	tbl := NewTable("user",
+		WithMode(TableModeSchemafull),
+		WithFields(StringField("name")),
+		WithIndexes(UniqueIndex("email_idx", []string{"email"})),
+		WithEvents(NewEvent("e", "$cond", "DO")),
+	)
+	stmts := tbl.ToSurqlStatementsIfNotExists()
+	if stmts[0] != "DEFINE TABLE IF NOT EXISTS user SCHEMAFULL;" {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+	found := 0
+	for _, s := range stmts {
+		if strings.Contains(s, "DEFINE FIELD IF NOT EXISTS name") {
+			found++
+		}
+		if strings.Contains(s, "DEFINE INDEX IF NOT EXISTS email_idx") {
+			found++
+		}
+		if strings.Contains(s, "DEFINE EVENT IF NOT EXISTS e") {
+			found++
+		}
+	}
+	if found != 3 {
+		t.Errorf("expected 3 IF NOT EXISTS matches, got %d: %v", found, stmts)
+	}
+}
+
+func TestTableStatements_DefaultOmitsIfNotExists(t *testing.T) {
+	tbl := NewTable("user",
+		WithFields(StringField("name")),
+		WithIndexes(UniqueIndex("email_idx", []string{"email"})),
+		WithEvents(NewEvent("e", "$cond", "DO")),
+	)
+	stmts := tbl.ToSurqlStatements()
+	for _, s := range stmts {
+		if strings.Contains(s, "IF NOT EXISTS") {
+			t.Errorf("unexpected IF NOT EXISTS in %q", s)
+		}
+	}
+}
+
+func TestIndexType_IsValid(t *testing.T) {
+	for _, ty := range []IndexType{
+		IndexTypeStandard, IndexTypeUnique, IndexTypeSearch,
+		IndexTypeMTree, IndexTypeHNSW,
+	} {
+		if !ty.IsValid() {
+			t.Errorf("%q should be valid", string(ty))
+		}
+	}
+	if IndexType("X").IsValid() {
+		t.Error("bogus IndexType")
+	}
+}
+
+func TestMTreeDistance_Values(t *testing.T) {
+	for _, v := range []MTreeDistanceType{
+		MTreeDistanceCosine, MTreeDistanceEuclidean,
+		MTreeDistanceManhattan, MTreeDistanceMinkowski,
+	} {
+		if !v.IsValid() {
+			t.Errorf("MTree distance %q should be valid", string(v))
+		}
+	}
+	if MTreeDistanceType("X").IsValid() {
+		t.Error("bogus MTree distance")
+	}
+}
+
+func TestHnswDistance_Values(t *testing.T) {
+	for _, v := range []HnswDistanceType{
+		HnswDistanceChebyshev, HnswDistanceCosine, HnswDistanceEuclidean,
+		HnswDistanceHamming, HnswDistanceJaccard, HnswDistanceManhattan,
+		HnswDistanceMinkowski, HnswDistancePearson,
+	} {
+		if !v.IsValid() {
+			t.Errorf("Hnsw distance %q should be valid", string(v))
+		}
+	}
+}
+
+func TestVectorType_Values(t *testing.T) {
+	for _, v := range []MTreeVectorType{
+		MTreeVectorF64, MTreeVectorF32, MTreeVectorI64, MTreeVectorI32, MTreeVectorI16,
+	} {
+		if !v.IsValid() {
+			t.Errorf("vector type %q should be valid", string(v))
+		}
+	}
+}
+
+func TestMTreeIndex_ToSurql(t *testing.T) {
+	idx := MTreeIndex("embedding_idx", "embedding", 1536, MTreeIndexOptions{
+		Distance:   MTreeDistanceCosine,
+		VectorType: MTreeVectorF32,
+	})
+	got := idx.ToSurql("doc")
+	want := "DEFINE INDEX embedding_idx ON TABLE doc COLUMNS embedding MTREE DIMENSION 1536 DIST COSINE TYPE F32;"
+	if got != want {
+		t.Errorf("ToSurql = %q, want %q", got, want)
+	}
+}
+
+func TestMTreeIndex_Defaults(t *testing.T) {
+	idx := MTreeIndex("e", "v", 8, MTreeIndexOptions{})
+	got := idx.ToSurql("t")
+	if !strings.Contains(got, "DIST EUCLIDEAN") {
+		t.Errorf("default distance missing: %q", got)
+	}
+	if !strings.Contains(got, "TYPE F64") {
+		t.Errorf("default vector type missing: %q", got)
+	}
+}
+
+func TestHnswIndex_ToSurql(t *testing.T) {
+	idx := HnswIndex("embedding_idx", "embedding", 1536, HnswIndexOptions{
+		Distance:   HnswDistanceCosine,
+		VectorType: MTreeVectorF32,
+		EFC:        150,
+		M:          12,
+	})
+	got := idx.ToSurql("doc")
+	want := "DEFINE INDEX embedding_idx ON TABLE doc COLUMNS embedding HNSW DIMENSION 1536 DIST COSINE TYPE F32 EFC 150 M 12;"
+	if got != want {
+		t.Errorf("ToSurql = %q, want %q", got, want)
+	}
+}
+
+func TestHnswIndex_OmitsEFCAndMWhenZero(t *testing.T) {
+	idx := HnswIndex("e", "v", 8, HnswIndexOptions{})
+	got := idx.ToSurql("t")
+	if strings.Contains(got, "EFC") {
+		t.Errorf("unexpected EFC clause: %q", got)
+	}
+	if strings.Contains(got, " M ") {
+		t.Errorf("unexpected M clause: %q", got)
+	}
+}
+
+func TestIndexToSurql_UniqueAndStandard(t *testing.T) {
+	u := UniqueIndex("u", []string{"email"})
+	if g := u.ToSurql("user"); g != "DEFINE INDEX u ON TABLE user COLUMNS email UNIQUE;" {
+		t.Errorf("unique = %q", g)
+	}
+	s := NewIndex("t", []string{"title"}, IndexTypeStandard)
+	if g := s.ToSurql("post"); g != "DEFINE INDEX t ON TABLE post COLUMNS title;" {
+		t.Errorf("standard = %q", g)
+	}
+}
+
+func TestIndexValidate_Empty(t *testing.T) {
+	cases := []IndexDefinition{
+		{Name: "", Columns: []string{"x"}, Type: IndexTypeUnique},
+		{Name: "n", Columns: []string{}, Type: IndexTypeUnique},
+		{Name: "n", Columns: []string{""}, Type: IndexTypeUnique},
+		{Name: "n", Columns: []string{"x"}, Type: IndexType("bogus")},
+	}
+	for i, idx := range cases {
+		err := idx.Validate()
+		if err == nil {
+			t.Errorf("case %d: Validate() returned nil", i)
+			continue
+		}
+		if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+			t.Errorf("case %d: err = %v", i, err)
+		}
+	}
+}
+
+func TestIndexValidate_MTreeDimension(t *testing.T) {
+	idx := IndexDefinition{Name: "n", Columns: []string{"v"}, Type: IndexTypeMTree, Dimension: 0}
+	if err := idx.Validate(); err == nil {
+		t.Error("MTREE with dimension 0 should fail")
+	}
+}
+
+func TestIndexValidate_HnswDimension(t *testing.T) {
+	idx := IndexDefinition{Name: "n", Columns: []string{"v"}, Type: IndexTypeHNSW, Dimension: 0}
+	if err := idx.Validate(); err == nil {
+		t.Error("HNSW with dimension 0 should fail")
+	}
+}
+
+func TestEventToSurql(t *testing.T) {
+	e := NewEvent("audit", "$before != $after", "CREATE log")
+	got := e.ToSurql("user")
+	want := "DEFINE EVENT audit ON TABLE user WHEN $before != $after THEN CREATE log;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestEventValidate(t *testing.T) {
+	cases := []EventDefinition{
+		{Name: "", Condition: "c", Action: "a"},
+		{Name: "n", Condition: "", Action: "a"},
+		{Name: "n", Condition: "c", Action: ""},
+	}
+	for _, e := range cases {
+		if err := e.Validate(); err == nil {
+			t.Errorf("expected error for %+v", e)
+		}
+	}
+	ok := NewEvent("n", "c", "a")
+	if err := ok.Validate(); err != nil {
+		t.Errorf("valid event errored: %v", err)
+	}
+}
+
+func TestTableValidate_EmptyName(t *testing.T) {
+	tbl := NewTable("")
+	if err := tbl.Validate(); err == nil {
+		t.Error("empty name should fail")
+	}
+}
+
+func TestTableValidate_InvalidMode(t *testing.T) {
+	tbl := TableDefinition{Name: "t", Mode: TableMode("bogus")}
+	if err := tbl.Validate(); err == nil {
+		t.Error("invalid mode should fail")
+	}
+}
+
+func TestTableValidate_PropagatesField(t *testing.T) {
+	tbl := NewTable("t", WithFields(NewField("1bad", FieldTypeString)))
+	err := tbl.Validate()
+	if err == nil {
+		t.Fatal("expected validation error from field")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestTablePermissions_MapCopyIsolation(t *testing.T) {
+	perms := map[string]string{"select": "$auth.id = id"}
+	tbl := NewTable("t", WithTablePermissions(perms))
+	perms["select"] = "MUTATED"
+	if tbl.Permissions["select"] != "$auth.id = id" {
+		t.Errorf("expected copied map; got %q", tbl.Permissions["select"])
+	}
+}
+
+func TestTableStatements_StatementOrder(t *testing.T) {
+	tbl := NewTable("user",
+		WithFields(StringField("name")),
+		WithIndexes(UniqueIndex("name_idx", []string{"name"})),
+	)
+	stmts := tbl.ToSurqlStatements()
+	if !strings.HasPrefix(stmts[0], "DEFINE TABLE") {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+	if !strings.HasPrefix(stmts[1], "DEFINE FIELD") {
+		t.Errorf("stmts[1] = %q", stmts[1])
+	}
+	if !strings.HasPrefix(stmts[2], "DEFINE INDEX") {
+		t.Errorf("stmts[2] = %q", stmts[2])
+	}
+}


### PR DESCRIPTION
Closes #11.

## Summary
Port surql-py/src/surql/schema/{fields,table,edge,access}.py to Go. SQL generator, registry, validator, parser, visualizer follow in separate PRs.

- **\`schema/fields.go\`**: FieldDefinition + FieldType enum + builders. ObjectField defaults Flexible=true (matches Python).
- **\`schema/table.go\`**: TableDefinition, TableMode, IndexDefinition, IndexType (Unique/Search/Standard/Mtree/Hnsw) with MTreeIndexOptions / HnswIndexOptions (zero-valued EFC/M = omit clause), EventDefinition.
- **\`schema/edge.go\`**: EdgeDefinition, EdgeMode (Relation/Schemafull/Schemaless), + edge / typed_edge / bidirectional_edge helpers. \`ToSurqlStatements()\` returns \`([]string, error)\` — only method that can fail on RELATION invariants.
- **\`schema/access.go\`**: AccessDefinition, AccessType (Record/Jwt), JwtConfig, RecordAccessConfig + helpers.

## Deviations
- Functional-options pattern (\`WithMode\`, \`WithFields\`, ...) replaces Python kwargs / \`model_copy\`.
- Permission maps iterate sorted keys for deterministic output (Go map iteration is randomised).
- Reserved-word collisions surface via \`FieldDefinition.ReservedWarning(allowEdgeFields)\` rather than Python's \`warnings.warn\`.
- \`TableDefinition.Drop\` stored but not rendered (parity with Python's current behaviour).

## Test plan
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./... -race\` — **103 new subtests green, 90% schema pkg coverage**
- [ ] CI green