### PR TITLE
feat(schema): port SQL generator + registry

### DIFF
--- a/pkg/surql/schema/registry.go
+++ b/pkg/surql/schema/registry.go
@@ -1,0 +1,166 @@
+package schema
+
+import (
+	"sort"
+	"sync"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// SchemaRegistry is a thread-safe registry for code-defined table and edge
+// schemas. It mirrors surql-py's SchemaRegistry but uses a sync.RWMutex for
+// concurrent access and emits definitions in deterministic (alphabetical)
+// order for schema comparison and SQL generation.
+type SchemaRegistry struct {
+	mu     sync.RWMutex
+	tables map[string]TableDefinition
+	edges  map[string]EdgeDefinition
+}
+
+// NewSchemaRegistry constructs an empty SchemaRegistry. Prefer GetRegistry for
+// the process-wide singleton used by code-as-schema consumers; NewSchemaRegistry
+// is primarily useful for tests and scoped schema registration.
+func NewSchemaRegistry() *SchemaRegistry {
+	return &SchemaRegistry{
+		tables: make(map[string]TableDefinition),
+		edges:  make(map[string]EdgeDefinition),
+	}
+}
+
+var (
+	globalRegistry     *SchemaRegistry
+	globalRegistryOnce sync.Once
+)
+
+// GetRegistry returns the process-wide SchemaRegistry singleton, creating it
+// on first call. It is safe for concurrent use.
+func GetRegistry() *SchemaRegistry {
+	globalRegistryOnce.Do(func() {
+		globalRegistry = NewSchemaRegistry()
+	})
+	return globalRegistry
+}
+
+// RegisterTable stores a table definition keyed by its name. An empty-name
+// table returns ErrValidation. Re-registering the same name silently replaces
+// the previous definition, matching surql-py semantics.
+func (r *SchemaRegistry) RegisterTable(table TableDefinition) error {
+	if table.Name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"cannot register table with empty name")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tables[table.Name] = table
+	return nil
+}
+
+// RegisterEdge stores an edge definition keyed by its name.
+func (r *SchemaRegistry) RegisterEdge(edge EdgeDefinition) error {
+	if edge.Name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"cannot register edge with empty name")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.edges[edge.Name] = edge
+	return nil
+}
+
+// GetTable returns a registered table definition and a boolean indicating
+// whether it was found.
+func (r *SchemaRegistry) GetTable(name string) (TableDefinition, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	t, ok := r.tables[name]
+	return t, ok
+}
+
+// GetEdge returns a registered edge definition and a boolean indicating
+// whether it was found.
+func (r *SchemaRegistry) GetEdge(name string) (EdgeDefinition, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	e, ok := r.edges[name]
+	return e, ok
+}
+
+// Tables returns every registered TableDefinition sorted alphabetically by
+// name. The returned slice is a fresh copy; callers may mutate it freely.
+func (r *SchemaRegistry) Tables() []TableDefinition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.tables))
+	for name := range r.tables {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]TableDefinition, 0, len(names))
+	for _, name := range names {
+		out = append(out, r.tables[name])
+	}
+	return out
+}
+
+// Edges returns every registered EdgeDefinition sorted alphabetically by name.
+// The returned slice is a fresh copy.
+func (r *SchemaRegistry) Edges() []EdgeDefinition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.edges))
+	for name := range r.edges {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]EdgeDefinition, 0, len(names))
+	for _, name := range names {
+		out = append(out, r.edges[name])
+	}
+	return out
+}
+
+// TableNames returns the names of every registered table, sorted.
+func (r *SchemaRegistry) TableNames() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.tables))
+	for name := range r.tables {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// EdgeNames returns the names of every registered edge, sorted.
+func (r *SchemaRegistry) EdgeNames() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.edges))
+	for name := range r.edges {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TableCount returns the number of registered tables.
+func (r *SchemaRegistry) TableCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.tables)
+}
+
+// EdgeCount returns the number of registered edges.
+func (r *SchemaRegistry) EdgeCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.edges)
+}
+
+// Clear removes every registered table and edge. Useful for test isolation.
+func (r *SchemaRegistry) Clear() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tables = make(map[string]TableDefinition)
+	r.edges = make(map[string]EdgeDefinition)
+}

--- a/pkg/surql/schema/registry_test.go
+++ b/pkg/surql/schema/registry_test.go
@@ -1,0 +1,312 @@
+package schema
+
+import (
+	stdErrors "errors"
+	"sync"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestNewSchemaRegistry_Empty(t *testing.T) {
+	r := NewSchemaRegistry()
+	if r.TableCount() != 0 {
+		t.Errorf("TableCount() = %d, want 0", r.TableCount())
+	}
+	if r.EdgeCount() != 0 {
+		t.Errorf("EdgeCount() = %d, want 0", r.EdgeCount())
+	}
+}
+
+func TestRegistry_RegisterAndGetTable(t *testing.T) {
+	r := NewSchemaRegistry()
+	tbl := NewTable("user", WithMode(TableModeSchemafull))
+	if err := r.RegisterTable(tbl); err != nil {
+		t.Fatalf("RegisterTable: %v", err)
+	}
+	got, ok := r.GetTable("user")
+	if !ok {
+		t.Fatal("GetTable returned not-found")
+	}
+	if got.Name != "user" {
+		t.Errorf("got.Name = %q", got.Name)
+	}
+	if got.Mode != TableModeSchemafull {
+		t.Errorf("got.Mode = %q", got.Mode)
+	}
+}
+
+func TestRegistry_RegisterAndGetEdge(t *testing.T) {
+	r := NewSchemaRegistry()
+	e := TypedEdge("likes", "user", "post")
+	if err := r.RegisterEdge(e); err != nil {
+		t.Fatalf("RegisterEdge: %v", err)
+	}
+	got, ok := r.GetEdge("likes")
+	if !ok {
+		t.Fatal("GetEdge returned not-found")
+	}
+	if got.Name != "likes" {
+		t.Errorf("got.Name = %q", got.Name)
+	}
+	if got.FromTable != "user" || got.ToTable != "post" {
+		t.Errorf("from/to mismatch: %q/%q", got.FromTable, got.ToTable)
+	}
+}
+
+func TestRegistry_GetTable_NotFound(t *testing.T) {
+	r := NewSchemaRegistry()
+	_, ok := r.GetTable("missing")
+	if ok {
+		t.Error("expected not-found for missing table")
+	}
+}
+
+func TestRegistry_GetEdge_NotFound(t *testing.T) {
+	r := NewSchemaRegistry()
+	_, ok := r.GetEdge("missing")
+	if ok {
+		t.Error("expected not-found for missing edge")
+	}
+}
+
+func TestRegistry_RegisterTable_EmptyNameReturnsError(t *testing.T) {
+	r := NewSchemaRegistry()
+	err := r.RegisterTable(TableDefinition{Mode: TableModeSchemafull})
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestRegistry_RegisterEdge_EmptyNameReturnsError(t *testing.T) {
+	r := NewSchemaRegistry()
+	err := r.RegisterEdge(EdgeDefinition{Mode: EdgeModeRelation})
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestRegistry_Tables_SortedByName(t *testing.T) {
+	r := NewSchemaRegistry()
+	for _, name := range []string{"zebra", "apple", "mango"} {
+		if err := r.RegisterTable(NewTable(name)); err != nil {
+			t.Fatalf("RegisterTable(%q): %v", name, err)
+		}
+	}
+	tables := r.Tables()
+	if len(tables) != 3 {
+		t.Fatalf("len(tables) = %d, want 3", len(tables))
+	}
+	want := []string{"apple", "mango", "zebra"}
+	for i, tbl := range tables {
+		if tbl.Name != want[i] {
+			t.Errorf("tables[%d].Name = %q, want %q", i, tbl.Name, want[i])
+		}
+	}
+}
+
+func TestRegistry_Edges_SortedByName(t *testing.T) {
+	r := NewSchemaRegistry()
+	for _, name := range []string{"follows", "authored", "likes"} {
+		if err := r.RegisterEdge(TypedEdge(name, "user", "post")); err != nil {
+			t.Fatalf("RegisterEdge(%q): %v", name, err)
+		}
+	}
+	edges := r.Edges()
+	want := []string{"authored", "follows", "likes"}
+	for i, e := range edges {
+		if e.Name != want[i] {
+			t.Errorf("edges[%d].Name = %q, want %q", i, e.Name, want[i])
+		}
+	}
+}
+
+func TestRegistry_TableNames_Sorted(t *testing.T) {
+	r := NewSchemaRegistry()
+	for _, n := range []string{"c", "a", "b"} {
+		_ = r.RegisterTable(NewTable(n))
+	}
+	got := r.TableNames()
+	want := []string{"a", "b", "c"}
+	for i, n := range got {
+		if n != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, n, want[i])
+		}
+	}
+}
+
+func TestRegistry_EdgeNames_Sorted(t *testing.T) {
+	r := NewSchemaRegistry()
+	for _, n := range []string{"c", "a", "b"} {
+		_ = r.RegisterEdge(TypedEdge(n, "x", "y"))
+	}
+	got := r.EdgeNames()
+	want := []string{"a", "b", "c"}
+	for i, n := range got {
+		if n != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, n, want[i])
+		}
+	}
+}
+
+func TestRegistry_ReRegisterReplaces(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user", WithMode(TableModeSchemafull)))
+	_ = r.RegisterTable(NewTable("user", WithMode(TableModeSchemaless)))
+	got, ok := r.GetTable("user")
+	if !ok {
+		t.Fatal("missing table after re-register")
+	}
+	if got.Mode != TableModeSchemaless {
+		t.Errorf("got.Mode = %q, want SCHEMALESS after re-register", got.Mode)
+	}
+	if r.TableCount() != 1 {
+		t.Errorf("TableCount() = %d, want 1", r.TableCount())
+	}
+}
+
+func TestRegistry_Clear(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user"))
+	_ = r.RegisterEdge(TypedEdge("likes", "user", "post"))
+	r.Clear()
+	if r.TableCount() != 0 {
+		t.Errorf("TableCount() = %d, want 0 after Clear", r.TableCount())
+	}
+	if r.EdgeCount() != 0 {
+		t.Errorf("EdgeCount() = %d, want 0 after Clear", r.EdgeCount())
+	}
+}
+
+func TestRegistry_TablesReturnsCopy(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user"))
+	tables := r.Tables()
+	tables[0] = NewTable("other") // should not affect registry
+	got, ok := r.GetTable("user")
+	if !ok || got.Name != "user" {
+		t.Errorf("registry state mutated by caller; got %q / %v", got.Name, ok)
+	}
+}
+
+func TestRegistry_EdgesReturnsCopy(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterEdge(TypedEdge("likes", "user", "post"))
+	edges := r.Edges()
+	edges[0] = TypedEdge("other", "a", "b")
+	got, ok := r.GetEdge("likes")
+	if !ok || got.Name != "likes" {
+		t.Errorf("registry state mutated by caller; got %q / %v", got.Name, ok)
+	}
+}
+
+func TestGetRegistry_ReturnsSingleton(t *testing.T) {
+	r1 := GetRegistry()
+	r2 := GetRegistry()
+	if r1 != r2 {
+		t.Error("GetRegistry returned distinct instances")
+	}
+}
+
+func TestGetRegistry_SingletonClearIsolation(t *testing.T) {
+	r := GetRegistry()
+	r.Clear()
+	if err := r.RegisterTable(NewTable("singleton_user")); err != nil {
+		t.Fatalf("RegisterTable: %v", err)
+	}
+	other := GetRegistry()
+	if _, ok := other.GetTable("singleton_user"); !ok {
+		t.Error("expected singleton to share state across GetRegistry calls")
+	}
+	// cleanup so we don't leak across tests
+	r.Clear()
+}
+
+func TestRegistry_ConcurrentRegister(t *testing.T) {
+	r := NewSchemaRegistry()
+	var wg sync.WaitGroup
+	const goroutines = 32
+	const perGoroutine = 16
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				name := tableNameFor(gid, i)
+				_ = r.RegisterTable(NewTable(name))
+			}
+		}(g)
+	}
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				name := edgeNameFor(gid, i)
+				_ = r.RegisterEdge(TypedEdge(name, "user", "post"))
+			}
+		}(g)
+	}
+	// readers in parallel
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				_ = r.Tables()
+				_ = r.Edges()
+				_ = r.TableCount()
+				_ = r.EdgeCount()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if r.TableCount() != goroutines*perGoroutine {
+		t.Errorf("TableCount() = %d, want %d",
+			r.TableCount(), goroutines*perGoroutine)
+	}
+	if r.EdgeCount() != goroutines*perGoroutine {
+		t.Errorf("EdgeCount() = %d, want %d",
+			r.EdgeCount(), goroutines*perGoroutine)
+	}
+}
+
+func tableNameFor(g, i int) string {
+	return "t_" + itoa(g) + "_" + itoa(i)
+}
+
+func edgeNameFor(g, i int) string {
+	return "e_" + itoa(g) + "_" + itoa(i)
+}
+
+// itoa is a tiny allocation-free integer->string formatter used by the
+// concurrent-registration test; avoids pulling strconv into a test helper.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/pkg/surql/schema/sql.go
+++ b/pkg/surql/schema/sql.go
@@ -1,0 +1,95 @@
+package schema
+
+import (
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// GenerateTableSQL emits the full list of DEFINE statements for a table: the
+// DEFINE TABLE line followed by each DEFINE FIELD / INDEX / EVENT, plus any
+// DEFINE FIELD PERMISSIONS rendered from the permission map.
+//
+// It mirrors surql-py's generate_table_sql and delegates to the TableDefinition
+// ToSurqlStatements* methods for deterministic output (permissions are sorted
+// by action name).
+//
+// When ifNotExists is true, every DEFINE statement that supports it is emitted
+// with an IF NOT EXISTS clause.
+func GenerateTableSQL(table TableDefinition, ifNotExists bool) []string {
+	if ifNotExists {
+		return table.ToSurqlStatementsIfNotExists()
+	}
+	return table.ToSurqlStatements()
+}
+
+// GenerateEdgeSQL emits the full list of DEFINE statements for an edge table.
+// It returns an ErrValidation error when the edge has RELATION mode without
+// both from_table and to_table set (matching surql-py behaviour).
+func GenerateEdgeSQL(edge EdgeDefinition, ifNotExists bool) ([]string, error) {
+	if ifNotExists {
+		return edge.ToSurqlStatementsIfNotExists()
+	}
+	return edge.ToSurqlStatements()
+}
+
+// GenerateAccessSQL emits the DEFINE ACCESS statement for an access definition.
+// It always returns a single-element slice to match the surql-py signature.
+func GenerateAccessSQL(access AccessDefinition) []string {
+	return []string{access.ToSurql()}
+}
+
+// GenerateSchemaSQL composes a full SurrealQL schema script from every table
+// and edge registered in r. Tables are emitted first (in sorted order),
+// followed by edges (also sorted). Each definition group is separated by a
+// blank line for readability, matching the surql-py output format.
+//
+// A nil registry produces an empty script. When ifNotExists is true, every
+// emitted DEFINE statement includes IF NOT EXISTS.
+//
+// GenerateSchemaSQL surfaces the same validation errors as GenerateEdgeSQL:
+// an edge registered in RELATION mode without from/to tables yields an
+// ErrValidation error.
+func GenerateSchemaSQL(r *SchemaRegistry, ifNotExists bool) (string, error) {
+	if r == nil {
+		return "", nil
+	}
+
+	tables := r.Tables()
+	edges := r.Edges()
+
+	return generateSchemaScript(tables, edges, ifNotExists)
+}
+
+// GenerateSchemaSQLFromSlices composes a full SurrealQL schema script from the
+// supplied table and edge slices without consulting any registry. Inputs are
+// emitted in the order provided (callers sort first if determinism is
+// required).
+func GenerateSchemaSQLFromSlices(tables []TableDefinition, edges []EdgeDefinition, ifNotExists bool) (string, error) {
+	return generateSchemaScript(tables, edges, ifNotExists)
+}
+
+func generateSchemaScript(tables []TableDefinition, edges []EdgeDefinition, ifNotExists bool) (string, error) {
+	if len(tables) == 0 && len(edges) == 0 {
+		return "", nil
+	}
+
+	stmts := make([]string, 0, len(tables)*3+len(edges)*3)
+
+	for _, t := range tables {
+		stmts = append(stmts, GenerateTableSQL(t, ifNotExists)...)
+		stmts = append(stmts, "")
+	}
+
+	for _, e := range edges {
+		edgeStmts, err := GenerateEdgeSQL(e, ifNotExists)
+		if err != nil {
+			return "", surqlerrors.Wrapf(surqlerrors.ErrValidation, err,
+				"failed to generate SQL for edge %q", e.Name)
+		}
+		stmts = append(stmts, edgeStmts...)
+		stmts = append(stmts, "")
+	}
+
+	return strings.TrimRight(strings.Join(stmts, "\n"), "\n"), nil
+}

--- a/pkg/surql/schema/sql_test.go
+++ b/pkg/surql/schema/sql_test.go
@@ -1,0 +1,579 @@
+package schema
+
+import (
+	stdErrors "errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// ---------- GenerateTableSQL ----------
+
+func TestGenerateTableSQL_SchemafullMinimal(t *testing.T) {
+	tbl := NewTable("user", WithMode(TableModeSchemafull))
+	stmts := GenerateTableSQL(tbl, false)
+	if len(stmts) != 1 {
+		t.Fatalf("len(stmts) = %d, want 1", len(stmts))
+	}
+	if stmts[0] != "DEFINE TABLE user SCHEMAFULL;" {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+}
+
+func TestGenerateTableSQL_Schemaless(t *testing.T) {
+	tbl := NewTable("log", WithMode(TableModeSchemaless))
+	stmts := GenerateTableSQL(tbl, false)
+	if stmts[0] != "DEFINE TABLE log SCHEMALESS;" {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+}
+
+func TestGenerateTableSQL_WithFields(t *testing.T) {
+	tbl := NewTable("user",
+		WithMode(TableModeSchemafull),
+		WithFields(StringField("name"), IntField("age")),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	if !containsSubstring(stmts, "DEFINE FIELD name ON TABLE user TYPE string") {
+		t.Errorf("missing name field; stmts = %v", stmts)
+	}
+	if !containsSubstring(stmts, "DEFINE FIELD age ON TABLE user TYPE int") {
+		t.Errorf("missing age field; stmts = %v", stmts)
+	}
+}
+
+func TestGenerateTableSQL_WithFieldAssertion(t *testing.T) {
+	tbl := NewTable("user",
+		WithFields(StringField("email",
+			WithAssertion("string::is::email($value)"))),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	if !containsSubstring(stmts, "ASSERT string::is::email($value)") {
+		t.Errorf("missing assertion; stmts = %v", stmts)
+	}
+}
+
+func TestGenerateTableSQL_WithFieldDefault(t *testing.T) {
+	tbl := NewTable("event",
+		WithFields(DatetimeField("created_at", WithDefault("time::now()"))),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	if !containsSubstring(stmts, "DEFAULT time::now()") {
+		t.Errorf("missing default; stmts = %v", stmts)
+	}
+}
+
+func TestGenerateTableSQL_WithReadOnlyField(t *testing.T) {
+	tbl := NewTable("event",
+		WithFields(DatetimeField("created_at", WithReadOnly(true))),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	if !containsSubstring(stmts, "READONLY") {
+		t.Errorf("missing READONLY; stmts = %v", stmts)
+	}
+}
+
+func TestGenerateTableSQL_WithUniqueIndex(t *testing.T) {
+	tbl := NewTable("user",
+		WithIndexes(UniqueIndex("email_idx", []string{"email"})),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	want := "DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE;"
+	if !hasExact(stmts, want) {
+		t.Errorf("expected %q in stmts = %v", want, stmts)
+	}
+}
+
+func TestGenerateTableSQL_WithStandardIndex(t *testing.T) {
+	tbl := NewTable("post",
+		WithIndexes(NewIndex("title_idx", []string{"title"}, IndexTypeStandard)),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	want := "DEFINE INDEX title_idx ON TABLE post COLUMNS title;"
+	if !hasExact(stmts, want) {
+		t.Errorf("expected %q in stmts = %v", want, stmts)
+	}
+}
+
+func TestGenerateTableSQL_WithEvent(t *testing.T) {
+	tbl := NewTable("user",
+		WithEvents(NewEvent("email_changed",
+			"$before.email != $after.email",
+			"CREATE audit_log SET user = $value.id")),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	if !containsSubstring(stmts, "DEFINE EVENT email_changed ON TABLE user") {
+		t.Errorf("missing event header; stmts = %v", stmts)
+	}
+	if !containsSubstring(stmts, "WHEN $before.email != $after.email") {
+		t.Errorf("missing event WHEN; stmts = %v", stmts)
+	}
+}
+
+func TestGenerateTableSQL_WithPermissions(t *testing.T) {
+	tbl := NewTable("user",
+		WithTablePermissions(map[string]string{"select": "$auth.id = id"}),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "FOR SELECT") && strings.Contains(s, "$auth.id = id") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected FOR SELECT ... $auth.id = id; stmts = %v", stmts)
+	}
+}
+
+func TestGenerateTableSQL_MinimalSingleStatement(t *testing.T) {
+	tbl := NewTable("empty")
+	stmts := GenerateTableSQL(tbl, false)
+	if len(stmts) != 1 {
+		t.Errorf("len(stmts) = %d, want 1", len(stmts))
+	}
+}
+
+func TestGenerateTableSQL_FirstStatementIsTable(t *testing.T) {
+	tbl := NewTable("user",
+		WithFields(StringField("name")),
+		WithIndexes(UniqueIndex("name_idx", []string{"name"})),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	if !strings.HasPrefix(stmts[0], "DEFINE TABLE") {
+		t.Errorf("first stmt = %q, want prefix DEFINE TABLE", stmts[0])
+	}
+}
+
+// ---------- GenerateEdgeSQL ----------
+
+func TestGenerateEdgeSQL_RelationWithFromTo(t *testing.T) {
+	e := TypedEdge("likes", "user", "post")
+	stmts, err := GenerateEdgeSQL(e, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := "DEFINE TABLE likes TYPE RELATION FROM user TO post;"
+	if stmts[0] != want {
+		t.Errorf("stmts[0] = %q, want %q", stmts[0], want)
+	}
+}
+
+func TestGenerateEdgeSQL_Schemafull(t *testing.T) {
+	e := NewEdge("entity_relation", WithEdgeMode(EdgeModeSchemafull))
+	stmts, err := GenerateEdgeSQL(e, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := "DEFINE TABLE entity_relation SCHEMAFULL;"
+	if stmts[0] != want {
+		t.Errorf("stmts[0] = %q, want %q", stmts[0], want)
+	}
+}
+
+func TestGenerateEdgeSQL_Schemaless(t *testing.T) {
+	e := NewEdge("loose_rel", WithEdgeMode(EdgeModeSchemaless))
+	stmts, err := GenerateEdgeSQL(e, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := "DEFINE TABLE loose_rel SCHEMALESS;"
+	if stmts[0] != want {
+		t.Errorf("stmts[0] = %q, want %q", stmts[0], want)
+	}
+}
+
+func TestGenerateEdgeSQL_WithFields(t *testing.T) {
+	e := TypedEdge("likes", "user", "post",
+		WithEdgeFields(DatetimeField("created_at", WithDefault("time::now()"))),
+	)
+	stmts, err := GenerateEdgeSQL(e, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !containsSubstring(stmts, "DEFINE FIELD created_at ON TABLE likes TYPE datetime") {
+		t.Errorf("missing field; stmts = %v", stmts)
+	}
+}
+
+func TestGenerateEdgeSQL_RelationMissingFrom(t *testing.T) {
+	e := NewEdge("likes", WithToTable("post"))
+	_, err := GenerateEdgeSQL(e, false)
+	if err == nil {
+		t.Fatal("expected error for missing from_table")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestGenerateEdgeSQL_RelationMissingTo(t *testing.T) {
+	e := NewEdge("likes", WithFromTable("user"))
+	_, err := GenerateEdgeSQL(e, false)
+	if err == nil {
+		t.Fatal("expected error for missing to_table")
+	}
+}
+
+func TestGenerateEdgeSQL_RelationMissingBoth(t *testing.T) {
+	e := NewEdge("likes")
+	_, err := GenerateEdgeSQL(e, false)
+	if err == nil {
+		t.Fatal("expected error for missing both tables")
+	}
+}
+
+func TestGenerateEdgeSQL_SchemafullNoTablesRequired(t *testing.T) {
+	e := NewEdge("entity_rel", WithEdgeMode(EdgeModeSchemafull))
+	stmts, err := GenerateEdgeSQL(e, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(stmts) < 1 {
+		t.Errorf("want >=1 stmts, got %d", len(stmts))
+	}
+}
+
+func TestGenerateEdgeSQL_FirstStatementIsTable(t *testing.T) {
+	e := BidirectionalEdge("follows", "user")
+	stmts, err := GenerateEdgeSQL(e, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.HasPrefix(stmts[0], "DEFINE TABLE") {
+		t.Errorf("first stmt = %q", stmts[0])
+	}
+}
+
+// ---------- GenerateAccessSQL ----------
+
+func TestGenerateAccessSQL_JWT(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{Key: "secret"})
+	stmts := GenerateAccessSQL(a)
+	if len(stmts) != 1 {
+		t.Fatalf("len(stmts) = %d, want 1", len(stmts))
+	}
+	want := "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'secret';"
+	if stmts[0] != want {
+		t.Errorf("stmts[0] = %q, want %q", stmts[0], want)
+	}
+}
+
+func TestGenerateAccessSQL_Record(t *testing.T) {
+	a := RecordAccess("users", RecordAccessConfig{
+		Signup: "CREATE user SET email = $email",
+		Signin: "SELECT * FROM user WHERE email = $email",
+	})
+	stmts := GenerateAccessSQL(a)
+	if !strings.Contains(stmts[0], "SIGNUP (CREATE user SET email = $email)") {
+		t.Errorf("missing SIGNUP; got %q", stmts[0])
+	}
+	if !strings.Contains(stmts[0], "SIGNIN (SELECT * FROM user WHERE email = $email)") {
+		t.Errorf("missing SIGNIN; got %q", stmts[0])
+	}
+}
+
+// ---------- GenerateSchemaSQL (registry) ----------
+
+func TestGenerateSchemaSQL_CombinesTablesAndEdges(t *testing.T) {
+	r := NewSchemaRegistry()
+	if err := r.RegisterTable(NewTable("user", WithMode(TableModeSchemafull))); err != nil {
+		t.Fatalf("register table: %v", err)
+	}
+	if err := r.RegisterEdge(TypedEdge("likes", "user", "post")); err != nil {
+		t.Fatalf("register edge: %v", err)
+	}
+	sql, err := GenerateSchemaSQL(r, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(sql, "DEFINE TABLE user SCHEMAFULL") {
+		t.Errorf("missing user table; sql = %q", sql)
+	}
+	if !strings.Contains(sql, "DEFINE TABLE likes TYPE RELATION FROM user TO post") {
+		t.Errorf("missing likes edge; sql = %q", sql)
+	}
+}
+
+func TestGenerateSchemaSQL_TablesOnly(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user"))
+	sql, err := GenerateSchemaSQL(r, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(sql, "DEFINE TABLE user") {
+		t.Errorf("sql missing user; sql = %q", sql)
+	}
+}
+
+func TestGenerateSchemaSQL_EdgesOnly(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterEdge(BidirectionalEdge("follows", "user"))
+	sql, err := GenerateSchemaSQL(r, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(sql, "DEFINE TABLE follows TYPE RELATION") {
+		t.Errorf("missing edge; sql = %q", sql)
+	}
+}
+
+func TestGenerateSchemaSQL_EmptyRegistryReturnsEmpty(t *testing.T) {
+	r := NewSchemaRegistry()
+	sql, err := GenerateSchemaSQL(r, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if sql != "" {
+		t.Errorf("expected empty string, got %q", sql)
+	}
+}
+
+func TestGenerateSchemaSQL_NilRegistryReturnsEmpty(t *testing.T) {
+	sql, err := GenerateSchemaSQL(nil, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if sql != "" {
+		t.Errorf("expected empty string, got %q", sql)
+	}
+}
+
+func TestGenerateSchemaSQL_MultipleTablesSorted(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user"))
+	_ = r.RegisterTable(NewTable("post"))
+	sql, err := GenerateSchemaSQL(r, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	// sorted: post should appear before user
+	postIdx := strings.Index(sql, "DEFINE TABLE post")
+	userIdx := strings.Index(sql, "DEFINE TABLE user")
+	if postIdx == -1 || userIdx == -1 {
+		t.Fatalf("missing tables; sql = %q", sql)
+	}
+	if postIdx > userIdx {
+		t.Errorf("tables not sorted: post index %d > user index %d", postIdx, userIdx)
+	}
+}
+
+func TestGenerateSchemaSQL_TablesSeparatedByBlankLines(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user"))
+	_ = r.RegisterTable(NewTable("post"))
+	sql, err := GenerateSchemaSQL(r, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	hasBlank := false
+	for _, line := range strings.Split(sql, "\n") {
+		if line == "" {
+			hasBlank = true
+			break
+		}
+	}
+	if !hasBlank {
+		t.Errorf("expected blank line separator; sql = %q", sql)
+	}
+}
+
+func TestGenerateSchemaSQL_EdgeValidationError(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterEdge(NewEdge("bad", WithFromTable("user")))
+	_, err := GenerateSchemaSQL(r, false)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestGenerateSchemaSQLFromSlices_PreservesOrder(t *testing.T) {
+	tables := []TableDefinition{NewTable("z"), NewTable("a")}
+	sql, err := GenerateSchemaSQLFromSlices(tables, nil, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	zIdx := strings.Index(sql, "DEFINE TABLE z")
+	aIdx := strings.Index(sql, "DEFINE TABLE a")
+	if zIdx == -1 || aIdx == -1 {
+		t.Fatalf("missing tables; sql = %q", sql)
+	}
+	if zIdx > aIdx {
+		t.Errorf("slice order not preserved: z at %d, a at %d", zIdx, aIdx)
+	}
+}
+
+// ---------- IF NOT EXISTS ----------
+
+func TestIfNotExists_TableDefinition(t *testing.T) {
+	tbl := NewTable("user", WithMode(TableModeSchemafull))
+	stmts := GenerateTableSQL(tbl, true)
+	want := "DEFINE TABLE IF NOT EXISTS user SCHEMAFULL;"
+	if stmts[0] != want {
+		t.Errorf("stmts[0] = %q, want %q", stmts[0], want)
+	}
+}
+
+func TestIfNotExists_Field(t *testing.T) {
+	tbl := NewTable("user",
+		WithMode(TableModeSchemafull),
+		WithFields(StringField("name")),
+	)
+	stmts := GenerateTableSQL(tbl, true)
+	want := "DEFINE FIELD IF NOT EXISTS name ON TABLE user TYPE string;"
+	if !hasExact(stmts, want) {
+		t.Errorf("missing %q; stmts = %v", want, stmts)
+	}
+}
+
+func TestIfNotExists_Index(t *testing.T) {
+	tbl := NewTable("user",
+		WithIndexes(UniqueIndex("email_idx", []string{"email"})),
+	)
+	stmts := GenerateTableSQL(tbl, true)
+	want := "DEFINE INDEX IF NOT EXISTS email_idx ON TABLE user COLUMNS email UNIQUE;"
+	if !hasExact(stmts, want) {
+		t.Errorf("missing %q; stmts = %v", want, stmts)
+	}
+}
+
+func TestIfNotExists_StandardIndex(t *testing.T) {
+	tbl := NewTable("post",
+		WithIndexes(NewIndex("title_idx", []string{"title"}, IndexTypeStandard)),
+	)
+	stmts := GenerateTableSQL(tbl, true)
+	want := "DEFINE INDEX IF NOT EXISTS title_idx ON TABLE post COLUMNS title;"
+	if !hasExact(stmts, want) {
+		t.Errorf("missing %q; stmts = %v", want, stmts)
+	}
+}
+
+func TestIfNotExists_Event(t *testing.T) {
+	tbl := NewTable("user",
+		WithEvents(NewEvent("email_changed",
+			"$before.email != $after.email",
+			"CREATE audit_log SET user = $value.id")),
+	)
+	stmts := GenerateTableSQL(tbl, true)
+	found := false
+	for _, s := range stmts {
+		if strings.HasPrefix(s, "DEFINE EVENT IF NOT EXISTS email_changed ON TABLE user") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("missing DEFINE EVENT IF NOT EXISTS; stmts = %v", stmts)
+	}
+}
+
+func TestIfNotExists_EdgeRelation(t *testing.T) {
+	e := TypedEdge("likes", "user", "post")
+	stmts, err := GenerateEdgeSQL(e, true)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := "DEFINE TABLE IF NOT EXISTS likes TYPE RELATION FROM user TO post;"
+	if stmts[0] != want {
+		t.Errorf("stmts[0] = %q, want %q", stmts[0], want)
+	}
+}
+
+func TestIfNotExists_EdgeSchemafull(t *testing.T) {
+	e := NewEdge("entity_relation", WithEdgeMode(EdgeModeSchemafull))
+	stmts, err := GenerateEdgeSQL(e, true)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := "DEFINE TABLE IF NOT EXISTS entity_relation SCHEMAFULL;"
+	if stmts[0] != want {
+		t.Errorf("stmts[0] = %q, want %q", stmts[0], want)
+	}
+}
+
+func TestIfNotExists_EdgeSchemaless(t *testing.T) {
+	e := NewEdge("loose_rel", WithEdgeMode(EdgeModeSchemaless))
+	stmts, err := GenerateEdgeSQL(e, true)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := "DEFINE TABLE IF NOT EXISTS loose_rel SCHEMALESS;"
+	if stmts[0] != want {
+		t.Errorf("stmts[0] = %q, want %q", stmts[0], want)
+	}
+}
+
+func TestIfNotExists_EdgeFields(t *testing.T) {
+	e := TypedEdge("likes", "user", "post",
+		WithEdgeFields(DatetimeField("created_at", WithDefault("time::now()"))),
+	)
+	stmts, err := GenerateEdgeSQL(e, true)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !containsSubstring(stmts, "DEFINE FIELD IF NOT EXISTS created_at ON TABLE likes") {
+		t.Errorf("missing IF NOT EXISTS field; stmts = %v", stmts)
+	}
+}
+
+func TestIfNotExists_SchemaSQL(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user", WithMode(TableModeSchemafull)))
+	_ = r.RegisterEdge(TypedEdge("likes", "user", "post"))
+	sql, err := GenerateSchemaSQL(r, true)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(sql, "DEFINE TABLE IF NOT EXISTS user SCHEMAFULL") {
+		t.Errorf("missing IF NOT EXISTS table; sql = %q", sql)
+	}
+	if !strings.Contains(sql, "DEFINE TABLE IF NOT EXISTS likes TYPE RELATION FROM user TO post") {
+		t.Errorf("missing IF NOT EXISTS edge; sql = %q", sql)
+	}
+}
+
+func TestIfNotExistsDefault_False(t *testing.T) {
+	tbl := NewTable("user",
+		WithMode(TableModeSchemafull),
+		WithFields(StringField("name")),
+		WithIndexes(UniqueIndex("email_idx", []string{"email"})),
+		WithEvents(NewEvent("email_changed",
+			"$before.email != $after.email",
+			"CREATE audit_log SET user = $value.id")),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	if stmts[0] != "DEFINE TABLE user SCHEMAFULL;" {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+	for _, s := range stmts {
+		if strings.Contains(s, "IF NOT EXISTS") {
+			t.Errorf("did not expect IF NOT EXISTS; got %q", s)
+		}
+	}
+}
+
+// ---------- helpers ----------
+
+func containsSubstring(stmts []string, needle string) bool {
+	for _, s := range stmts {
+		if strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExact(stmts []string, needle string) bool {
+	for _, s := range stmts {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #13.

## Summary
Port surql-py/src/surql/schema/{sql,registry}.py.

- **\`schema/sql.go\`**: \`GenerateTableSQL\`, \`GenerateEdgeSQL\`, \`GenerateAccessSQL\`, \`GenerateSchemaSQL(*SchemaRegistry)\`, \`GenerateSchemaSQLFromSlices\` (order-preserving). Delegates to existing \`ToSurql*\` methods; generators that touch RELATION edges propagate \`surqlerrors.ErrValidation\` when from/to are missing.
- **\`schema/registry.go\`**: \`SchemaRegistry\` (sync.RWMutex), \`NewSchemaRegistry\`, singleton \`GetRegistry()\` via sync.Once. Methods: \`RegisterTable\`, \`RegisterEdge\` (both reject empty names), \`GetTable\`, \`GetEdge\`, \`Tables\` / \`Edges\` / \`TableNames\` / \`EdgeNames\` (sorted, defensive copies), \`Clear\`, \`TableCount\`, \`EdgeCount\`.

## Deviations
- Go API takes positional \`ifNotExists bool\` instead of Python's keyword.
- \`Tables()\` / \`Edges()\` sorted by name for deterministic output; Python uses dict insertion order.

## Test plan
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./... -race\` — **61 new tests** (36 sql, 25 registry) green; 32-goroutine concurrent-register smoke test passes
- [ ] CI green