### PR TITLE
feat(schema): port validator

### DIFF
--- a/pkg/surql/schema/validator.go
+++ b/pkg/surql/schema/validator.go
@@ -1,0 +1,1151 @@
+package schema
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// ValidationSeverity enumerates the severity of a ValidationResult.
+type ValidationSeverity string
+
+// Severity values.
+const (
+	// SeverityError indicates a breaking issue requiring remediation.
+	SeverityError ValidationSeverity = "error"
+	// SeverityWarning indicates a non-critical inconsistency.
+	SeverityWarning ValidationSeverity = "warning"
+	// SeverityInfo indicates an informational finding only.
+	SeverityInfo ValidationSeverity = "info"
+)
+
+// IsValid reports whether the severity value is recognised.
+func (s ValidationSeverity) IsValid() bool {
+	switch s {
+	case SeverityError, SeverityWarning, SeverityInfo:
+		return true
+	}
+	return false
+}
+
+// ValidationResult is a single finding produced by the validator.
+type ValidationResult struct {
+	Severity  ValidationSeverity
+	Table     string
+	Field     string
+	Message   string
+	CodeValue string
+	DBValue   string
+}
+
+// String returns a human-readable representation of the result.
+func (r ValidationResult) String() string {
+	var b strings.Builder
+	b.WriteString("[")
+	b.WriteString(strings.ToUpper(string(r.Severity)))
+	b.WriteString("] ")
+	b.WriteString(r.Table)
+	if r.Field != "" {
+		b.WriteString(".")
+		b.WriteString(r.Field)
+	}
+	b.WriteString(": ")
+	b.WriteString(r.Message)
+	if r.CodeValue != "" || r.DBValue != "" {
+		b.WriteString(" (code: ")
+		b.WriteString(r.CodeValue)
+		b.WriteString(", db: ")
+		b.WriteString(r.DBValue)
+		b.WriteString(")")
+	}
+	return b.String()
+}
+
+// ValidationReport aggregates ValidationResults and exposes convenience
+// accessors for downstream tooling (CLI reporters, migration planners).
+type ValidationReport struct {
+	Results []ValidationResult
+}
+
+// NewValidationReport constructs an empty report.
+func NewValidationReport() *ValidationReport {
+	return &ValidationReport{}
+}
+
+// Add appends a single result to the report.
+func (vr *ValidationReport) Add(r ValidationResult) {
+	if vr == nil {
+		return
+	}
+	vr.Results = append(vr.Results, r)
+}
+
+// AddAll appends multiple results to the report.
+func (vr *ValidationReport) AddAll(rs []ValidationResult) {
+	if vr == nil {
+		return
+	}
+	vr.Results = append(vr.Results, rs...)
+}
+
+// Merge appends every result from other into vr. It is a no-op when either
+// report is nil.
+func (vr *ValidationReport) Merge(other *ValidationReport) {
+	if vr == nil || other == nil {
+		return
+	}
+	vr.Results = append(vr.Results, other.Results...)
+}
+
+// Errors returns only ERROR-severity results.
+func (vr *ValidationReport) Errors() []ValidationResult {
+	if vr == nil {
+		return nil
+	}
+	return FilterBySeverity(vr.Results, SeverityError)
+}
+
+// Warnings returns only WARNING-severity results.
+func (vr *ValidationReport) Warnings() []ValidationResult {
+	if vr == nil {
+		return nil
+	}
+	return FilterBySeverity(vr.Results, SeverityWarning)
+}
+
+// Infos returns only INFO-severity results.
+func (vr *ValidationReport) Infos() []ValidationResult {
+	if vr == nil {
+		return nil
+	}
+	return FilterBySeverity(vr.Results, SeverityInfo)
+}
+
+// HasErrors reports whether any ERROR-severity result is present.
+func (vr *ValidationReport) HasErrors() bool {
+	if vr == nil {
+		return false
+	}
+	return HasErrors(vr.Results)
+}
+
+// IsValid is the inverse of HasErrors.
+func (vr *ValidationReport) IsValid() bool {
+	return !vr.HasErrors()
+}
+
+// Len returns the total number of results in the report.
+func (vr *ValidationReport) Len() int {
+	if vr == nil {
+		return 0
+	}
+	return len(vr.Results)
+}
+
+// ValidateSchema performs cross-schema validation over every table, edge, and
+// access definition currently registered in r. It returns a ValidationReport
+// describing every inconsistency. A hard error is returned only when r is nil.
+//
+// The Access parameter is optional and may be supplied via the variadic accesses
+// argument for callers that manage access definitions outside the registry
+// (the current SchemaRegistry tracks tables and edges only).
+func ValidateSchema(r *SchemaRegistry, accesses ...AccessDefinition) (*ValidationReport, error) {
+	if r == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation,
+			"cannot validate schema: registry is nil")
+	}
+
+	report := NewValidationReport()
+	tables := r.Tables()
+	edges := r.Edges()
+
+	// Per-definition structural validation.
+	for _, t := range tables {
+		report.Merge(ValidateTable(t))
+	}
+	for _, e := range edges {
+		report.Merge(ValidateEdge(e))
+	}
+	for _, a := range accesses {
+		report.Merge(ValidateAccess(a))
+	}
+
+	// Cross-definition checks.
+	report.AddAll(detectNameCollisions(tables, edges))
+	report.AddAll(detectRecordFieldTargets(tables, edges))
+	report.AddAll(detectEdgeTableReferences(tables, edges))
+	report.AddAll(detectDuplicateAccessNames(accesses))
+
+	return report, nil
+}
+
+// ValidateTable performs internal consistency checks on a single table
+// definition. It never returns a hard error; every issue is expressed as a
+// ValidationResult so callers can display the full set.
+func ValidateTable(t TableDefinition) *ValidationReport {
+	report := NewValidationReport()
+
+	if t.Name == "" {
+		report.Add(ValidationResult{
+			Severity: SeverityError,
+			Message:  "table name cannot be empty",
+		})
+		return report
+	}
+
+	if !t.Mode.IsValid() {
+		report.Add(ValidationResult{
+			Severity:  SeverityError,
+			Table:     t.Name,
+			Message:   "invalid table mode",
+			CodeValue: string(t.Mode),
+		})
+	}
+
+	report.AddAll(validateFieldList(t.Name, t.Fields, false))
+	report.AddAll(validateIndexList(t.Name, t.Indexes, t.Fields))
+	report.AddAll(validateEventList(t.Name, t.Events))
+	report.AddAll(validatePermissions(t.Name, t.Permissions))
+
+	return report
+}
+
+// ValidateEdge performs internal consistency checks on a single edge
+// definition, including RELATION-mode requirements for from/to tables.
+func ValidateEdge(e EdgeDefinition) *ValidationReport {
+	report := NewValidationReport()
+
+	if e.Name == "" {
+		report.Add(ValidationResult{
+			Severity: SeverityError,
+			Message:  "edge name cannot be empty",
+		})
+		return report
+	}
+
+	if !e.Mode.IsValid() {
+		report.Add(ValidationResult{
+			Severity:  SeverityError,
+			Table:     e.Name,
+			Message:   "invalid edge mode",
+			CodeValue: string(e.Mode),
+		})
+	}
+
+	if e.Mode == EdgeModeRelation {
+		if e.FromTable == "" {
+			report.Add(ValidationResult{
+				Severity: SeverityError,
+				Table:    e.Name,
+				Message:  "edge with RELATION mode requires a from_table",
+			})
+		}
+		if e.ToTable == "" {
+			report.Add(ValidationResult{
+				Severity: SeverityError,
+				Table:    e.Name,
+				Message:  "edge with RELATION mode requires a to_table",
+			})
+		}
+	}
+
+	// Warn about reserved identifier usage (in/out are permitted on edges).
+	report.AddAll(validateFieldList(e.Name, e.Fields, true))
+	report.AddAll(validateIndexList(e.Name, e.Indexes, e.Fields))
+	report.AddAll(validateEventList(e.Name, e.Events))
+	report.AddAll(validatePermissions(e.Name, e.Permissions))
+
+	return report
+}
+
+// ValidateAccess performs internal consistency checks on a single access
+// definition.
+func ValidateAccess(a AccessDefinition) *ValidationReport {
+	report := NewValidationReport()
+
+	if a.Name == "" {
+		report.Add(ValidationResult{
+			Severity: SeverityError,
+			Message:  "access name cannot be empty",
+		})
+		return report
+	}
+
+	if !a.Type.IsValid() {
+		report.Add(ValidationResult{
+			Severity:  SeverityError,
+			Table:     a.Name,
+			Message:   "invalid access type",
+			CodeValue: string(a.Type),
+		})
+	}
+
+	switch a.Type {
+	case AccessTypeJWT:
+		if a.JWT == nil {
+			report.Add(ValidationResult{
+				Severity: SeverityError,
+				Table:    a.Name,
+				Message:  "JWT access requires a JWT configuration",
+			})
+		} else {
+			if a.JWT.Key == "" && a.JWT.URL == "" {
+				report.Add(ValidationResult{
+					Severity: SeverityError,
+					Table:    a.Name,
+					Message:  "JWT access requires either a KEY or a URL",
+				})
+			}
+			if a.JWT.Key != "" && a.JWT.URL != "" {
+				report.Add(ValidationResult{
+					Severity: SeverityWarning,
+					Table:    a.Name,
+					Message:  "JWT access has both KEY and URL; URL takes precedence",
+				})
+			}
+		}
+		if a.Record != nil {
+			report.Add(ValidationResult{
+				Severity: SeverityWarning,
+				Table:    a.Name,
+				Message:  "JWT access should not carry a record configuration",
+			})
+		}
+	case AccessTypeRecord:
+		if a.Record == nil {
+			report.Add(ValidationResult{
+				Severity: SeverityError,
+				Table:    a.Name,
+				Message:  "RECORD access requires a record configuration",
+			})
+		} else {
+			if a.Record.Signup == "" && a.Record.Signin == "" {
+				report.Add(ValidationResult{
+					Severity: SeverityWarning,
+					Table:    a.Name,
+					Message:  "RECORD access declares neither SIGNUP nor SIGNIN",
+				})
+			}
+		}
+		if a.JWT != nil {
+			report.Add(ValidationResult{
+				Severity: SeverityWarning,
+				Table:    a.Name,
+				Message:  "RECORD access should not carry a JWT configuration",
+			})
+		}
+	}
+
+	return report
+}
+
+// CompareSchemas reports drift between a code-defined schema and the schema
+// extracted from a live database. It mirrors the semantics of surql-py's
+// validate_schema but consumes pre-fetched TableDefinition / EdgeDefinition
+// slices so that the caller owns database I/O.
+//
+// Missing / extra / mismatched tables, fields, indexes, and events are
+// surfaced with the severity levels documented in the Python implementation.
+func CompareSchemas(
+	codeTables, dbTables []TableDefinition,
+	codeEdges, dbEdges []EdgeDefinition,
+) *ValidationReport {
+	report := NewValidationReport()
+
+	codeByName := tablesByName(codeTables)
+	dbByName := tablesByName(dbTables)
+
+	// Missing / extra tables.
+	for _, name := range sortedKeys(codeByName) {
+		if _, ok := dbByName[name]; !ok {
+			report.Add(ValidationResult{
+				Severity:  SeverityError,
+				Table:     name,
+				Message:   "Table defined in code but missing from database",
+				CodeValue: "exists",
+				DBValue:   "missing",
+			})
+		}
+	}
+	for _, name := range sortedKeys(dbByName) {
+		if _, ok := codeByName[name]; !ok {
+			report.Add(ValidationResult{
+				Severity:  SeverityWarning,
+				Table:     name,
+				Message:   "Table exists in database but not defined in code",
+				CodeValue: "missing",
+				DBValue:   "exists",
+			})
+		}
+	}
+
+	// Common tables: deep compare.
+	for _, name := range sortedKeys(codeByName) {
+		db, ok := dbByName[name]
+		if !ok {
+			continue
+		}
+		report.AddAll(diffTable(codeByName[name], db))
+	}
+
+	// Edges.
+	codeEdgeByName := edgesByName(codeEdges)
+	dbEdgeByName := edgesByName(dbEdges)
+
+	for _, name := range sortedKeys(codeEdgeByName) {
+		if _, ok := dbEdgeByName[name]; !ok {
+			report.Add(ValidationResult{
+				Severity:  SeverityError,
+				Table:     name,
+				Message:   "Edge defined in code but missing from database",
+				CodeValue: "exists",
+				DBValue:   "missing",
+			})
+		}
+	}
+	for _, name := range sortedKeys(dbEdgeByName) {
+		if _, ok := codeEdgeByName[name]; !ok {
+			report.Add(ValidationResult{
+				Severity:  SeverityWarning,
+				Table:     name,
+				Message:   "Edge exists in database but not defined in code",
+				CodeValue: "missing",
+				DBValue:   "exists",
+			})
+		}
+	}
+
+	for _, name := range sortedKeys(codeEdgeByName) {
+		db, ok := dbEdgeByName[name]
+		if !ok {
+			continue
+		}
+		report.AddAll(diffEdge(codeEdgeByName[name], db))
+	}
+
+	return report
+}
+
+// diffTable computes the drift between two TableDefinition objects.
+func diffTable(code, db TableDefinition) []ValidationResult {
+	var results []ValidationResult
+
+	if code.Mode != db.Mode {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     code.Name,
+			Message:   "Table mode mismatch",
+			CodeValue: string(code.Mode),
+			DBValue:   string(db.Mode),
+		})
+	}
+
+	results = append(results, diffFields(code.Name, code.Fields, db.Fields)...)
+	results = append(results, diffIndexes(code.Name, code.Indexes, db.Indexes)...)
+	results = append(results, diffEvents(code.Name, code.Events, db.Events)...)
+
+	return results
+}
+
+// diffEdge computes the drift between two EdgeDefinition objects.
+func diffEdge(code, db EdgeDefinition) []ValidationResult {
+	var results []ValidationResult
+
+	if code.Mode != db.Mode {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     code.Name,
+			Message:   "Edge mode mismatch",
+			CodeValue: string(code.Mode),
+			DBValue:   string(db.Mode),
+		})
+	}
+	if code.FromTable != db.FromTable {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     code.Name,
+			Message:   "Edge from_table mismatch",
+			CodeValue: code.FromTable,
+			DBValue:   db.FromTable,
+		})
+	}
+	if code.ToTable != db.ToTable {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     code.Name,
+			Message:   "Edge to_table mismatch",
+			CodeValue: code.ToTable,
+			DBValue:   db.ToTable,
+		})
+	}
+
+	results = append(results, diffFields(code.Name, code.Fields, db.Fields)...)
+	results = append(results, diffIndexes(code.Name, code.Indexes, db.Indexes)...)
+	results = append(results, diffEvents(code.Name, code.Events, db.Events)...)
+
+	return results
+}
+
+// diffFields enumerates missing / extra / mismatched fields between code and
+// database field slices for a given container (table or edge).
+func diffFields(container string, code, db []FieldDefinition) []ValidationResult {
+	var results []ValidationResult
+
+	codeByName := fieldsByName(code)
+	dbByName := fieldsByName(db)
+
+	for _, name := range sortedKeys(codeByName) {
+		if _, ok := dbByName[name]; !ok {
+			results = append(results, ValidationResult{
+				Severity:  SeverityError,
+				Table:     container,
+				Field:     name,
+				Message:   "Field defined in code but missing from database",
+				CodeValue: "exists",
+				DBValue:   "missing",
+			})
+		}
+	}
+	for _, name := range sortedKeys(dbByName) {
+		if _, ok := codeByName[name]; !ok {
+			results = append(results, ValidationResult{
+				Severity:  SeverityWarning,
+				Table:     container,
+				Field:     name,
+				Message:   "Field exists in database but not defined in code",
+				CodeValue: "missing",
+				DBValue:   "exists",
+			})
+		}
+	}
+	for _, name := range sortedKeys(codeByName) {
+		dbField, ok := dbByName[name]
+		if !ok {
+			continue
+		}
+		results = append(results, diffField(container, codeByName[name], dbField)...)
+	}
+
+	return results
+}
+
+// diffField compares a single pair of FieldDefinition objects.
+func diffField(container string, code, db FieldDefinition) []ValidationResult {
+	var results []ValidationResult
+
+	if code.Type != db.Type {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     container,
+			Field:     code.Name,
+			Message:   "Field type mismatch",
+			CodeValue: string(code.Type),
+			DBValue:   string(db.Type),
+		})
+	}
+	if normalizeExpression(code.Assertion) != normalizeExpression(db.Assertion) {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     code.Name,
+			Message:   "Field assertion mismatch",
+			CodeValue: code.Assertion,
+			DBValue:   db.Assertion,
+		})
+	}
+	if normalizeExpression(code.Default) != normalizeExpression(db.Default) {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     code.Name,
+			Message:   "Field default value mismatch",
+			CodeValue: code.Default,
+			DBValue:   db.Default,
+		})
+	}
+	if normalizeExpression(code.Value) != normalizeExpression(db.Value) {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     code.Name,
+			Message:   "Field computed value mismatch",
+			CodeValue: code.Value,
+			DBValue:   db.Value,
+		})
+	}
+	if code.ReadOnly != db.ReadOnly {
+		results = append(results, ValidationResult{
+			Severity:  SeverityInfo,
+			Table:     container,
+			Field:     code.Name,
+			Message:   "Field readonly flag mismatch",
+			CodeValue: strconv.FormatBool(code.ReadOnly),
+			DBValue:   strconv.FormatBool(db.ReadOnly),
+		})
+	}
+	if code.Flexible != db.Flexible {
+		results = append(results, ValidationResult{
+			Severity:  SeverityInfo,
+			Table:     container,
+			Field:     code.Name,
+			Message:   "Field flexible flag mismatch",
+			CodeValue: strconv.FormatBool(code.Flexible),
+			DBValue:   strconv.FormatBool(db.Flexible),
+		})
+	}
+
+	return results
+}
+
+// diffIndexes enumerates missing / extra / mismatched indexes.
+func diffIndexes(container string, code, db []IndexDefinition) []ValidationResult {
+	var results []ValidationResult
+
+	codeByName := indexesByName(code)
+	dbByName := indexesByName(db)
+
+	for _, name := range sortedKeys(codeByName) {
+		if _, ok := dbByName[name]; !ok {
+			results = append(results, ValidationResult{
+				Severity:  SeverityError,
+				Table:     container,
+				Field:     "index:" + name,
+				Message:   "Index defined in code but missing from database",
+				CodeValue: "exists",
+				DBValue:   "missing",
+			})
+		}
+	}
+	for _, name := range sortedKeys(dbByName) {
+		if _, ok := codeByName[name]; !ok {
+			results = append(results, ValidationResult{
+				Severity:  SeverityWarning,
+				Table:     container,
+				Field:     "index:" + name,
+				Message:   "Index exists in database but not defined in code",
+				CodeValue: "missing",
+				DBValue:   "exists",
+			})
+		}
+	}
+	for _, name := range sortedKeys(codeByName) {
+		dbIdx, ok := dbByName[name]
+		if !ok {
+			continue
+		}
+		results = append(results, diffIndex(container, codeByName[name], dbIdx)...)
+	}
+
+	return results
+}
+
+// diffIndex compares a single pair of IndexDefinition objects.
+func diffIndex(container string, code, db IndexDefinition) []ValidationResult {
+	var results []ValidationResult
+	indexField := "index:" + code.Name
+
+	if code.Type != db.Type {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     container,
+			Field:     indexField,
+			Message:   "Index type mismatch",
+			CodeValue: string(code.Type),
+			DBValue:   string(db.Type),
+		})
+	}
+	if !sortedSliceEqual(code.Columns, db.Columns) {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     container,
+			Field:     indexField,
+			Message:   "Index columns mismatch",
+			CodeValue: strings.Join(code.Columns, ","),
+			DBValue:   strings.Join(db.Columns, ","),
+		})
+	}
+
+	if code.Type == IndexTypeMTree && db.Type == IndexTypeMTree {
+		results = append(results, diffMTreeParams(container, code, db)...)
+	}
+	if code.Type == IndexTypeHNSW && db.Type == IndexTypeHNSW {
+		results = append(results, diffHnswParams(container, code, db)...)
+	}
+
+	return results
+}
+
+func diffMTreeParams(container string, code, db IndexDefinition) []ValidationResult {
+	var results []ValidationResult
+	indexField := "index:" + code.Name
+
+	if code.Dimension != db.Dimension {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     container,
+			Field:     indexField,
+			Message:   "MTREE index dimension mismatch",
+			CodeValue: strconv.Itoa(code.Dimension),
+			DBValue:   strconv.Itoa(db.Dimension),
+		})
+	}
+	if code.Distance != db.Distance {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     indexField,
+			Message:   "MTREE index distance metric mismatch",
+			CodeValue: string(code.Distance),
+			DBValue:   string(db.Distance),
+		})
+	}
+	if code.VectorType != db.VectorType {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     indexField,
+			Message:   "MTREE index vector type mismatch",
+			CodeValue: string(code.VectorType),
+			DBValue:   string(db.VectorType),
+		})
+	}
+	return results
+}
+
+func diffHnswParams(container string, code, db IndexDefinition) []ValidationResult {
+	var results []ValidationResult
+	indexField := "index:" + code.Name
+
+	if code.Dimension != db.Dimension {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     container,
+			Field:     indexField,
+			Message:   "HNSW index dimension mismatch",
+			CodeValue: strconv.Itoa(code.Dimension),
+			DBValue:   strconv.Itoa(db.Dimension),
+		})
+	}
+	if code.HnswDistance != db.HnswDistance {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     indexField,
+			Message:   "HNSW index distance metric mismatch",
+			CodeValue: string(code.HnswDistance),
+			DBValue:   string(db.HnswDistance),
+		})
+	}
+	if code.VectorType != db.VectorType {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     indexField,
+			Message:   "HNSW index vector type mismatch",
+			CodeValue: string(code.VectorType),
+			DBValue:   string(db.VectorType),
+		})
+	}
+	if code.EFC != db.EFC {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     indexField,
+			Message:   "HNSW index EFC mismatch",
+			CodeValue: strconv.Itoa(code.EFC),
+			DBValue:   strconv.Itoa(db.EFC),
+		})
+	}
+	if code.M != db.M {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     indexField,
+			Message:   "HNSW index M mismatch",
+			CodeValue: strconv.Itoa(code.M),
+			DBValue:   strconv.Itoa(db.M),
+		})
+	}
+	return results
+}
+
+// diffEvents enumerates missing / extra events between two event slices.
+func diffEvents(container string, code, db []EventDefinition) []ValidationResult {
+	var results []ValidationResult
+
+	codeByName := eventsByName(code)
+	dbByName := eventsByName(db)
+
+	for _, name := range sortedKeys(codeByName) {
+		if _, ok := dbByName[name]; !ok {
+			results = append(results, ValidationResult{
+				Severity:  SeverityError,
+				Table:     container,
+				Field:     "event:" + name,
+				Message:   "Event defined in code but missing from database",
+				CodeValue: "exists",
+				DBValue:   "missing",
+			})
+		}
+	}
+	for _, name := range sortedKeys(dbByName) {
+		if _, ok := codeByName[name]; !ok {
+			results = append(results, ValidationResult{
+				Severity:  SeverityWarning,
+				Table:     container,
+				Field:     "event:" + name,
+				Message:   "Event exists in database but not defined in code",
+				CodeValue: "missing",
+				DBValue:   "exists",
+			})
+		}
+	}
+
+	return results
+}
+
+// Structural helpers.
+
+// validateFieldList checks per-field invariants plus duplicate-name detection.
+func validateFieldList(container string, fields []FieldDefinition, allowEdgeReserved bool) []ValidationResult {
+	var results []ValidationResult
+	seen := make(map[string]struct{}, len(fields))
+
+	for _, f := range fields {
+		if _, dup := seen[f.Name]; dup && f.Name != "" {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    container,
+				Field:    f.Name,
+				Message:  "duplicate field name",
+			})
+			continue
+		}
+		seen[f.Name] = struct{}{}
+
+		if err := f.Validate(); err != nil {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    container,
+				Field:    f.Name,
+				Message:  err.Error(),
+			})
+			continue
+		}
+
+		if warn := f.ReservedWarning(allowEdgeReserved); warn != "" {
+			results = append(results, ValidationResult{
+				Severity: SeverityWarning,
+				Table:    container,
+				Field:    f.Name,
+				Message:  warn,
+			})
+		}
+	}
+
+	return results
+}
+
+// validateIndexList checks per-index invariants, duplicate-name detection, and
+// that every index column references a known field (when the table is
+// SCHEMAFULL and fields are supplied).
+func validateIndexList(container string, indexes []IndexDefinition, fields []FieldDefinition) []ValidationResult {
+	var results []ValidationResult
+	seen := make(map[string]struct{}, len(indexes))
+	fieldSet := make(map[string]struct{}, len(fields))
+	for _, f := range fields {
+		fieldSet[f.Name] = struct{}{}
+	}
+
+	for _, idx := range indexes {
+		if _, dup := seen[idx.Name]; dup && idx.Name != "" {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    container,
+				Field:    "index:" + idx.Name,
+				Message:  "duplicate index name",
+			})
+			continue
+		}
+		seen[idx.Name] = struct{}{}
+
+		if err := idx.Validate(); err != nil {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    container,
+				Field:    "index:" + idx.Name,
+				Message:  err.Error(),
+			})
+			continue
+		}
+
+		// Warn when an index references a column absent from the field list
+		// (fields may be empty for SCHEMALESS tables, so only warn when we
+		// have a non-empty field set to compare against).
+		if len(fieldSet) == 0 {
+			continue
+		}
+		for _, col := range idx.Columns {
+			if _, ok := fieldSet[col]; !ok {
+				results = append(results, ValidationResult{
+					Severity:  SeverityWarning,
+					Table:     container,
+					Field:     "index:" + idx.Name,
+					Message:   fmt.Sprintf("index references unknown column %q", col),
+					CodeValue: col,
+				})
+			}
+		}
+	}
+
+	return results
+}
+
+// validateEventList checks per-event invariants plus duplicate-name detection.
+func validateEventList(container string, events []EventDefinition) []ValidationResult {
+	var results []ValidationResult
+	seen := make(map[string]struct{}, len(events))
+
+	for _, e := range events {
+		if _, dup := seen[e.Name]; dup && e.Name != "" {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    container,
+				Field:    "event:" + e.Name,
+				Message:  "duplicate event name",
+			})
+			continue
+		}
+		seen[e.Name] = struct{}{}
+
+		if err := e.Validate(); err != nil {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    container,
+				Field:    "event:" + e.Name,
+				Message:  err.Error(),
+			})
+		}
+	}
+
+	return results
+}
+
+// validatePermissions surfaces malformed permission entries.
+func validatePermissions(container string, perms map[string]string) []ValidationResult {
+	var results []ValidationResult
+	if len(perms) == 0 {
+		return nil
+	}
+	allowed := map[string]struct{}{
+		"select": {},
+		"create": {},
+		"update": {},
+		"delete": {},
+	}
+	for _, action := range sortedKeysString(perms) {
+		expr := perms[action]
+		lower := strings.ToLower(action)
+		if _, ok := allowed[lower]; !ok {
+			results = append(results, ValidationResult{
+				Severity:  SeverityWarning,
+				Table:     container,
+				Field:     "permissions:" + action,
+				Message:   "unknown permission action",
+				CodeValue: action,
+			})
+		}
+		if strings.TrimSpace(expr) == "" {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    container,
+				Field:    "permissions:" + action,
+				Message:  "permission expression cannot be empty",
+			})
+		}
+	}
+	return results
+}
+
+// detectNameCollisions reports tables and edges that share a name.
+func detectNameCollisions(tables []TableDefinition, edges []EdgeDefinition) []ValidationResult {
+	var results []ValidationResult
+	tableNames := make(map[string]struct{}, len(tables))
+	for _, t := range tables {
+		tableNames[t.Name] = struct{}{}
+	}
+	for _, e := range edges {
+		if _, clash := tableNames[e.Name]; clash {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    e.Name,
+				Message:  "name conflict: edge and table share the same name",
+			})
+		}
+	}
+	return results
+}
+
+// detectRecordFieldTargets warns when a record-typed field references an
+// unknown table. The Python implementation does not perform this check, but
+// it is a natural extension of cross-schema validation.
+func detectRecordFieldTargets(tables []TableDefinition, edges []EdgeDefinition) []ValidationResult {
+	var results []ValidationResult
+	known := make(map[string]struct{}, len(tables)+len(edges))
+	for _, t := range tables {
+		known[t.Name] = struct{}{}
+	}
+	for _, e := range edges {
+		known[e.Name] = struct{}{}
+	}
+
+	walk := func(container string, fields []FieldDefinition) {
+		for _, f := range fields {
+			if f.Type != FieldTypeRecord {
+				continue
+			}
+			target := extractRecordTarget(f.Assertion)
+			if target == "" {
+				continue
+			}
+			if _, ok := known[target]; !ok {
+				results = append(results, ValidationResult{
+					Severity:  SeverityWarning,
+					Table:     container,
+					Field:     f.Name,
+					Message:   "record field references unknown table",
+					CodeValue: target,
+				})
+			}
+		}
+	}
+
+	for _, t := range tables {
+		walk(t.Name, t.Fields)
+	}
+	for _, e := range edges {
+		walk(e.Name, e.Fields)
+	}
+	return results
+}
+
+// detectEdgeTableReferences warns when a RELATION edge references a table
+// that is not registered with the schema.
+func detectEdgeTableReferences(tables []TableDefinition, edges []EdgeDefinition) []ValidationResult {
+	var results []ValidationResult
+	known := make(map[string]struct{}, len(tables))
+	for _, t := range tables {
+		known[t.Name] = struct{}{}
+	}
+	for _, e := range edges {
+		if e.Mode != EdgeModeRelation {
+			continue
+		}
+		if e.FromTable != "" {
+			if _, ok := known[e.FromTable]; !ok {
+				results = append(results, ValidationResult{
+					Severity:  SeverityWarning,
+					Table:     e.Name,
+					Message:   "edge from_table is not a registered table",
+					CodeValue: e.FromTable,
+				})
+			}
+		}
+		if e.ToTable != "" {
+			if _, ok := known[e.ToTable]; !ok {
+				results = append(results, ValidationResult{
+					Severity:  SeverityWarning,
+					Table:     e.Name,
+					Message:   "edge to_table is not a registered table",
+					CodeValue: e.ToTable,
+				})
+			}
+		}
+	}
+	return results
+}
+
+// detectDuplicateAccessNames reports access definitions that share a name.
+func detectDuplicateAccessNames(accesses []AccessDefinition) []ValidationResult {
+	var results []ValidationResult
+	seen := make(map[string]struct{}, len(accesses))
+	for _, a := range accesses {
+		if a.Name == "" {
+			continue
+		}
+		if _, dup := seen[a.Name]; dup {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    a.Name,
+				Message:  "duplicate access definition",
+			})
+			continue
+		}
+		seen[a.Name] = struct{}{}
+	}
+	return results
+}
+
+// Lookup helpers.
+
+func tablesByName(tables []TableDefinition) map[string]TableDefinition {
+	out := make(map[string]TableDefinition, len(tables))
+	for _, t := range tables {
+		out[t.Name] = t
+	}
+	return out
+}
+
+func edgesByName(edges []EdgeDefinition) map[string]EdgeDefinition {
+	out := make(map[string]EdgeDefinition, len(edges))
+	for _, e := range edges {
+		out[e.Name] = e
+	}
+	return out
+}
+
+func fieldsByName(fields []FieldDefinition) map[string]FieldDefinition {
+	out := make(map[string]FieldDefinition, len(fields))
+	for _, f := range fields {
+		out[f.Name] = f
+	}
+	return out
+}
+
+func indexesByName(indexes []IndexDefinition) map[string]IndexDefinition {
+	out := make(map[string]IndexDefinition, len(indexes))
+	for _, i := range indexes {
+		out[i.Name] = i
+	}
+	return out
+}
+
+func eventsByName(events []EventDefinition) map[string]EventDefinition {
+	out := make(map[string]EventDefinition, len(events))
+	for _, e := range events {
+		out[e.Name] = e
+	}
+	return out
+}
+
+// sortedKeys is generic over maps keyed by string.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedKeysString(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/surql/schema/validator_test.go
+++ b/pkg/surql/schema/validator_test.go
@@ -1,0 +1,1337 @@
+package schema
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// ValidationSeverity.
+
+func TestValidationSeverityValues(t *testing.T) {
+	if SeverityError != "error" {
+		t.Errorf("SeverityError = %q, want error", SeverityError)
+	}
+	if SeverityWarning != "warning" {
+		t.Errorf("SeverityWarning = %q, want warning", SeverityWarning)
+	}
+	if SeverityInfo != "info" {
+		t.Errorf("SeverityInfo = %q, want info", SeverityInfo)
+	}
+}
+
+func TestValidationSeverityIsValid(t *testing.T) {
+	valid := []ValidationSeverity{SeverityError, SeverityWarning, SeverityInfo}
+	for _, s := range valid {
+		if !s.IsValid() {
+			t.Errorf("IsValid(%q) = false, want true", s)
+		}
+	}
+	if ValidationSeverity("bogus").IsValid() {
+		t.Errorf("IsValid(bogus) = true, want false")
+	}
+}
+
+// ValidationResult.
+
+func TestValidationResultStringWithField(t *testing.T) {
+	r := ValidationResult{
+		Severity:  SeverityError,
+		Table:     "user",
+		Field:     "email",
+		Message:   "Field type mismatch",
+		CodeValue: "string",
+		DBValue:   "int",
+	}
+	s := r.String()
+	for _, want := range []string{"[ERROR]", "user.email", "Field type mismatch",
+		"code: string", "db: int"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("String missing %q: %s", want, s)
+		}
+	}
+}
+
+func TestValidationResultStringWithoutField(t *testing.T) {
+	r := ValidationResult{
+		Severity: SeverityWarning,
+		Table:    "post",
+		Message:  "Table exists in database but not defined in code",
+	}
+	s := r.String()
+	if !strings.Contains(s, "[WARNING]") {
+		t.Errorf("missing [WARNING]: %s", s)
+	}
+	if strings.Contains(s, "post.") {
+		t.Errorf("unexpected field separator: %s", s)
+	}
+}
+
+func TestValidationResultStringWithoutValues(t *testing.T) {
+	r := ValidationResult{Severity: SeverityInfo, Table: "user", Field: "name", Message: "Info"}
+	s := r.String()
+	if !strings.Contains(s, "[INFO]") {
+		t.Errorf("missing [INFO]: %s", s)
+	}
+	if strings.Contains(s, "code:") {
+		t.Errorf("unexpected code: in output: %s", s)
+	}
+}
+
+// ValidationReport.
+
+func TestNewValidationReport(t *testing.T) {
+	vr := NewValidationReport()
+	if vr == nil {
+		t.Fatal("NewValidationReport returned nil")
+	}
+	if vr.Len() != 0 {
+		t.Errorf("Len = %d, want 0", vr.Len())
+	}
+}
+
+func TestValidationReportAdd(t *testing.T) {
+	vr := NewValidationReport()
+	vr.Add(ValidationResult{Severity: SeverityError, Table: "user"})
+	if vr.Len() != 1 {
+		t.Errorf("Len = %d, want 1", vr.Len())
+	}
+}
+
+func TestValidationReportAddAll(t *testing.T) {
+	vr := NewValidationReport()
+	vr.AddAll([]ValidationResult{
+		{Severity: SeverityError, Table: "a"},
+		{Severity: SeverityWarning, Table: "b"},
+	})
+	if vr.Len() != 2 {
+		t.Errorf("Len = %d, want 2", vr.Len())
+	}
+}
+
+func TestValidationReportMerge(t *testing.T) {
+	a := NewValidationReport()
+	a.Add(ValidationResult{Severity: SeverityError, Table: "one"})
+	b := NewValidationReport()
+	b.Add(ValidationResult{Severity: SeverityWarning, Table: "two"})
+	a.Merge(b)
+	if a.Len() != 2 {
+		t.Errorf("Len = %d, want 2", a.Len())
+	}
+}
+
+func TestValidationReportMergeNilSafe(t *testing.T) {
+	var vr *ValidationReport
+	vr.Merge(NewValidationReport()) // should not panic
+	other := NewValidationReport()
+	other.Merge(nil) // should not panic
+	if other.Len() != 0 {
+		t.Errorf("Len = %d, want 0", other.Len())
+	}
+}
+
+func TestValidationReportErrorsWarningsInfos(t *testing.T) {
+	vr := NewValidationReport()
+	vr.Add(ValidationResult{Severity: SeverityError})
+	vr.Add(ValidationResult{Severity: SeverityError})
+	vr.Add(ValidationResult{Severity: SeverityWarning})
+	vr.Add(ValidationResult{Severity: SeverityInfo})
+
+	if got := len(vr.Errors()); got != 2 {
+		t.Errorf("Errors = %d, want 2", got)
+	}
+	if got := len(vr.Warnings()); got != 1 {
+		t.Errorf("Warnings = %d, want 1", got)
+	}
+	if got := len(vr.Infos()); got != 1 {
+		t.Errorf("Infos = %d, want 1", got)
+	}
+	if !vr.HasErrors() {
+		t.Error("HasErrors = false, want true")
+	}
+	if vr.IsValid() {
+		t.Error("IsValid = true, want false")
+	}
+}
+
+func TestValidationReportNilAccessors(t *testing.T) {
+	var vr *ValidationReport
+	if vr.Len() != 0 {
+		t.Error("Len should be 0 for nil report")
+	}
+	if vr.HasErrors() {
+		t.Error("HasErrors should be false for nil report")
+	}
+	if !vr.IsValid() {
+		t.Error("IsValid should be true for nil report")
+	}
+	if vr.Errors() != nil {
+		t.Error("Errors should return nil for nil report")
+	}
+	if vr.Warnings() != nil {
+		t.Error("Warnings should return nil for nil report")
+	}
+	if vr.Infos() != nil {
+		t.Error("Infos should return nil for nil report")
+	}
+}
+
+// ValidateSchema top-level.
+
+func TestValidateSchemaNilRegistry(t *testing.T) {
+	_, err := ValidateSchema(nil)
+	if err == nil {
+		t.Fatal("expected error for nil registry")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestValidateSchemaEmptyRegistry(t *testing.T) {
+	r := NewSchemaRegistry()
+	report, err := ValidateSchema(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Len() != 0 {
+		t.Errorf("expected empty report, got %d results", report.Len())
+	}
+}
+
+func TestValidateSchemaHappyPath(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user", WithFields(StringField("name"))))
+	_ = r.RegisterEdge(TypedEdge("likes", "user", "post"))
+	_ = r.RegisterTable(NewTable("post", WithFields(StringField("title"))))
+
+	report, err := ValidateSchema(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.HasErrors() {
+		t.Errorf("expected no errors; got %+v", report.Errors())
+	}
+}
+
+func TestValidateSchemaNameCollision(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("likes"))
+	_ = r.RegisterTable(NewTable("user"))
+	_ = r.RegisterTable(NewTable("post"))
+	_ = r.RegisterEdge(TypedEdge("likes", "user", "post"))
+
+	report, err := ValidateSchema(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for _, res := range report.Errors() {
+		if res.Table == "likes" && strings.Contains(res.Message, "name conflict") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected name conflict error; got %+v", report.Results)
+	}
+}
+
+func TestValidateSchemaEdgeReferencesUnknownTable(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user"))
+	_ = r.RegisterEdge(TypedEdge("likes", "user", "missing"))
+
+	report, _ := ValidateSchema(r)
+	found := false
+	for _, res := range report.Warnings() {
+		if strings.Contains(res.Message, "to_table") && res.CodeValue == "missing" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for unknown to_table; got %+v", report.Results)
+	}
+}
+
+func TestValidateSchemaRecordFieldUnknownTarget(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user", WithFields(
+		RecordField("favorite", "nonexistent"),
+	)))
+
+	report, _ := ValidateSchema(r)
+	found := false
+	for _, res := range report.Warnings() {
+		if res.Field == "favorite" && res.CodeValue == "nonexistent" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for unknown record target; got %+v", report.Results)
+	}
+}
+
+func TestValidateSchemaRecordFieldKnownTarget(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("post"))
+	_ = r.RegisterTable(NewTable("user", WithFields(RecordField("favorite", "post"))))
+
+	report, _ := ValidateSchema(r)
+	for _, res := range report.Warnings() {
+		if res.Field == "favorite" {
+			t.Errorf("unexpected warning for known record target: %+v", res)
+		}
+	}
+}
+
+func TestValidateSchemaDuplicateAccessNames(t *testing.T) {
+	r := NewSchemaRegistry()
+	acc := JwtAccess("api", JwtConfig{Key: "secret"})
+	report, _ := ValidateSchema(r, acc, acc)
+	found := false
+	for _, res := range report.Errors() {
+		if strings.Contains(res.Message, "duplicate access") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected duplicate access error; got %+v", report.Results)
+	}
+}
+
+// ValidateTable.
+
+func TestValidateTableEmptyName(t *testing.T) {
+	report := ValidateTable(TableDefinition{})
+	if !report.HasErrors() {
+		t.Error("expected error for empty name")
+	}
+}
+
+func TestValidateTableInvalidMode(t *testing.T) {
+	report := ValidateTable(TableDefinition{Name: "user", Mode: "FOO"})
+	if !report.HasErrors() {
+		t.Error("expected error for invalid mode")
+	}
+}
+
+func TestValidateTableValid(t *testing.T) {
+	report := ValidateTable(NewTable("user", WithFields(StringField("name"))))
+	if report.HasErrors() {
+		t.Errorf("unexpected errors: %+v", report.Errors())
+	}
+}
+
+func TestValidateTableDuplicateField(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithFields(StringField("name"), StringField("name")),
+	))
+	found := false
+	for _, res := range report.Errors() {
+		if res.Field == "name" && strings.Contains(res.Message, "duplicate") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected duplicate field error; got %+v", report.Results)
+	}
+}
+
+func TestValidateTableInvalidFieldName(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithFields(FieldDefinition{Name: "1invalid", Type: FieldTypeString}),
+	))
+	if !report.HasErrors() {
+		t.Error("expected error for invalid field name")
+	}
+}
+
+func TestValidateTableInvalidFieldType(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithFields(FieldDefinition{Name: "x", Type: "bogus"}),
+	))
+	if !report.HasErrors() {
+		t.Error("expected error for invalid field type")
+	}
+}
+
+func TestValidateTableDuplicateIndex(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithFields(StringField("name")),
+		WithIndexes(
+			NewIndex("idx", []string{"name"}, IndexTypeStandard),
+			NewIndex("idx", []string{"name"}, IndexTypeStandard),
+		),
+	))
+	found := false
+	for _, res := range report.Errors() {
+		if res.Field == "index:idx" && strings.Contains(res.Message, "duplicate") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected duplicate index error; got %+v", report.Results)
+	}
+}
+
+func TestValidateTableIndexUnknownColumn(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithFields(StringField("name")),
+		WithIndexes(NewIndex("idx", []string{"ghost"}, IndexTypeStandard)),
+	))
+	found := false
+	for _, res := range report.Warnings() {
+		if res.Field == "index:idx" && strings.Contains(res.Message, "unknown column") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected unknown column warning; got %+v", report.Results)
+	}
+}
+
+func TestValidateTableIndexUnknownColumnSchemalessNoWarning(t *testing.T) {
+	// A table with no fields declared skips the unknown-column check.
+	report := ValidateTable(NewTable("user",
+		WithMode(TableModeSchemaless),
+		WithIndexes(NewIndex("idx", []string{"name"}, IndexTypeStandard)),
+	))
+	for _, res := range report.Warnings() {
+		if strings.Contains(res.Message, "unknown column") {
+			t.Errorf("unexpected unknown-column warning for schemaless table: %+v", res)
+		}
+	}
+}
+
+func TestValidateTableInvalidIndex(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithIndexes(IndexDefinition{Name: "", Columns: []string{"x"}, Type: IndexTypeStandard}),
+	))
+	if !report.HasErrors() {
+		t.Error("expected error for unnamed index")
+	}
+}
+
+func TestValidateTableDuplicateEvent(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithEvents(
+			NewEvent("on_create", "$event = 'CREATE'", "SELECT 1"),
+			NewEvent("on_create", "$event = 'CREATE'", "SELECT 1"),
+		),
+	))
+	found := false
+	for _, res := range report.Errors() {
+		if res.Field == "event:on_create" && strings.Contains(res.Message, "duplicate") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected duplicate event error; got %+v", report.Results)
+	}
+}
+
+func TestValidateTableInvalidEvent(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithEvents(EventDefinition{Name: "evt", Condition: "", Action: ""}),
+	))
+	if !report.HasErrors() {
+		t.Error("expected error for empty event condition/action")
+	}
+}
+
+func TestValidateTableReservedFieldNameWarns(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithFields(StringField("select")),
+	))
+	// May or may not produce a reserved warning depending on the types
+	// package content, so we just ensure the validator does not crash and
+	// returns a ValidationReport.
+	_ = report
+}
+
+func TestValidateTablePermissions(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithFields(StringField("name")),
+		WithTablePermissions(map[string]string{"select": "true", "bogus": "true", "update": ""}),
+	))
+	warnings := report.Warnings()
+	if len(warnings) == 0 {
+		t.Errorf("expected permissions warnings; got %+v", report.Results)
+	}
+	hasEmptyErr := false
+	for _, res := range report.Errors() {
+		if strings.Contains(res.Message, "permission expression cannot be empty") {
+			hasEmptyErr = true
+		}
+	}
+	if !hasEmptyErr {
+		t.Error("expected error for empty permission expression")
+	}
+}
+
+// ValidateEdge.
+
+func TestValidateEdgeEmptyName(t *testing.T) {
+	report := ValidateEdge(EdgeDefinition{})
+	if !report.HasErrors() {
+		t.Error("expected error for empty edge name")
+	}
+}
+
+func TestValidateEdgeInvalidMode(t *testing.T) {
+	report := ValidateEdge(EdgeDefinition{Name: "likes", Mode: "BOGUS"})
+	if !report.HasErrors() {
+		t.Error("expected error for invalid edge mode")
+	}
+}
+
+func TestValidateEdgeRelationRequiresFromTo(t *testing.T) {
+	report := ValidateEdge(NewEdge("likes"))
+	errs := report.Errors()
+	gotFrom, gotTo := false, false
+	for _, res := range errs {
+		if strings.Contains(res.Message, "from_table") {
+			gotFrom = true
+		}
+		if strings.Contains(res.Message, "to_table") {
+			gotTo = true
+		}
+	}
+	if !gotFrom || !gotTo {
+		t.Errorf("expected from_table and to_table errors; got %+v", errs)
+	}
+}
+
+func TestValidateEdgeRelationValid(t *testing.T) {
+	report := ValidateEdge(TypedEdge("likes", "user", "post"))
+	if report.HasErrors() {
+		t.Errorf("unexpected errors: %+v", report.Errors())
+	}
+}
+
+func TestValidateEdgeAllowsInOutFields(t *testing.T) {
+	e := TypedEdge("likes", "user", "post",
+		WithEdgeFields(RecordField("in", "user"), RecordField("out", "post")),
+	)
+	report := ValidateEdge(e)
+	if report.HasErrors() {
+		t.Errorf("unexpected errors for in/out fields: %+v", report.Errors())
+	}
+}
+
+// ValidateAccess.
+
+func TestValidateAccessEmptyName(t *testing.T) {
+	report := ValidateAccess(AccessDefinition{})
+	if !report.HasErrors() {
+		t.Error("expected error for empty name")
+	}
+}
+
+func TestValidateAccessInvalidType(t *testing.T) {
+	report := ValidateAccess(AccessDefinition{Name: "a", Type: "BOGUS"})
+	if !report.HasErrors() {
+		t.Error("expected error for invalid type")
+	}
+}
+
+func TestValidateAccessJwtRequiresConfig(t *testing.T) {
+	report := ValidateAccess(AccessDefinition{Name: "a", Type: AccessTypeJWT})
+	if !report.HasErrors() {
+		t.Error("expected error for JWT without config")
+	}
+}
+
+func TestValidateAccessJwtRequiresKeyOrURL(t *testing.T) {
+	report := ValidateAccess(JwtAccess("a", JwtConfig{}))
+	if !report.HasErrors() {
+		t.Error("expected error for JWT without KEY or URL")
+	}
+}
+
+func TestValidateAccessJwtBothKeyAndURL(t *testing.T) {
+	report := ValidateAccess(JwtAccess("a", JwtConfig{Key: "x", URL: "http://y"}))
+	found := false
+	for _, res := range report.Warnings() {
+		if strings.Contains(res.Message, "both KEY and URL") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for both KEY and URL; got %+v", report.Results)
+	}
+}
+
+func TestValidateAccessRecordRequiresConfig(t *testing.T) {
+	report := ValidateAccess(AccessDefinition{Name: "a", Type: AccessTypeRecord})
+	if !report.HasErrors() {
+		t.Error("expected error for RECORD without config")
+	}
+}
+
+func TestValidateAccessRecordWarnsWithoutSignupSignin(t *testing.T) {
+	report := ValidateAccess(RecordAccess("a", RecordAccessConfig{}))
+	found := false
+	for _, res := range report.Warnings() {
+		if strings.Contains(res.Message, "SIGNUP") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected SIGNUP/SIGNIN warning; got %+v", report.Results)
+	}
+}
+
+func TestValidateAccessJwtWithRecordConfigWarns(t *testing.T) {
+	a := JwtAccess("a", JwtConfig{Key: "x"})
+	a.Record = &RecordAccessConfig{Signup: "SELECT 1"}
+	report := ValidateAccess(a)
+	found := false
+	for _, res := range report.Warnings() {
+		if strings.Contains(res.Message, "should not carry a record") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for JWT with record config; got %+v", report.Results)
+	}
+}
+
+func TestValidateAccessRecordWithJWTConfigWarns(t *testing.T) {
+	a := RecordAccess("a", RecordAccessConfig{Signup: "SELECT 1"})
+	a.JWT = &JwtConfig{Key: "x"}
+	report := ValidateAccess(a)
+	found := false
+	for _, res := range report.Warnings() {
+		if strings.Contains(res.Message, "should not carry a JWT") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for RECORD with JWT config; got %+v", report.Results)
+	}
+}
+
+// CompareSchemas (drift detection).
+
+func TestCompareSchemasIdentical(t *testing.T) {
+	a := []TableDefinition{NewTable("user", WithFields(StringField("name")))}
+	report := CompareSchemas(a, a, nil, nil)
+	if report.Len() != 0 {
+		t.Errorf("expected empty report, got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasMissingTable(t *testing.T) {
+	code := []TableDefinition{NewTable("user")}
+	report := CompareSchemas(code, nil, nil, nil)
+	if report.Len() != 1 {
+		t.Fatalf("expected 1 result, got %d", report.Len())
+	}
+	res := report.Results[0]
+	if res.Severity != SeverityError || res.Table != "user" ||
+		!strings.Contains(res.Message, "missing from database") {
+		t.Errorf("unexpected result: %+v", res)
+	}
+}
+
+func TestCompareSchemasMultipleMissingTables(t *testing.T) {
+	code := []TableDefinition{NewTable("user"), NewTable("post")}
+	report := CompareSchemas(code, nil, nil, nil)
+	names := map[string]bool{}
+	for _, r := range report.Errors() {
+		names[r.Table] = true
+	}
+	if !names["user"] || !names["post"] {
+		t.Errorf("expected user and post; got %v", names)
+	}
+}
+
+func TestCompareSchemasExtraTable(t *testing.T) {
+	db := []TableDefinition{NewTable("legacy")}
+	report := CompareSchemas(nil, db, nil, nil)
+	if report.Len() != 1 {
+		t.Fatalf("expected 1 result, got %d", report.Len())
+	}
+	if report.Results[0].Severity != SeverityWarning {
+		t.Errorf("expected WARNING, got %+v", report.Results[0])
+	}
+}
+
+func TestCompareSchemasTableModeMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("user", WithMode(TableModeSchemafull))}
+	db := []TableDefinition{NewTable("user", WithMode(TableModeSchemaless))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if strings.Contains(strings.ToLower(r.Message), "mode mismatch") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected mode mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasFieldTypeMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("user", WithFields(IntField("age")))}
+	db := []TableDefinition{NewTable("user", WithFields(StringField("age")))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if r.Field == "age" && strings.Contains(r.Message, "type mismatch") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected type mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasFieldMissing(t *testing.T) {
+	code := []TableDefinition{NewTable("user",
+		WithFields(StringField("name"), StringField("email")))}
+	db := []TableDefinition{NewTable("user", WithFields(StringField("name")))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if r.Field == "email" && strings.Contains(r.Message, "missing from database") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected missing email field; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasExtraField(t *testing.T) {
+	code := []TableDefinition{NewTable("user", WithFields(StringField("name")))}
+	db := []TableDefinition{NewTable("user",
+		WithFields(StringField("name"), StringField("legacy")))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if r.Field == "legacy" && strings.Contains(r.Message, "not defined in code") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected extra legacy field; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasFieldAssertionMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("user", WithFields(
+		StringField("email", WithAssertion("string::is::email($value)"))))}
+	db := []TableDefinition{NewTable("user", WithFields(
+		StringField("email", WithAssertion("$value != NONE"))))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if r.Field == "email" && strings.Contains(r.Message, "assertion") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected assertion mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasFieldDefaultMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("u", WithFields(StringField("n", WithDefault("'a'"))))}
+	db := []TableDefinition{NewTable("u", WithFields(StringField("n", WithDefault("'b'"))))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if r.Field == "n" && strings.Contains(r.Message, "default") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected default mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasFieldValueMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("u", WithFields(StringField("n", WithValue("'a'"))))}
+	db := []TableDefinition{NewTable("u", WithFields(StringField("n", WithValue("'b'"))))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if r.Field == "n" && strings.Contains(r.Message, "computed value") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected computed value mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasFieldReadonlyMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("u",
+		WithFields(StringField("n", WithReadOnly(true))))}
+	db := []TableDefinition{NewTable("u",
+		WithFields(StringField("n", WithReadOnly(false))))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Infos() {
+		if r.Field == "n" && strings.Contains(r.Message, "readonly") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected readonly flag info; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasFieldFlexibleMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("u",
+		WithFields(StringField("n", WithFlexible(true))))}
+	db := []TableDefinition{NewTable("u",
+		WithFields(StringField("n", WithFlexible(false))))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Infos() {
+		if r.Field == "n" && strings.Contains(r.Message, "flexible") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected flexible flag info; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasAssertionWhitespaceNormalized(t *testing.T) {
+	code := []TableDefinition{NewTable("u", WithFields(
+		StringField("n", WithAssertion("$value  !=  NONE"))))}
+	db := []TableDefinition{NewTable("u", WithFields(
+		StringField("n", WithAssertion("$value != NONE"))))}
+	report := CompareSchemas(code, db, nil, nil)
+	for _, r := range report.Warnings() {
+		if r.Field == "n" && strings.Contains(r.Message, "assertion") {
+			t.Errorf("unexpected assertion warning after normalization: %+v", r)
+		}
+	}
+}
+
+func TestCompareSchemasIndexMissing(t *testing.T) {
+	code := []TableDefinition{NewTable("u",
+		WithFields(StringField("email")),
+		WithIndexes(UniqueIndex("email_idx", []string{"email"})))}
+	db := []TableDefinition{NewTable("u",
+		WithFields(StringField("email")))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if r.Field == "index:email_idx" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected missing index error; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasIndexExtra(t *testing.T) {
+	code := []TableDefinition{NewTable("u", WithFields(StringField("email")))}
+	db := []TableDefinition{NewTable("u",
+		WithFields(StringField("email")),
+		WithIndexes(UniqueIndex("legacy_idx", []string{"email"})))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if r.Field == "index:legacy_idx" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected extra index warning; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasIndexTypeMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("u",
+		WithFields(StringField("email")),
+		WithIndexes(UniqueIndex("email_idx", []string{"email"})))}
+	db := []TableDefinition{NewTable("u",
+		WithFields(StringField("email")),
+		WithIndexes(NewIndex("email_idx", []string{"email"}, IndexTypeStandard)))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if strings.Contains(r.Message, "Index type mismatch") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected index type mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasIndexColumnsMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("u",
+		WithFields(StringField("a"), StringField("b")),
+		WithIndexes(NewIndex("idx", []string{"a", "b"}, IndexTypeStandard)))}
+	db := []TableDefinition{NewTable("u",
+		WithFields(StringField("a")),
+		WithIndexes(NewIndex("idx", []string{"a"}, IndexTypeStandard)))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if strings.Contains(r.Message, "columns mismatch") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected columns mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasIndexColumnsOrderInsensitive(t *testing.T) {
+	code := []TableDefinition{NewTable("u",
+		WithFields(StringField("a"), StringField("b")),
+		WithIndexes(NewIndex("idx", []string{"a", "b"}, IndexTypeStandard)))}
+	db := []TableDefinition{NewTable("u",
+		WithFields(StringField("a"), StringField("b")),
+		WithIndexes(NewIndex("idx", []string{"b", "a"}, IndexTypeStandard)))}
+	report := CompareSchemas(code, db, nil, nil)
+	for _, r := range report.Errors() {
+		if strings.Contains(r.Message, "columns mismatch") {
+			t.Errorf("unexpected columns mismatch with reordered slice: %+v", r)
+		}
+	}
+}
+
+func TestCompareSchemasMTreeDimensionMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(MTreeIndex("vec", "emb", 1024, MTreeIndexOptions{
+			Distance: MTreeDistanceCosine, VectorType: MTreeVectorF32})))}
+	db := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(MTreeIndex("vec", "emb", 768, MTreeIndexOptions{
+			Distance: MTreeDistanceCosine, VectorType: MTreeVectorF32})))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if strings.Contains(r.Message, "MTREE index dimension") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected MTREE dim mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasMTreeDistanceMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(MTreeIndex("vec", "emb", 64, MTreeIndexOptions{
+			Distance: MTreeDistanceCosine, VectorType: MTreeVectorF32})))}
+	db := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(MTreeIndex("vec", "emb", 64, MTreeIndexOptions{
+			Distance: MTreeDistanceEuclidean, VectorType: MTreeVectorF32})))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if strings.Contains(r.Message, "distance metric") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected distance mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasHnswDimensionMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(HnswIndex("vec", "emb", 1024, HnswIndexOptions{
+			Distance: HnswDistanceCosine, VectorType: MTreeVectorF32})))}
+	db := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(HnswIndex("vec", "emb", 768, HnswIndexOptions{
+			Distance: HnswDistanceCosine, VectorType: MTreeVectorF32})))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if strings.Contains(r.Message, "HNSW index dimension") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected HNSW dim mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasHnswEfcMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(HnswIndex("vec", "emb", 64, HnswIndexOptions{EFC: 100})))}
+	db := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(HnswIndex("vec", "emb", 64, HnswIndexOptions{EFC: 200})))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if strings.Contains(r.Message, "EFC") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected EFC mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasHnswMMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(HnswIndex("vec", "emb", 64, HnswIndexOptions{M: 16})))}
+	db := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(HnswIndex("vec", "emb", 64, HnswIndexOptions{M: 32})))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if strings.Contains(r.Message, "HNSW index M mismatch") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected M mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasEventsMissing(t *testing.T) {
+	code := []TableDefinition{NewTable("u",
+		WithEvents(NewEvent("on_create", "$event = 'CREATE'", "SELECT 1")))}
+	db := []TableDefinition{NewTable("u")}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if r.Field == "event:on_create" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected missing event; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasEventsExtra(t *testing.T) {
+	code := []TableDefinition{NewTable("u")}
+	db := []TableDefinition{NewTable("u",
+		WithEvents(NewEvent("legacy_evt", "$event = 'CREATE'", "SELECT 1")))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if r.Field == "event:legacy_evt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected extra event warning; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasEdgeMissing(t *testing.T) {
+	code := []EdgeDefinition{TypedEdge("likes", "user", "post")}
+	report := CompareSchemas(nil, nil, code, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if r.Table == "likes" && strings.Contains(r.Message, "missing from database") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected missing edge error; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasEdgeExtra(t *testing.T) {
+	db := []EdgeDefinition{TypedEdge("likes", "user", "post")}
+	report := CompareSchemas(nil, nil, nil, db)
+	found := false
+	for _, r := range report.Warnings() {
+		if r.Table == "likes" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected extra edge warning; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasEdgeModeMismatch(t *testing.T) {
+	code := []EdgeDefinition{TypedEdge("likes", "user", "post")}
+	db := []EdgeDefinition{NewEdge("likes", WithEdgeMode(EdgeModeSchemafull))}
+	report := CompareSchemas(nil, nil, code, db)
+	found := false
+	for _, r := range report.Errors() {
+		if strings.Contains(r.Message, "Edge mode mismatch") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected edge mode mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasEdgeFromToMismatch(t *testing.T) {
+	code := []EdgeDefinition{TypedEdge("likes", "user", "post")}
+	db := []EdgeDefinition{TypedEdge("likes", "user", "comment")}
+	report := CompareSchemas(nil, nil, code, db)
+	found := false
+	for _, r := range report.Errors() {
+		if strings.Contains(r.Message, "to_table") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected to_table mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasEdgeFieldMismatch(t *testing.T) {
+	code := []EdgeDefinition{TypedEdge("likes", "user", "post",
+		WithEdgeFields(IntField("weight")))}
+	db := []EdgeDefinition{TypedEdge("likes", "user", "post")}
+	report := CompareSchemas(nil, nil, code, db)
+	found := false
+	for _, r := range report.Errors() {
+		if r.Field == "weight" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected edge field missing; got %+v", report.Results)
+	}
+}
+
+// Utility functions.
+
+func sampleResults() []ValidationResult {
+	return []ValidationResult{
+		{Severity: SeverityError, Table: "user", Field: "email"},
+		{Severity: SeverityWarning, Table: "user", Field: "name"},
+		{Severity: SeverityInfo, Table: "user", Field: "age"},
+		{Severity: SeverityError, Table: "post", Field: "title"},
+	}
+}
+
+func TestFilterBySeverityError(t *testing.T) {
+	got := FilterBySeverity(sampleResults(), SeverityError)
+	if len(got) != 2 {
+		t.Errorf("got %d errors, want 2", len(got))
+	}
+}
+
+func TestFilterBySeverityWarning(t *testing.T) {
+	got := FilterBySeverity(sampleResults(), SeverityWarning)
+	if len(got) != 1 {
+		t.Errorf("got %d warnings, want 1", len(got))
+	}
+}
+
+func TestFilterBySeverityNoMatch(t *testing.T) {
+	got := FilterBySeverity([]ValidationResult{{Severity: SeverityError}}, SeverityInfo)
+	if len(got) != 0 {
+		t.Errorf("expected empty slice, got %d", len(got))
+	}
+}
+
+func TestFilterBySeverityEmpty(t *testing.T) {
+	got := FilterBySeverity(nil, SeverityError)
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestFilterErrors(t *testing.T) {
+	got := FilterErrors(sampleResults())
+	if len(got) != 2 {
+		t.Errorf("got %d, want 2", len(got))
+	}
+	for _, r := range got {
+		if r.Severity != SeverityError {
+			t.Errorf("unexpected severity: %v", r)
+		}
+	}
+}
+
+func TestFilterWarnings(t *testing.T) {
+	got := FilterWarnings(sampleResults())
+	if len(got) != 1 {
+		t.Errorf("got %d, want 1", len(got))
+	}
+}
+
+func TestFilterInfos(t *testing.T) {
+	got := FilterInfos(sampleResults())
+	if len(got) != 1 {
+		t.Errorf("got %d, want 1", len(got))
+	}
+}
+
+func TestGroupByTable(t *testing.T) {
+	grouped := GroupByTable(sampleResults())
+	if len(grouped["user"]) != 3 {
+		t.Errorf("user: got %d, want 3", len(grouped["user"]))
+	}
+	if len(grouped["post"]) != 1 {
+		t.Errorf("post: got %d, want 1", len(grouped["post"]))
+	}
+}
+
+func TestGroupByTableEmpty(t *testing.T) {
+	grouped := GroupByTable(nil)
+	if len(grouped) != 0 {
+		t.Errorf("expected empty, got %d keys", len(grouped))
+	}
+}
+
+func TestHasErrorsTrue(t *testing.T) {
+	if !HasErrors(sampleResults()) {
+		t.Error("HasErrors = false, want true")
+	}
+}
+
+func TestHasErrorsFalse(t *testing.T) {
+	results := []ValidationResult{
+		{Severity: SeverityWarning},
+		{Severity: SeverityInfo},
+	}
+	if HasErrors(results) {
+		t.Error("HasErrors = true, want false")
+	}
+}
+
+func TestHasErrorsEmpty(t *testing.T) {
+	if HasErrors(nil) {
+		t.Error("HasErrors(nil) = true, want false")
+	}
+}
+
+func TestFormatValidationReportEmpty(t *testing.T) {
+	s := FormatValidationReport(nil, false)
+	if !strings.Contains(s, "No schema validation issues") {
+		t.Errorf("unexpected empty report: %q", s)
+	}
+}
+
+func TestFormatValidationReportWithErrors(t *testing.T) {
+	s := FormatValidationReport(sampleResults(), false)
+	for _, want := range []string{"Schema Validation Report", "user", "post", "[!]", "[~]"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("report missing %q: %s", want, s)
+		}
+	}
+}
+
+func TestFormatValidationReportExcludesInfoByDefault(t *testing.T) {
+	results := []ValidationResult{{Severity: SeverityInfo, Table: "u", Message: "info"}}
+	s := FormatValidationReport(results, false)
+	if !strings.Contains(s, "No significant") {
+		t.Errorf("expected 'No significant' summary, got: %s", s)
+	}
+}
+
+func TestFormatValidationReportIncludesInfoWhenRequested(t *testing.T) {
+	results := []ValidationResult{{Severity: SeverityInfo, Table: "u", Message: "info"}}
+	s := FormatValidationReport(results, true)
+	if !strings.Contains(s, "u") || !strings.Contains(s, "[i]") {
+		t.Errorf("expected info marker in report, got: %s", s)
+	}
+}
+
+func TestGetValidationSummaryMixed(t *testing.T) {
+	summary := GetValidationSummary(sampleResults())
+	if summary.Total != 4 {
+		t.Errorf("Total = %d, want 4", summary.Total)
+	}
+	if summary.Errors != 2 {
+		t.Errorf("Errors = %d, want 2", summary.Errors)
+	}
+	if summary.Warnings != 1 {
+		t.Errorf("Warnings = %d, want 1", summary.Warnings)
+	}
+	if summary.Info != 1 {
+		t.Errorf("Info = %d, want 1", summary.Info)
+	}
+	if summary.TablesAffected != 2 {
+		t.Errorf("TablesAffected = %d, want 2", summary.TablesAffected)
+	}
+	if !summary.HasErrors {
+		t.Error("HasErrors = false, want true")
+	}
+}
+
+func TestGetValidationSummaryEmpty(t *testing.T) {
+	summary := GetValidationSummary(nil)
+	if summary.Total != 0 || summary.HasErrors {
+		t.Errorf("expected zero summary, got %+v", summary)
+	}
+}
+
+func TestGetValidationSummaryNoErrors(t *testing.T) {
+	summary := GetValidationSummary([]ValidationResult{{Severity: SeverityWarning}})
+	if summary.HasErrors {
+		t.Error("HasErrors = true, want false")
+	}
+}
+
+// normalizeExpression / extractRecordTarget helpers.
+
+func TestNormalizeExpression(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"  ", ""},
+		{"$value != NONE", "$value != NONE"},
+		{"$value  !=  NONE", "$value != NONE"},
+		{"\t$value\n!=\tNONE ", "$value != NONE"},
+	}
+	for _, c := range cases {
+		got := normalizeExpression(c.in)
+		if got != c.want {
+			t.Errorf("normalize(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestExtractRecordTarget(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{`$value.table = "post"`, "post"},
+		{`$value.table = 'post'`, "post"},
+		{`($value.table = "post") AND ($value != NONE)`, "post"},
+		{`$value != NONE`, ""},
+		{`$value.table =`, ""},
+	}
+	for _, c := range cases {
+		got := extractRecordTarget(c.in)
+		if got != c.want {
+			t.Errorf("extractRecordTarget(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSortedSliceEqual(t *testing.T) {
+	if !sortedSliceEqual([]string{"a", "b"}, []string{"b", "a"}) {
+		t.Error("expected equal sorted slices")
+	}
+	if sortedSliceEqual([]string{"a"}, []string{"a", "b"}) {
+		t.Error("unequal lengths must not match")
+	}
+	if sortedSliceEqual([]string{"a"}, []string{"b"}) {
+		t.Error("different elements must not match")
+	}
+	if !sortedSliceEqual(nil, nil) {
+		t.Error("nil/nil should match")
+	}
+}

--- a/pkg/surql/schema/validator_utils.go
+++ b/pkg/surql/schema/validator_utils.go
@@ -1,0 +1,206 @@
+package schema
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// FilterBySeverity returns the subset of results with the given severity.
+// The input slice is not mutated. A nil results slice returns nil.
+func FilterBySeverity(results []ValidationResult, severity ValidationSeverity) []ValidationResult {
+	if len(results) == 0 {
+		return nil
+	}
+	out := make([]ValidationResult, 0, len(results))
+	for _, r := range results {
+		if r.Severity == severity {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// FilterErrors returns only ERROR-severity results.
+func FilterErrors(results []ValidationResult) []ValidationResult {
+	return FilterBySeverity(results, SeverityError)
+}
+
+// FilterWarnings returns only WARNING-severity results.
+func FilterWarnings(results []ValidationResult) []ValidationResult {
+	return FilterBySeverity(results, SeverityWarning)
+}
+
+// FilterInfos returns only INFO-severity results.
+func FilterInfos(results []ValidationResult) []ValidationResult {
+	return FilterBySeverity(results, SeverityInfo)
+}
+
+// GroupByTable buckets results by their Table field. The returned map keys are
+// sortable by the caller; map ordering itself is not guaranteed.
+func GroupByTable(results []ValidationResult) map[string][]ValidationResult {
+	grouped := make(map[string][]ValidationResult)
+	for _, r := range results {
+		grouped[r.Table] = append(grouped[r.Table], r)
+	}
+	return grouped
+}
+
+// HasErrors reports whether any ERROR-severity result exists in results.
+func HasErrors(results []ValidationResult) bool {
+	for _, r := range results {
+		if r.Severity == SeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+// FormatValidationReport renders a human-readable schema report. When
+// includeInfo is false (the default in surql-py), INFO-severity findings are
+// omitted from the output.
+func FormatValidationReport(results []ValidationResult, includeInfo bool) string {
+	if len(results) == 0 {
+		return "No schema validation issues found."
+	}
+
+	filtered := results
+	if !includeInfo {
+		filtered = make([]ValidationResult, 0, len(results))
+		for _, r := range results {
+			if r.Severity != SeverityInfo {
+				filtered = append(filtered, r)
+			}
+		}
+	}
+
+	if len(filtered) == 0 {
+		return "No significant schema validation issues found."
+	}
+
+	grouped := GroupByTable(filtered)
+	errorCount := len(FilterErrors(filtered))
+	warningCount := len(FilterWarnings(filtered))
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Schema Validation Report: %d errors, %d warnings\n",
+		errorCount, warningCount)
+	b.WriteString(strings.Repeat("=", 60))
+
+	tableNames := make([]string, 0, len(grouped))
+	for k := range grouped {
+		tableNames = append(tableNames, k)
+	}
+	sort.Strings(tableNames)
+
+	for _, name := range tableNames {
+		b.WriteString("\n\n[")
+		b.WriteString(name)
+		b.WriteString("]")
+		for _, r := range grouped[name] {
+			b.WriteString("\n  ")
+			b.WriteString(severityIcon(r.Severity))
+			b.WriteString(" ")
+			b.WriteString(r.Message)
+			if r.Field != "" {
+				b.WriteString(".")
+				b.WriteString(r.Field)
+			}
+			if r.CodeValue != "" || r.DBValue != "" {
+				b.WriteString("\n      code: ")
+				b.WriteString(r.CodeValue)
+				b.WriteString(", db: ")
+				b.WriteString(r.DBValue)
+			}
+		}
+	}
+
+	return b.String()
+}
+
+// ValidationSummary aggregates counts across severity levels for quick
+// programmatic inspection (CLI JSON output, dashboards).
+type ValidationSummary struct {
+	Total          int  `json:"total"`
+	Errors         int  `json:"errors"`
+	Warnings       int  `json:"warnings"`
+	Info           int  `json:"info"`
+	TablesAffected int  `json:"tables_affected"`
+	HasErrors      bool `json:"has_errors"`
+}
+
+// GetValidationSummary returns a ValidationSummary for the provided results.
+func GetValidationSummary(results []ValidationResult) ValidationSummary {
+	return ValidationSummary{
+		Total:          len(results),
+		Errors:         len(FilterErrors(results)),
+		Warnings:       len(FilterWarnings(results)),
+		Info:           len(FilterInfos(results)),
+		TablesAffected: len(GroupByTable(results)),
+		HasErrors:      HasErrors(results),
+	}
+}
+
+// severityIcon returns a short ASCII badge for a severity level.
+func severityIcon(s ValidationSeverity) string {
+	switch s {
+	case SeverityError:
+		return "[!]"
+	case SeverityWarning:
+		return "[~]"
+	case SeverityInfo:
+		return "[i]"
+	}
+	return "[ ]"
+}
+
+// normalizeExpression collapses contiguous whitespace and trims the result for
+// comparing SurrealQL expression fragments (ASSERT, DEFAULT, VALUE). Returns
+// the empty string when the input is empty or only whitespace.
+func normalizeExpression(expr string) string {
+	return strings.Join(strings.Fields(expr), " ")
+}
+
+// extractRecordTarget pulls the target table name out of an assertion of the
+// form `$value.table = "name"` produced by RecordField. Returns the empty
+// string when no match is found (manual assertions are deliberately skipped to
+// avoid false positives).
+func extractRecordTarget(assertion string) string {
+	const prefix = "$value.table ="
+	idx := strings.Index(assertion, prefix)
+	if idx == -1 {
+		return ""
+	}
+	rest := strings.TrimSpace(assertion[idx+len(prefix):])
+	if rest == "" {
+		return ""
+	}
+	quote := rest[0]
+	if quote != '"' && quote != '\'' {
+		return ""
+	}
+	end := strings.IndexByte(rest[1:], quote)
+	if end == -1 {
+		return ""
+	}
+	return rest[1 : 1+end]
+}
+
+// sortedSliceEqual reports whether a and b contain the same strings, ignoring
+// their original order. Used by diffIndex so index column ordering differences
+// don't trigger false mismatches (matching surql-py behaviour).
+func sortedSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aa := append([]string(nil), a...)
+	bb := append([]string(nil), b...)
+	sort.Strings(aa)
+	sort.Strings(bb)
+	for i := range aa {
+		if aa[i] != bb[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Closes #15.

## Summary
Port surql-py/src/surql/schema/{validator,validator_utils}.py.

- **\`schema/validator.go\`**: \`ValidateSchema\`, \`ValidateTable\`, \`ValidateEdge\`, \`ValidateAccess\`, \`CompareSchemas\` + \`ValidationReport\` / \`ValidationResult\` / \`ValidationSeverity\` types.
- **\`schema/validator_utils.go\`**: \`FilterBySeverity/Errors/Warnings/Infos\`, \`GroupByTable\`, \`HasErrors\`, \`FormatValidationReport\`, \`GetValidationSummary\` + \`ValidationSummary\` struct.
- Cross-checks (name collisions, unknown record targets, unknown edge from/to, duplicate access) + per-definition structural checks (mode/type/fields/indexes/events/permissions/MTREE+HNSW) + \`CompareSchemas\` drift detection.

## Deviations
- Soft findings in \`ValidationReport\`; hard failures (nil registry) return \`surqlerrors.ErrValidation\`.
- \`ValidateSchema\` accepts variadic \`AccessDefinition\` (current registry only tracks tables/edges).
- Index columns compared order-insensitive (matches Python \`sorted()\`).
- Field expressions normalized (whitespace-collapsed) before comparison.

## Test plan
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./... -race\` — **101 validator tests green**
- [ ] CI green