### PR TITLE
feat(schema): port INFO parser

### DIFF
--- a/pkg/surql/schema/parser.go
+++ b/pkg/surql/schema/parser.go
@@ -1,0 +1,754 @@
+package schema
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// DatabaseInfo is the parsed shape of an INFO FOR DB response. Tables, Edges,
+// and Accesses are keyed by definition name. Edges are tables whose tb
+// definition includes TYPE RELATION; everything else is a regular table.
+type DatabaseInfo struct {
+	Tables   map[string]TableDefinition
+	Edges    map[string]EdgeDefinition
+	Accesses map[string]AccessDefinition
+}
+
+// ParseDBInfo parses a SurrealDB INFO FOR DB response into a DatabaseInfo.
+//
+// The accepted shape is the object map returned by SurrealDB (e.g. {"tb": {
+// "user": "DEFINE TABLE user SCHEMAFULL;", ... }, "ac": {...}}). Each value in
+// the inner maps is the DEFINE statement string for that object. Unparseable
+// entries are skipped silently, matching the Python behaviour which logs and
+// moves on.
+//
+// The returned DatabaseInfo always has non-nil maps, even when the input is
+// empty.
+func ParseDBInfo(info map[string]any) (DatabaseInfo, error) {
+	if info == nil {
+		return DatabaseInfo{
+			Tables:   map[string]TableDefinition{},
+			Edges:    map[string]EdgeDefinition{},
+			Accesses: map[string]AccessDefinition{},
+		}, nil
+	}
+
+	tables := map[string]TableDefinition{}
+	edges := map[string]EdgeDefinition{}
+	accesses := map[string]AccessDefinition{}
+
+	tbDict := extractStringMap(info, "tables", "tb")
+	for name, def := range tbDict {
+		if name == "" {
+			continue
+		}
+		if isEdgeDefinitionSource(def) {
+			if edge, err := parseEdgeFromDefinition(name, def); err == nil {
+				edges[name] = edge
+			}
+			continue
+		}
+		tables[name] = TableDefinition{
+			Name: name,
+			Mode: parseTableMode(def),
+		}
+	}
+
+	acDict := extractStringMap(info, "accesses", "ac")
+	for name, def := range acDict {
+		if name == "" {
+			continue
+		}
+		access, err := ParseAccess(name, def)
+		if err != nil {
+			continue
+		}
+		accesses[name] = access
+	}
+
+	return DatabaseInfo{
+		Tables:   tables,
+		Edges:    edges,
+		Accesses: accesses,
+	}, nil
+}
+
+// ParseTableInfo parses a SurrealDB INFO FOR TABLE response into a
+// TableDefinition. The tableName identifies the table (the INFO payload itself
+// does not carry it). Unknown or malformed fields/indexes/events are skipped.
+//
+// Returns an error wrapping ErrSchemaParse only for catastrophic failures
+// (currently: an empty name). Individual child parse failures are silent.
+func ParseTableInfo(tableName string, info map[string]any) (TableDefinition, error) {
+	if tableName == "" {
+		return TableDefinition{}, surqlerrors.New(surqlerrors.ErrSchemaParse,
+			"table name cannot be empty")
+	}
+
+	tb := stringAt(info, "tb")
+	mode := parseTableMode(tb)
+
+	fieldsDict := extractStringMap(info, "fields", "fd")
+	fields := parseFields(fieldsDict)
+
+	indexesDict := extractStringMap(info, "indexes", "ix")
+	indexes := parseIndexes(indexesDict)
+
+	eventsDict := extractStringMap(info, "events", "ev")
+	events := parseEvents(eventsDict)
+
+	return TableDefinition{
+		Name:    tableName,
+		Mode:    mode,
+		Fields:  fields,
+		Indexes: indexes,
+		Events:  events,
+	}, nil
+}
+
+// ParseEdgeInfo parses a SurrealDB INFO FOR TABLE response into an
+// EdgeDefinition. The edgeName identifies the edge. The tb definition (when
+// present) is consulted to extract RELATION / FROM / TO clauses.
+func ParseEdgeInfo(edgeName string, info map[string]any) (EdgeDefinition, error) {
+	if edgeName == "" {
+		return EdgeDefinition{}, surqlerrors.New(surqlerrors.ErrSchemaParse,
+			"edge name cannot be empty")
+	}
+
+	tb := stringAt(info, "tb")
+	edge, _ := parseEdgeFromDefinition(edgeName, tb)
+
+	fieldsDict := extractStringMap(info, "fields", "fd")
+	edge.Fields = parseFields(fieldsDict)
+
+	indexesDict := extractStringMap(info, "indexes", "ix")
+	edge.Indexes = parseIndexes(indexesDict)
+
+	eventsDict := extractStringMap(info, "events", "ev")
+	edge.Events = parseEvents(eventsDict)
+
+	return edge, nil
+}
+
+// ParseField parses a single DEFINE FIELD statement into a FieldDefinition.
+// Returns an error wrapping ErrSchemaParse when the definition string is empty.
+func ParseField(fieldName, definition string) (FieldDefinition, error) {
+	if fieldName == "" {
+		return FieldDefinition{}, surqlerrors.New(surqlerrors.ErrSchemaParse,
+			"field name cannot be empty")
+	}
+	if strings.TrimSpace(definition) == "" {
+		return FieldDefinition{}, surqlerrors.Newf(surqlerrors.ErrSchemaParse,
+			"field %q has empty definition", fieldName)
+	}
+	return FieldDefinition{
+		Name:      fieldName,
+		Type:      extractFieldType(definition),
+		Assertion: extractAssertion(definition),
+		Default:   extractDefault(definition),
+		Value:     extractValue(definition),
+		ReadOnly:  extractReadOnly(definition),
+		Flexible:  extractFlexible(definition),
+	}, nil
+}
+
+// ParseIndex parses a single DEFINE INDEX statement into an IndexDefinition.
+// Returns an error wrapping ErrSchemaParse when the definition string is empty.
+func ParseIndex(indexName, definition string) (IndexDefinition, error) {
+	if indexName == "" {
+		return IndexDefinition{}, surqlerrors.New(surqlerrors.ErrSchemaParse,
+			"index name cannot be empty")
+	}
+	if strings.TrimSpace(definition) == "" {
+		return IndexDefinition{}, surqlerrors.Newf(surqlerrors.ErrSchemaParse,
+			"index %q has empty definition", indexName)
+	}
+
+	columns := extractIndexColumns(definition)
+	if len(columns) == 0 {
+		columns = extractIndexFields(definition)
+	}
+
+	indexType := extractIndexType(definition)
+
+	idx := IndexDefinition{
+		Name:    indexName,
+		Columns: columns,
+		Type:    indexType,
+	}
+
+	switch indexType {
+	case IndexTypeMTree:
+		idx.Dimension = extractMtreeDimension(definition)
+		idx.Distance = extractMtreeDistance(definition)
+		idx.VectorType = extractVectorType(definition)
+	case IndexTypeHNSW:
+		idx.Dimension = extractMtreeDimension(definition)
+		idx.VectorType = extractVectorType(definition)
+		idx.HnswDistance = extractHnswDistance(definition)
+		idx.EFC = extractHnswEFC(definition)
+		idx.M = extractHnswM(definition)
+	}
+
+	return idx, nil
+}
+
+// ParseEvent parses a single DEFINE EVENT statement into an EventDefinition.
+// Returns an error wrapping ErrSchemaParse when the definition is empty or
+// when neither a WHEN clause nor a THEN clause can be located.
+func ParseEvent(eventName, definition string) (EventDefinition, error) {
+	if eventName == "" {
+		return EventDefinition{}, surqlerrors.New(surqlerrors.ErrSchemaParse,
+			"event name cannot be empty")
+	}
+	if strings.TrimSpace(definition) == "" {
+		return EventDefinition{}, surqlerrors.Newf(surqlerrors.ErrSchemaParse,
+			"event %q has empty definition", eventName)
+	}
+
+	condition := extractEventCondition(definition)
+	action := extractEventAction(definition)
+	if condition == "" || action == "" {
+		return EventDefinition{}, surqlerrors.Newf(surqlerrors.ErrSchemaParse,
+			"event %q missing WHEN or THEN clause", eventName)
+	}
+
+	return EventDefinition{
+		Name:      eventName,
+		Condition: condition,
+		Action:    action,
+	}, nil
+}
+
+// ParseAccess parses a single DEFINE ACCESS statement into an AccessDefinition.
+// Returns an error wrapping ErrSchemaParse when the definition is empty or
+// when the access type cannot be determined.
+func ParseAccess(accessName, definition string) (AccessDefinition, error) {
+	if accessName == "" {
+		return AccessDefinition{}, surqlerrors.New(surqlerrors.ErrSchemaParse,
+			"access name cannot be empty")
+	}
+	if strings.TrimSpace(definition) == "" {
+		return AccessDefinition{}, surqlerrors.Newf(surqlerrors.ErrSchemaParse,
+			"access %q has empty definition", accessName)
+	}
+
+	accessType := extractAccessType(definition)
+	if !accessType.IsValid() {
+		return AccessDefinition{}, surqlerrors.Newf(surqlerrors.ErrSchemaParse,
+			"access %q has unknown type", accessName)
+	}
+
+	ad := AccessDefinition{
+		Name:            accessName,
+		Type:            accessType,
+		DurationSession: extractAccessDuration(definition, "SESSION"),
+		DurationToken:   extractAccessDuration(definition, "TOKEN"),
+	}
+
+	switch accessType {
+	case AccessTypeJWT:
+		ad.JWT = &JwtConfig{
+			Algorithm: extractJwtAlgorithm(definition),
+			Key:       extractQuoted(definition, "KEY"),
+			URL:       extractQuoted(definition, "URL"),
+			Issuer:    extractJwtIssuer(definition),
+		}
+	case AccessTypeRecord:
+		ad.Record = &RecordAccessConfig{
+			Signup: extractParenClause(definition, "SIGNUP"),
+			Signin: extractParenClause(definition, "SIGNIN"),
+		}
+	}
+
+	return ad, nil
+}
+
+// -----------------------------------------------------------------------------
+// Internal helpers
+// -----------------------------------------------------------------------------
+
+func stringAt(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// extractStringMap returns the first map[string]string-shaped value found
+// under any of keys. The underlying value may be map[string]any or
+// map[string]string; each entry that is not a string is dropped.
+func extractStringMap(info map[string]any, keys ...string) map[string]string {
+	if info == nil {
+		return nil
+	}
+	for _, k := range keys {
+		raw, ok := info[k]
+		if !ok {
+			continue
+		}
+		switch typed := raw.(type) {
+		case map[string]string:
+			if len(typed) == 0 {
+				continue
+			}
+			out := make(map[string]string, len(typed))
+			for k2, v2 := range typed {
+				out[k2] = v2
+			}
+			return out
+		case map[string]any:
+			if len(typed) == 0 {
+				continue
+			}
+			out := make(map[string]string, len(typed))
+			for k2, v2 := range typed {
+				if s, ok := v2.(string); ok {
+					out[k2] = s
+				}
+			}
+			if len(out) > 0 {
+				return out
+			}
+		}
+	}
+	return nil
+}
+
+// parseTableMode recovers the TableMode from a DEFINE TABLE statement. The
+// default (matching surql-py) is SCHEMALESS.
+func parseTableMode(def string) TableMode {
+	if def == "" {
+		return TableModeSchemaless
+	}
+	up := strings.ToUpper(def)
+	switch {
+	case strings.Contains(up, "SCHEMAFULL"):
+		return TableModeSchemafull
+	case strings.Contains(up, "SCHEMALESS"):
+		return TableModeSchemaless
+	case strings.Contains(up, "DROP"):
+		return TableModeDrop
+	default:
+		return TableModeSchemaless
+	}
+}
+
+var reRelationFrom = regexp.MustCompile(`(?i)FROM\s+([A-Za-z_][A-Za-z0-9_]*)`)
+var reRelationTo = regexp.MustCompile(`(?i)\bTO\s+([A-Za-z_][A-Za-z0-9_]*)`)
+
+func isEdgeDefinitionSource(def string) bool {
+	return strings.Contains(strings.ToUpper(def), "TYPE RELATION")
+}
+
+func parseEdgeFromDefinition(name, def string) (EdgeDefinition, error) {
+	edge := EdgeDefinition{Name: name, Mode: EdgeModeRelation}
+	up := strings.ToUpper(def)
+
+	switch {
+	case strings.Contains(up, "TYPE RELATION"):
+		edge.Mode = EdgeModeRelation
+		if m := reRelationFrom.FindStringSubmatch(def); len(m) == 2 {
+			edge.FromTable = m[1]
+		}
+		if m := reRelationTo.FindStringSubmatch(def); len(m) == 2 {
+			edge.ToTable = m[1]
+		}
+	case strings.Contains(up, "SCHEMAFULL"):
+		edge.Mode = EdgeModeSchemafull
+	case strings.Contains(up, "SCHEMALESS"):
+		edge.Mode = EdgeModeSchemaless
+	}
+
+	return edge, nil
+}
+
+func parseFields(dict map[string]string) []FieldDefinition {
+	if len(dict) == 0 {
+		return nil
+	}
+	out := make([]FieldDefinition, 0, len(dict))
+	for name, def := range dict {
+		fd, err := ParseField(name, def)
+		if err != nil {
+			continue
+		}
+		out = append(out, fd)
+	}
+	return out
+}
+
+func parseIndexes(dict map[string]string) []IndexDefinition {
+	if len(dict) == 0 {
+		return nil
+	}
+	out := make([]IndexDefinition, 0, len(dict))
+	for name, def := range dict {
+		idx, err := ParseIndex(name, def)
+		if err != nil {
+			continue
+		}
+		out = append(out, idx)
+	}
+	return out
+}
+
+func parseEvents(dict map[string]string) []EventDefinition {
+	if len(dict) == 0 {
+		return nil
+	}
+	out := make([]EventDefinition, 0, len(dict))
+	for name, def := range dict {
+		ev, err := ParseEvent(name, def)
+		if err != nil {
+			continue
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+// -----------------------------------------------------------------------------
+// Field extraction helpers
+// -----------------------------------------------------------------------------
+
+var (
+	reFieldType      = regexp.MustCompile(`(?i)TYPE\s+([A-Za-z_]\w*)`)
+	reFieldAssert    = regexp.MustCompile(`(?is)ASSERT\s+(.+?)(?:\s+DEFAULT\b|\s+VALUE\b|\s+READONLY\b|\s+FLEXIBLE\b|\s+PERMISSIONS\b|\s*;|\s*$)`)
+	reFieldDefault   = regexp.MustCompile(`(?is)DEFAULT\s+(.+?)(?:\s+VALUE\b|\s+READONLY\b|\s+FLEXIBLE\b|\s+PERMISSIONS\b|\s+ASSERT\b|\s*;|\s*$)`)
+	reFieldValueExpr = regexp.MustCompile(`(?is)\bVALUE\s+(.+?)(?:\s+DEFAULT\b|\s+READONLY\b|\s+FLEXIBLE\b|\s+PERMISSIONS\b|\s+ASSERT\b|\s*;|\s*$)`)
+	reFieldReadOnly  = regexp.MustCompile(`(?i)\bREADONLY\b`)
+	reFieldFlexible  = regexp.MustCompile(`(?i)\bFLEXIBLE\b`)
+)
+
+var fieldTypeMap = map[string]FieldType{
+	"string":   FieldTypeString,
+	"int":      FieldTypeInt,
+	"float":    FieldTypeFloat,
+	"bool":     FieldTypeBool,
+	"datetime": FieldTypeDatetime,
+	"duration": FieldTypeDuration,
+	"decimal":  FieldTypeDecimal,
+	"number":   FieldTypeNumber,
+	"object":   FieldTypeObject,
+	"array":    FieldTypeArray,
+	"record":   FieldTypeRecord,
+	"geometry": FieldTypeGeometry,
+	"any":      FieldTypeAny,
+}
+
+func extractFieldType(def string) FieldType {
+	m := reFieldType.FindStringSubmatch(def)
+	if len(m) != 2 {
+		return FieldTypeAny
+	}
+	if ft, ok := fieldTypeMap[strings.ToLower(m[1])]; ok {
+		return ft
+	}
+	return FieldTypeAny
+}
+
+func extractAssertion(def string) string {
+	if m := reFieldAssert.FindStringSubmatch(def); len(m) == 2 {
+		return strings.TrimSpace(strings.TrimSuffix(m[1], ";"))
+	}
+	return ""
+}
+
+func extractDefault(def string) string {
+	if m := reFieldDefault.FindStringSubmatch(def); len(m) == 2 {
+		return strings.TrimSpace(strings.TrimSuffix(m[1], ";"))
+	}
+	return ""
+}
+
+func extractValue(def string) string {
+	if m := reFieldValueExpr.FindStringSubmatch(def); len(m) == 2 {
+		return strings.TrimSpace(strings.TrimSuffix(m[1], ";"))
+	}
+	return ""
+}
+
+func extractReadOnly(def string) bool {
+	return reFieldReadOnly.MatchString(def)
+}
+
+func extractFlexible(def string) bool {
+	return reFieldFlexible.MatchString(def)
+}
+
+// -----------------------------------------------------------------------------
+// Index extraction helpers
+// -----------------------------------------------------------------------------
+
+var (
+	reIndexColumns = regexp.MustCompile(`(?i)COLUMNS\s+([^;]+?)(?:\s+UNIQUE\b|\s+SEARCH\b|\s+HNSW\b|\s+MTREE\b|\s*;|\s*$)`)
+	reIndexFields  = regexp.MustCompile(`(?i)FIELDS\s+([^;]+?)(?:\s+UNIQUE\b|\s+SEARCH\b|\s+HNSW\b|\s+MTREE\b|\s*;|\s*$)`)
+	reIndexDim     = regexp.MustCompile(`(?i)DIMENSION\s+(\d+)`)
+	reIndexDist    = regexp.MustCompile(`(?i)(?:DIST|DISTANCE)\s+([A-Za-z_]\w*)`)
+	reVectorType   = regexp.MustCompile(`(?i)TYPE\s+([A-Za-z_]\w*)`)
+	reIndexEFC     = regexp.MustCompile(`(?i)\bEFC\s+(\d+)`)
+	reIndexM       = regexp.MustCompile(`(?i)\bM\s+(\d+)`)
+)
+
+func splitColumns(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func extractIndexColumns(def string) []string {
+	if m := reIndexColumns.FindStringSubmatch(def); len(m) == 2 {
+		return splitColumns(m[1])
+	}
+	return nil
+}
+
+func extractIndexFields(def string) []string {
+	if m := reIndexFields.FindStringSubmatch(def); len(m) == 2 {
+		return splitColumns(m[1])
+	}
+	return nil
+}
+
+func extractIndexType(def string) IndexType {
+	up := strings.ToUpper(def)
+	switch {
+	case strings.Contains(up, "UNIQUE"):
+		return IndexTypeUnique
+	case strings.Contains(up, "HNSW"):
+		return IndexTypeHNSW
+	case strings.Contains(up, "MTREE"):
+		return IndexTypeMTree
+	case strings.Contains(up, "SEARCH"):
+		return IndexTypeSearch
+	default:
+		return IndexTypeStandard
+	}
+}
+
+func extractMtreeDimension(def string) int {
+	if m := reIndexDim.FindStringSubmatch(def); len(m) == 2 {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+var mtreeDistanceMap = map[string]MTreeDistanceType{
+	"COSINE":    MTreeDistanceCosine,
+	"EUCLIDEAN": MTreeDistanceEuclidean,
+	"MANHATTAN": MTreeDistanceManhattan,
+	"MINKOWSKI": MTreeDistanceMinkowski,
+}
+
+func extractMtreeDistance(def string) MTreeDistanceType {
+	if m := reIndexDist.FindStringSubmatch(def); len(m) == 2 {
+		if d, ok := mtreeDistanceMap[strings.ToUpper(m[1])]; ok {
+			return d
+		}
+	}
+	return ""
+}
+
+var hnswDistanceMap = map[string]HnswDistanceType{
+	"CHEBYSHEV": HnswDistanceChebyshev,
+	"COSINE":    HnswDistanceCosine,
+	"EUCLIDEAN": HnswDistanceEuclidean,
+	"HAMMING":   HnswDistanceHamming,
+	"JACCARD":   HnswDistanceJaccard,
+	"MANHATTAN": HnswDistanceManhattan,
+	"MINKOWSKI": HnswDistanceMinkowski,
+	"PEARSON":   HnswDistancePearson,
+}
+
+func extractHnswDistance(def string) HnswDistanceType {
+	if m := reIndexDist.FindStringSubmatch(def); len(m) == 2 {
+		if d, ok := hnswDistanceMap[strings.ToUpper(m[1])]; ok {
+			return d
+		}
+	}
+	return ""
+}
+
+var vectorTypeMap = map[string]MTreeVectorType{
+	"F64": MTreeVectorF64,
+	"F32": MTreeVectorF32,
+	"I64": MTreeVectorI64,
+	"I32": MTreeVectorI32,
+	"I16": MTreeVectorI16,
+}
+
+func extractVectorType(def string) MTreeVectorType {
+	if m := reVectorType.FindStringSubmatch(def); len(m) == 2 {
+		if v, ok := vectorTypeMap[strings.ToUpper(m[1])]; ok {
+			return v
+		}
+	}
+	return ""
+}
+
+func extractHnswEFC(def string) int {
+	if m := reIndexEFC.FindStringSubmatch(def); len(m) == 2 {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+func extractHnswM(def string) int {
+	if m := reIndexM.FindStringSubmatch(def); len(m) == 2 {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+// -----------------------------------------------------------------------------
+// Event extraction helpers
+// -----------------------------------------------------------------------------
+
+var (
+	reEventWhen = regexp.MustCompile(`(?is)WHEN\s+(.+?)\s+THEN\b`)
+	reEventThen = regexp.MustCompile(`(?is)THEN\s+(?:\{\s*(.+?)\s*\}|(.+?))(?:\s*;|\s*$)`)
+)
+
+func extractEventCondition(def string) string {
+	if m := reEventWhen.FindStringSubmatch(def); len(m) == 2 {
+		return strings.TrimSpace(m[1])
+	}
+	return ""
+}
+
+func extractEventAction(def string) string {
+	m := reEventThen.FindStringSubmatch(def)
+	if len(m) < 3 {
+		return ""
+	}
+	action := m[1]
+	if action == "" {
+		action = m[2]
+	}
+	return strings.TrimSpace(action)
+}
+
+// -----------------------------------------------------------------------------
+// Access extraction helpers
+// -----------------------------------------------------------------------------
+
+var (
+	reAccessType    = regexp.MustCompile(`(?i)TYPE\s+(JWT|RECORD)\b`)
+	reJwtAlgorithm  = regexp.MustCompile(`(?i)ALGORITHM\s+([A-Za-z0-9]+)`)
+	reJwtIssuer     = regexp.MustCompile(`(?i)WITH\s+ISSUER\s+'([^']*)'`)
+	reDurationBlock = regexp.MustCompile(`(?is)DURATION\s+(.+?)(?:\s*;|\s*$)`)
+	rePerSession    = regexp.MustCompile(`(?i)FOR\s+SESSION\s+([^,;]+?)(?:\s*,|\s*$)`)
+	rePerToken      = regexp.MustCompile(`(?i)FOR\s+TOKEN\s+([^,;]+?)(?:\s*,|\s*$)`)
+)
+
+func extractAccessType(def string) AccessType {
+	if m := reAccessType.FindStringSubmatch(def); len(m) == 2 {
+		switch strings.ToUpper(m[1]) {
+		case "JWT":
+			return AccessTypeJWT
+		case "RECORD":
+			return AccessTypeRecord
+		}
+	}
+	return ""
+}
+
+func extractJwtAlgorithm(def string) string {
+	if m := reJwtAlgorithm.FindStringSubmatch(def); len(m) == 2 {
+		return strings.ToUpper(m[1])
+	}
+	return ""
+}
+
+func extractJwtIssuer(def string) string {
+	if m := reJwtIssuer.FindStringSubmatch(def); len(m) == 2 {
+		return m[1]
+	}
+	return ""
+}
+
+// extractQuoted pulls KEYWORD 'value' out of a DEFINE ACCESS body.
+func extractQuoted(def, keyword string) string {
+	re := regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(keyword) + `\s+'([^']*)'`)
+	if m := re.FindStringSubmatch(def); len(m) == 2 {
+		return m[1]
+	}
+	return ""
+}
+
+// extractParenClause pulls KEYWORD (expression) out of a DEFINE ACCESS body
+// handling nested parentheses.
+func extractParenClause(def, keyword string) string {
+	up := strings.ToUpper(def)
+	kw := strings.ToUpper(keyword)
+	idx := strings.Index(up, kw)
+	if idx < 0 {
+		return ""
+	}
+	rest := def[idx+len(kw):]
+	// skip whitespace
+	i := 0
+	for i < len(rest) && (rest[i] == ' ' || rest[i] == '\t' || rest[i] == '\n' || rest[i] == '\r') {
+		i++
+	}
+	if i >= len(rest) || rest[i] != '(' {
+		return ""
+	}
+	depth := 0
+	start := i + 1
+	for j := i; j < len(rest); j++ {
+		switch rest[j] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return strings.TrimSpace(rest[start:j])
+			}
+		}
+	}
+	return ""
+}
+
+func extractAccessDuration(def, clause string) string {
+	block := reDurationBlock.FindStringSubmatch(def)
+	if len(block) != 2 {
+		return ""
+	}
+	body := block[1]
+	var re *regexp.Regexp
+	switch strings.ToUpper(clause) {
+	case "SESSION":
+		re = rePerSession
+	case "TOKEN":
+		re = rePerToken
+	default:
+		return ""
+	}
+	// Append trailing comma so the regex's "," terminator matches a lone clause.
+	if m := re.FindStringSubmatch(body + ","); len(m) == 2 {
+		return strings.TrimSpace(m[1])
+	}
+	return ""
+}

--- a/pkg/surql/schema/parser_test.go
+++ b/pkg/surql/schema/parser_test.go
@@ -1,0 +1,852 @@
+package schema
+
+import (
+	stdErrors "errors"
+	"reflect"
+	"sort"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// ---------------------------------------------------------------------------
+// parseTableMode / ParseTableInfo
+// ---------------------------------------------------------------------------
+
+func TestParseTableMode_Schemafull(t *testing.T) {
+	if got := parseTableMode("DEFINE TABLE user SCHEMAFULL;"); got != TableModeSchemafull {
+		t.Errorf("parseTableMode(SCHEMAFULL) = %q, want %q", got, TableModeSchemafull)
+	}
+}
+
+func TestParseTableMode_Schemaless(t *testing.T) {
+	if got := parseTableMode("DEFINE TABLE user SCHEMALESS;"); got != TableModeSchemaless {
+		t.Errorf("parseTableMode(SCHEMALESS) = %q, want %q", got, TableModeSchemaless)
+	}
+}
+
+func TestParseTableMode_Drop(t *testing.T) {
+	if got := parseTableMode("DEFINE TABLE tmp DROP;"); got != TableModeDrop {
+		t.Errorf("parseTableMode(DROP) = %q, want %q", got, TableModeDrop)
+	}
+}
+
+func TestParseTableMode_EmptyDefaultsSchemaless(t *testing.T) {
+	if got := parseTableMode(""); got != TableModeSchemaless {
+		t.Errorf("parseTableMode(\"\") = %q, want %q", got, TableModeSchemaless)
+	}
+}
+
+func TestParseTableInfo_EmptyName(t *testing.T) {
+	_, err := ParseTableInfo("", nil)
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrSchemaParse) {
+		t.Errorf("expected ErrSchemaParse, got %v", err)
+	}
+}
+
+func TestParseTableInfo_MinimalSchemafull(t *testing.T) {
+	info := map[string]any{
+		"tb": "DEFINE TABLE user SCHEMAFULL;",
+	}
+	got, err := ParseTableInfo("user", info)
+	if err != nil {
+		t.Fatalf("ParseTableInfo: %v", err)
+	}
+	if got.Name != "user" {
+		t.Errorf("Name = %q, want user", got.Name)
+	}
+	if got.Mode != TableModeSchemafull {
+		t.Errorf("Mode = %q, want SCHEMAFULL", got.Mode)
+	}
+	if len(got.Fields) != 0 || len(got.Indexes) != 0 || len(got.Events) != 0 {
+		t.Errorf("expected empty children, got %+v", got)
+	}
+}
+
+func TestParseTableInfo_FullRoundTrip(t *testing.T) {
+	table := TableDefinition{
+		Name: "user",
+		Mode: TableModeSchemafull,
+		Fields: []FieldDefinition{
+			StringField("email", WithAssertion("string::is::email($value)")),
+			IntField("age", WithDefault("0")),
+			BoolField("admin", WithReadOnly(true)),
+		},
+		Indexes: []IndexDefinition{
+			UniqueIndex("email_idx", []string{"email"}),
+		},
+		Events: []EventDefinition{
+			NewEvent("on_create", "$event = 'CREATE'", "(CREATE log SET t = time::now())"),
+		},
+	}
+
+	// Build synthetic INFO response.
+	fd := map[string]any{}
+	for _, f := range table.Fields {
+		fd[f.Name] = f.ToSurql(table.Name)
+	}
+	ix := map[string]any{}
+	for _, i := range table.Indexes {
+		ix[i.Name] = i.ToSurql(table.Name)
+	}
+	ev := map[string]any{}
+	for _, e := range table.Events {
+		ev[e.Name] = e.ToSurql(table.Name)
+	}
+
+	info := map[string]any{
+		"tb":      table.ToSurql(),
+		"fields":  fd,
+		"indexes": ix,
+		"events":  ev,
+	}
+
+	parsed, err := ParseTableInfo("user", info)
+	if err != nil {
+		t.Fatalf("ParseTableInfo: %v", err)
+	}
+	if parsed.Mode != table.Mode {
+		t.Errorf("Mode = %q, want %q", parsed.Mode, table.Mode)
+	}
+	if len(parsed.Fields) != len(table.Fields) {
+		t.Errorf("expected %d fields, got %d", len(table.Fields), len(parsed.Fields))
+	}
+	if len(parsed.Indexes) != len(table.Indexes) {
+		t.Errorf("expected %d indexes, got %d", len(table.Indexes), len(parsed.Indexes))
+	}
+	if len(parsed.Events) != len(table.Events) {
+		t.Errorf("expected %d events, got %d", len(table.Events), len(parsed.Events))
+	}
+}
+
+func TestParseTableInfo_AliasKeys(t *testing.T) {
+	info := map[string]any{
+		"tb": "DEFINE TABLE user SCHEMAFULL;",
+		"fd": map[string]any{
+			"email": "DEFINE FIELD email ON TABLE user TYPE string;",
+		},
+		"ix": map[string]any{
+			"email_idx": "DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE;",
+		},
+		"ev": map[string]any{
+			"on_x": "DEFINE EVENT on_x ON TABLE user WHEN $event = 'CREATE' THEN (SELECT 1);",
+		},
+	}
+	got, err := ParseTableInfo("user", info)
+	if err != nil {
+		t.Fatalf("ParseTableInfo: %v", err)
+	}
+	if len(got.Fields) != 1 || got.Fields[0].Name != "email" {
+		t.Errorf("fields = %+v", got.Fields)
+	}
+	if len(got.Indexes) != 1 || got.Indexes[0].Name != "email_idx" {
+		t.Errorf("indexes = %+v", got.Indexes)
+	}
+	if len(got.Events) != 1 || got.Events[0].Name != "on_x" {
+		t.Errorf("events = %+v", got.Events)
+	}
+}
+
+func TestParseTableInfo_MapStringStringAccepted(t *testing.T) {
+	info := map[string]any{
+		"tb": "DEFINE TABLE user SCHEMAFULL;",
+		"fields": map[string]string{
+			"email": "DEFINE FIELD email ON TABLE user TYPE string;",
+		},
+	}
+	got, err := ParseTableInfo("user", info)
+	if err != nil {
+		t.Fatalf("ParseTableInfo: %v", err)
+	}
+	if len(got.Fields) != 1 {
+		t.Errorf("expected 1 field, got %d", len(got.Fields))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseField
+// ---------------------------------------------------------------------------
+
+func TestParseField_String(t *testing.T) {
+	fd, err := ParseField("email", "DEFINE FIELD email ON TABLE user TYPE string;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fd.Type != FieldTypeString {
+		t.Errorf("Type = %q, want string", fd.Type)
+	}
+}
+
+func TestParseField_AllTypes(t *testing.T) {
+	cases := map[string]FieldType{
+		"string":   FieldTypeString,
+		"int":      FieldTypeInt,
+		"float":    FieldTypeFloat,
+		"bool":     FieldTypeBool,
+		"datetime": FieldTypeDatetime,
+		"duration": FieldTypeDuration,
+		"decimal":  FieldTypeDecimal,
+		"number":   FieldTypeNumber,
+		"object":   FieldTypeObject,
+		"array":    FieldTypeArray,
+		"record":   FieldTypeRecord,
+		"geometry": FieldTypeGeometry,
+		"any":      FieldTypeAny,
+	}
+	for typeStr, want := range cases {
+		def := "DEFINE FIELD x ON TABLE user TYPE " + typeStr + ";"
+		fd, err := ParseField("x", def)
+		if err != nil {
+			t.Fatalf("ParseField(%s): %v", typeStr, err)
+		}
+		if fd.Type != want {
+			t.Errorf("Type for %q = %q, want %q", typeStr, fd.Type, want)
+		}
+	}
+}
+
+func TestParseField_UnknownTypeFallsBackToAny(t *testing.T) {
+	fd, err := ParseField("x", "DEFINE FIELD x ON TABLE user TYPE weirdthing;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fd.Type != FieldTypeAny {
+		t.Errorf("Type = %q, want any", fd.Type)
+	}
+}
+
+func TestParseField_WithAssertion(t *testing.T) {
+	fd, err := ParseField("email",
+		"DEFINE FIELD email ON TABLE user TYPE string ASSERT string::is::email($value);")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fd.Assertion != "string::is::email($value)" {
+		t.Errorf("Assertion = %q", fd.Assertion)
+	}
+}
+
+func TestParseField_WithDefault(t *testing.T) {
+	fd, err := ParseField("age",
+		"DEFINE FIELD age ON TABLE user TYPE int DEFAULT 18;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fd.Default != "18" {
+		t.Errorf("Default = %q, want 18", fd.Default)
+	}
+}
+
+func TestParseField_WithValue(t *testing.T) {
+	fd, err := ParseField("full",
+		"DEFINE FIELD full ON TABLE user TYPE string VALUE string::concat(first, last);")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fd.Value != "string::concat(first, last)" {
+		t.Errorf("Value = %q", fd.Value)
+	}
+}
+
+func TestParseField_ReadOnlyFlag(t *testing.T) {
+	fd, err := ParseField("id",
+		"DEFINE FIELD id ON TABLE user TYPE string READONLY;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fd.ReadOnly {
+		t.Error("ReadOnly should be true")
+	}
+}
+
+func TestParseField_FlexibleFlag(t *testing.T) {
+	fd, err := ParseField("meta",
+		"DEFINE FIELD meta ON TABLE user TYPE object FLEXIBLE;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fd.Flexible {
+		t.Error("Flexible should be true")
+	}
+}
+
+func TestParseField_EmptyDefinitionErrors(t *testing.T) {
+	_, err := ParseField("x", "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrSchemaParse) {
+		t.Errorf("expected ErrSchemaParse, got %v", err)
+	}
+}
+
+func TestParseField_EmptyNameErrors(t *testing.T) {
+	_, err := ParseField("", "DEFINE FIELD x ON TABLE user TYPE string;")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseField_RoundTrip(t *testing.T) {
+	orig := NewField("email", FieldTypeString,
+		WithAssertion("$value != NONE"),
+		WithDefault("'a@b.com'"),
+	)
+	def := orig.ToSurql("user")
+	parsed, err := ParseField("email", def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Type != orig.Type {
+		t.Errorf("Type: got %q, want %q", parsed.Type, orig.Type)
+	}
+	if parsed.Assertion != orig.Assertion {
+		t.Errorf("Assertion: got %q, want %q", parsed.Assertion, orig.Assertion)
+	}
+	if parsed.Default != orig.Default {
+		t.Errorf("Default: got %q, want %q", parsed.Default, orig.Default)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseIndex
+// ---------------------------------------------------------------------------
+
+func TestParseIndex_Standard(t *testing.T) {
+	idx, err := ParseIndex("ix1",
+		"DEFINE INDEX ix1 ON TABLE user COLUMNS email;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx.Type != IndexTypeStandard {
+		t.Errorf("Type = %q, want INDEX", idx.Type)
+	}
+	if !reflect.DeepEqual(idx.Columns, []string{"email"}) {
+		t.Errorf("Columns = %v", idx.Columns)
+	}
+}
+
+func TestParseIndex_Unique(t *testing.T) {
+	idx, err := ParseIndex("email_idx",
+		"DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx.Type != IndexTypeUnique {
+		t.Errorf("Type = %q, want UNIQUE", idx.Type)
+	}
+}
+
+func TestParseIndex_MultipleColumns(t *testing.T) {
+	idx, err := ParseIndex("composite",
+		"DEFINE INDEX composite ON TABLE user COLUMNS a, b, c UNIQUE;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"a", "b", "c"}
+	if !reflect.DeepEqual(idx.Columns, want) {
+		t.Errorf("Columns = %v, want %v", idx.Columns, want)
+	}
+}
+
+func TestParseIndex_FieldsAlias(t *testing.T) {
+	idx, err := ParseIndex("ix",
+		"DEFINE INDEX ix ON TABLE user FIELDS a, b;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(idx.Columns, []string{"a", "b"}) {
+		t.Errorf("Columns = %v", idx.Columns)
+	}
+}
+
+func TestParseIndex_MTree(t *testing.T) {
+	idx, err := ParseIndex("emb_idx",
+		"DEFINE INDEX emb_idx ON TABLE doc COLUMNS embedding MTREE DIMENSION 128 DIST COSINE TYPE F32;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx.Type != IndexTypeMTree {
+		t.Errorf("Type = %q, want MTREE", idx.Type)
+	}
+	if idx.Dimension != 128 {
+		t.Errorf("Dimension = %d", idx.Dimension)
+	}
+	if idx.Distance != MTreeDistanceCosine {
+		t.Errorf("Distance = %q", idx.Distance)
+	}
+	if idx.VectorType != MTreeVectorF32 {
+		t.Errorf("VectorType = %q", idx.VectorType)
+	}
+}
+
+func TestParseIndex_HNSW(t *testing.T) {
+	idx, err := ParseIndex("hnsw_idx",
+		"DEFINE INDEX hnsw_idx ON TABLE doc COLUMNS embedding HNSW DIMENSION 256 DIST EUCLIDEAN TYPE F64 EFC 200 M 16;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx.Type != IndexTypeHNSW {
+		t.Errorf("Type = %q, want HNSW", idx.Type)
+	}
+	if idx.Dimension != 256 {
+		t.Errorf("Dimension = %d", idx.Dimension)
+	}
+	if idx.HnswDistance != HnswDistanceEuclidean {
+		t.Errorf("HnswDistance = %q", idx.HnswDistance)
+	}
+	if idx.VectorType != MTreeVectorF64 {
+		t.Errorf("VectorType = %q", idx.VectorType)
+	}
+	if idx.EFC != 200 {
+		t.Errorf("EFC = %d", idx.EFC)
+	}
+	if idx.M != 16 {
+		t.Errorf("M = %d", idx.M)
+	}
+}
+
+func TestParseIndex_HNSWChebyshev(t *testing.T) {
+	idx, err := ParseIndex("h",
+		"DEFINE INDEX h ON TABLE x COLUMNS v HNSW DIMENSION 4 DIST CHEBYSHEV;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx.HnswDistance != HnswDistanceChebyshev {
+		t.Errorf("got %q", idx.HnswDistance)
+	}
+}
+
+func TestParseIndex_EmptyDefinition(t *testing.T) {
+	_, err := ParseIndex("x", "   ")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrSchemaParse) {
+		t.Errorf("expected ErrSchemaParse")
+	}
+}
+
+func TestParseIndex_RoundTripUnique(t *testing.T) {
+	orig := UniqueIndex("email_idx", []string{"email"})
+	parsed, err := ParseIndex(orig.Name, orig.ToSurql("user"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Type != orig.Type {
+		t.Errorf("Type: got %q, want %q", parsed.Type, orig.Type)
+	}
+	if !reflect.DeepEqual(parsed.Columns, orig.Columns) {
+		t.Errorf("Columns: got %v, want %v", parsed.Columns, orig.Columns)
+	}
+}
+
+func TestParseIndex_RoundTripMTree(t *testing.T) {
+	orig := MTreeIndex("emb_idx", "embedding", 64, MTreeIndexOptions{
+		Distance:   MTreeDistanceEuclidean,
+		VectorType: MTreeVectorF32,
+	})
+	parsed, err := ParseIndex(orig.Name, orig.ToSurql("doc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Type != IndexTypeMTree {
+		t.Errorf("Type = %q", parsed.Type)
+	}
+	if parsed.Dimension != 64 {
+		t.Errorf("Dimension = %d", parsed.Dimension)
+	}
+	if parsed.Distance != MTreeDistanceEuclidean {
+		t.Errorf("Distance = %q", parsed.Distance)
+	}
+	if parsed.VectorType != MTreeVectorF32 {
+		t.Errorf("VectorType = %q", parsed.VectorType)
+	}
+}
+
+func TestParseIndex_RoundTripHnsw(t *testing.T) {
+	orig := HnswIndex("h", "v", 128, HnswIndexOptions{
+		Distance:   HnswDistanceCosine,
+		VectorType: MTreeVectorF32,
+		EFC:        150,
+		M:          12,
+	})
+	parsed, err := ParseIndex(orig.Name, orig.ToSurql("doc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.HnswDistance != HnswDistanceCosine {
+		t.Errorf("HnswDistance = %q", parsed.HnswDistance)
+	}
+	if parsed.EFC != 150 || parsed.M != 12 {
+		t.Errorf("EFC=%d M=%d", parsed.EFC, parsed.M)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseEvent
+// ---------------------------------------------------------------------------
+
+func TestParseEvent_Simple(t *testing.T) {
+	ev, err := ParseEvent("on_create",
+		"DEFINE EVENT on_create ON TABLE user WHEN $event = 'CREATE' THEN (SELECT 1);")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.Condition != "$event = 'CREATE'" {
+		t.Errorf("Condition = %q", ev.Condition)
+	}
+	if ev.Action != "(SELECT 1)" {
+		t.Errorf("Action = %q", ev.Action)
+	}
+}
+
+func TestParseEvent_WithBraces(t *testing.T) {
+	ev, err := ParseEvent("on_create",
+		"DEFINE EVENT on_create ON TABLE user WHEN $event = 'CREATE' THEN { CREATE log SET type = 'create' };")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.Action != "CREATE log SET type = 'create'" {
+		t.Errorf("Action = %q", ev.Action)
+	}
+}
+
+func TestParseEvent_MissingWhen(t *testing.T) {
+	_, err := ParseEvent("bad",
+		"DEFINE EVENT bad ON TABLE user THEN (SELECT 1);")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrSchemaParse) {
+		t.Error("expected ErrSchemaParse")
+	}
+}
+
+func TestParseEvent_EmptyDefinition(t *testing.T) {
+	_, err := ParseEvent("x", "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseEvent_RoundTrip(t *testing.T) {
+	orig := NewEvent("trigger", "$before.count < $after.count", "(UPDATE stats SET incremented += 1)")
+	parsed, err := ParseEvent(orig.Name, orig.ToSurql("t"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Condition != orig.Condition {
+		t.Errorf("Condition: got %q, want %q", parsed.Condition, orig.Condition)
+	}
+	if parsed.Action != "(UPDATE stats SET incremented += 1)" {
+		t.Errorf("Action: got %q", parsed.Action)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseAccess
+// ---------------------------------------------------------------------------
+
+func TestParseAccess_JWTKey(t *testing.T) {
+	def := "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'secret';"
+	ad, err := ParseAccess("api", def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ad.Type != AccessTypeJWT {
+		t.Errorf("Type = %q", ad.Type)
+	}
+	if ad.JWT == nil {
+		t.Fatal("JWT config nil")
+	}
+	if ad.JWT.Algorithm != "HS256" {
+		t.Errorf("Algorithm = %q", ad.JWT.Algorithm)
+	}
+	if ad.JWT.Key != "secret" {
+		t.Errorf("Key = %q", ad.JWT.Key)
+	}
+}
+
+func TestParseAccess_JWTURLIssuer(t *testing.T) {
+	def := "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM RS256 URL 'https://jwks.example/.well-known/jwks.json' WITH ISSUER 'issuer-x';"
+	ad, err := ParseAccess("api", def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ad.JWT.URL != "https://jwks.example/.well-known/jwks.json" {
+		t.Errorf("URL = %q", ad.JWT.URL)
+	}
+	if ad.JWT.Issuer != "issuer-x" {
+		t.Errorf("Issuer = %q", ad.JWT.Issuer)
+	}
+	if ad.JWT.Algorithm != "RS256" {
+		t.Errorf("Algorithm = %q", ad.JWT.Algorithm)
+	}
+}
+
+func TestParseAccess_Record(t *testing.T) {
+	def := "DEFINE ACCESS user ON DATABASE TYPE RECORD SIGNUP (CREATE user SET email=$email) SIGNIN (SELECT * FROM user WHERE email=$email);"
+	ad, err := ParseAccess("user", def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ad.Type != AccessTypeRecord {
+		t.Errorf("Type = %q", ad.Type)
+	}
+	if ad.Record == nil {
+		t.Fatal("Record config nil")
+	}
+	if ad.Record.Signup != "CREATE user SET email=$email" {
+		t.Errorf("Signup = %q", ad.Record.Signup)
+	}
+	if ad.Record.Signin != "SELECT * FROM user WHERE email=$email" {
+		t.Errorf("Signin = %q", ad.Record.Signin)
+	}
+}
+
+func TestParseAccess_Duration(t *testing.T) {
+	def := "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'x' DURATION FOR SESSION 12h, FOR TOKEN 1h;"
+	ad, err := ParseAccess("api", def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ad.DurationSession != "12h" {
+		t.Errorf("DurationSession = %q", ad.DurationSession)
+	}
+	if ad.DurationToken != "1h" {
+		t.Errorf("DurationToken = %q", ad.DurationToken)
+	}
+}
+
+func TestParseAccess_UnknownTypeError(t *testing.T) {
+	def := "DEFINE ACCESS api ON DATABASE TYPE FOO;"
+	_, err := ParseAccess("api", def)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrSchemaParse) {
+		t.Errorf("expected ErrSchemaParse")
+	}
+}
+
+func TestParseAccess_EmptyDefError(t *testing.T) {
+	_, err := ParseAccess("api", "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseAccess_EmptyNameError(t *testing.T) {
+	_, err := ParseAccess("", "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'x';")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseAccess_JWTRoundTrip(t *testing.T) {
+	orig := JwtAccess("api", JwtConfig{Algorithm: "HS256", Key: "topsecret", Issuer: "me"})
+	parsed, err := ParseAccess(orig.Name, orig.ToSurql())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.JWT.Key != "topsecret" || parsed.JWT.Issuer != "me" || parsed.JWT.Algorithm != "HS256" {
+		t.Errorf("JWT round trip mismatch: %+v", parsed.JWT)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseDBInfo
+// ---------------------------------------------------------------------------
+
+func TestParseDBInfo_Nil(t *testing.T) {
+	got, err := ParseDBInfo(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Tables == nil || got.Edges == nil || got.Accesses == nil {
+		t.Error("expected non-nil maps")
+	}
+}
+
+func TestParseDBInfo_TablesAndEdges(t *testing.T) {
+	info := map[string]any{
+		"tb": map[string]any{
+			"user":    "DEFINE TABLE user SCHEMAFULL;",
+			"product": "DEFINE TABLE product SCHEMALESS;",
+			"likes":   "DEFINE TABLE likes TYPE RELATION FROM user TO product;",
+		},
+	}
+	got, err := ParseDBInfo(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Tables) != 2 {
+		t.Errorf("tables = %d, want 2", len(got.Tables))
+	}
+	if _, ok := got.Tables["user"]; !ok {
+		t.Error("missing user table")
+	}
+	if got.Tables["user"].Mode != TableModeSchemafull {
+		t.Errorf("user mode = %q", got.Tables["user"].Mode)
+	}
+	if got.Tables["product"].Mode != TableModeSchemaless {
+		t.Errorf("product mode = %q", got.Tables["product"].Mode)
+	}
+	if len(got.Edges) != 1 {
+		t.Errorf("edges = %d, want 1", len(got.Edges))
+	}
+	likes := got.Edges["likes"]
+	if likes.FromTable != "user" || likes.ToTable != "product" {
+		t.Errorf("likes from/to = %q/%q", likes.FromTable, likes.ToTable)
+	}
+	if likes.Mode != EdgeModeRelation {
+		t.Errorf("likes mode = %q", likes.Mode)
+	}
+}
+
+func TestParseDBInfo_Accesses(t *testing.T) {
+	info := map[string]any{
+		"ac": map[string]any{
+			"api":  "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'k';",
+			"user": "DEFINE ACCESS user ON DATABASE TYPE RECORD SIGNUP (CREATE user) SIGNIN (SELECT * FROM user);",
+		},
+	}
+	got, err := ParseDBInfo(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Accesses) != 2 {
+		t.Errorf("accesses = %d, want 2", len(got.Accesses))
+	}
+	names := []string{}
+	for n := range got.Accesses {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	if !reflect.DeepEqual(names, []string{"api", "user"}) {
+		t.Errorf("names = %v", names)
+	}
+}
+
+func TestParseDBInfo_SkipsMalformedAccess(t *testing.T) {
+	info := map[string]any{
+		"ac": map[string]any{
+			"good": "DEFINE ACCESS good ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'k';",
+			"bad":  "DEFINE ACCESS bad ON DATABASE TYPE UNKNOWN;",
+		},
+	}
+	got, err := ParseDBInfo(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got.Accesses["good"]; !ok {
+		t.Error("good access missing")
+	}
+	if _, ok := got.Accesses["bad"]; ok {
+		t.Error("bad access should have been skipped")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseEdgeInfo
+// ---------------------------------------------------------------------------
+
+func TestParseEdgeInfo_Relation(t *testing.T) {
+	info := map[string]any{
+		"tb": "DEFINE TABLE likes TYPE RELATION FROM user TO product;",
+		"fields": map[string]any{
+			"weight": "DEFINE FIELD weight ON TABLE likes TYPE float DEFAULT 1.0;",
+		},
+	}
+	edge, err := ParseEdgeInfo("likes", info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if edge.Mode != EdgeModeRelation {
+		t.Errorf("Mode = %q", edge.Mode)
+	}
+	if edge.FromTable != "user" || edge.ToTable != "product" {
+		t.Errorf("from/to = %q/%q", edge.FromTable, edge.ToTable)
+	}
+	if len(edge.Fields) != 1 || edge.Fields[0].Name != "weight" {
+		t.Errorf("fields = %+v", edge.Fields)
+	}
+}
+
+func TestParseEdgeInfo_EmptyName(t *testing.T) {
+	_, err := ParseEdgeInfo("", map[string]any{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractParenClause / helpers
+// ---------------------------------------------------------------------------
+
+func TestExtractParenClause_Nested(t *testing.T) {
+	def := "DEFINE ACCESS u ON DATABASE TYPE RECORD SIGNUP (CREATE user SET x = (1 + 2));"
+	got := extractParenClause(def, "SIGNUP")
+	want := "CREATE user SET x = (1 + 2)"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExtractParenClause_Missing(t *testing.T) {
+	def := "DEFINE ACCESS u ON DATABASE TYPE RECORD;"
+	if got := extractParenClause(def, "SIGNUP"); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestSplitColumns_TrimsEmpties(t *testing.T) {
+	got := splitColumns("a, ,b , c,")
+	want := []string{"a", "b", "c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestExtractStringMap_ReadsAlias(t *testing.T) {
+	in := map[string]any{
+		"fd": map[string]any{"x": "def"},
+	}
+	got := extractStringMap(in, "fields", "fd")
+	if got["x"] != "def" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestExtractStringMap_IgnoresNonString(t *testing.T) {
+	in := map[string]any{
+		"fd": map[string]any{"x": 123, "y": "ok"},
+	}
+	got := extractStringMap(in, "fd")
+	if _, ok := got["x"]; ok {
+		t.Error("numeric entry should be dropped")
+	}
+	if got["y"] != "ok" {
+		t.Errorf("y = %q", got["y"])
+	}
+}
+
+func TestStringAt_WrongTypeReturnsEmpty(t *testing.T) {
+	in := map[string]any{"tb": 5}
+	if got := stringAt(in, "tb"); got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestIsEdgeDefinitionSource(t *testing.T) {
+	if !isEdgeDefinitionSource("DEFINE TABLE likes TYPE RELATION FROM a TO b;") {
+		t.Error("should detect RELATION")
+	}
+	if isEdgeDefinitionSource("DEFINE TABLE user SCHEMAFULL;") {
+		t.Error("should not flag plain table")
+	}
+}


### PR DESCRIPTION
Closes #17.

## Summary
Port surql-py/src/surql/schema/parser.py. Parses SurrealDB \`INFO FOR DB\` / \`INFO FOR TABLE\` responses back into schema definitions.

- **\`schema/parser.go\`**:
  - \`ParseDBInfo(map[string]any) (DatabaseInfo, error)\` — splits \`tb\` entries into plain tables vs \`TYPE RELATION\` edges.
  - \`ParseTableInfo(name, info)\` / \`ParseEdgeInfo(name, info)\` — accepts both full (\`fields\`, \`indexes\`, \`events\`, \`accesses\`) and alias (\`fd\`, \`ix\`, \`ev\`, \`ac\`) keys, plus \`map[string]any\` and \`map[string]string\` inner shapes.
  - \`ParseField\` / \`ParseIndex\` / \`ParseEvent\` / \`ParseAccess\` helpers mirror the Python private helpers. MTREE / HNSW attrs parsed (distance, dimension, vector type, EFC, M). Nested-paren handling for SIGNUP / SIGNIN record-access clauses.
  - Errors wrap \`surqlerrors.ErrSchemaParse\`; unparseable child entries skipped silently to match Python.

## Test plan
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./... -race\` — **58 parser tests green** (round-trip, alias variants, 13 field types, MTREE+HNSW, JWT+Record access, nested parens, negative cases)
- [ ] CI green