### PR TITLE
feat(schema): port visualizer + themes

### DIFF
--- a/pkg/surql/schema/themes.go
+++ b/pkg/surql/schema/themes.go
@@ -1,0 +1,350 @@
+package schema
+
+import (
+	"sort"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// ColorScheme is the base color palette used across visualization themes.
+// All colors are hex color codes (e.g. "#6366f1").
+type ColorScheme struct {
+	Primary    string
+	Secondary  string
+	Background string
+	Text       string
+	Accent     string
+	Success    string
+	Warning    string
+	Error      string
+	Muted      string
+}
+
+// GraphVizTheme controls visual aspects of GraphViz DOT output: node and edge
+// styling, layout, and advanced features like gradients and clustering.
+type GraphVizTheme struct {
+	NodeColor    string
+	EdgeColor    string
+	BgColor      string // use "transparent" for none
+	FontName     string
+	NodeShape    string // e.g. "record", "box"
+	NodeStyle    string // e.g. "filled,rounded"
+	EdgeStyle    string // e.g. "solid", "dashed"
+	UseGradients bool
+	UseClusters  bool
+}
+
+// MermaidTheme controls Mermaid ER diagram appearance via Mermaid's theming
+// system. Supports both built-in themes and custom CSS variables.
+type MermaidTheme struct {
+	ThemeName      string // one of "default", "dark", "forest", "neutral", "base"
+	PrimaryColor   string
+	SecondaryColor string
+	UseCustomCSS   bool
+}
+
+// ASCIITheme controls ASCII diagram rendering including box drawing
+// characters, ANSI colors, and Unicode icons.
+type ASCIITheme struct {
+	BoxStyle    string // one of "single", "double", "rounded", "heavy"
+	UseUnicode  bool
+	UseColors   bool
+	UseIcons    bool
+	ColorScheme string
+}
+
+// Theme bundles a color scheme with format-specific configurations into a
+// coherent visual design.
+type Theme struct {
+	Name        string
+	Description string
+	Colors      ColorScheme
+	GraphViz    GraphVizTheme
+	Mermaid     MermaidTheme
+	ASCII       ASCIITheme
+}
+
+// ModernColorScheme returns the clean professional palette used by the
+// "modern" preset (indigo primary, pink secondary, slate backgrounds).
+func ModernColorScheme() ColorScheme {
+	return ColorScheme{
+		Primary:    "#6366f1",
+		Secondary:  "#ec4899",
+		Background: "#f8fafc",
+		Text:       "#0f172a",
+		Accent:     "#8b5cf6",
+		Success:    "#10b981",
+		Warning:    "#f59e0b",
+		Error:      "#ef4444",
+		Muted:      "#94a3b8",
+	}
+}
+
+// DarkColorScheme returns the dark-mode palette (violet primary, fuchsia
+// secondary, indigo-950 background).
+func DarkColorScheme() ColorScheme {
+	return ColorScheme{
+		Primary:    "#8b5cf6",
+		Secondary:  "#d946ef",
+		Background: "#1e1b4b",
+		Text:       "#f1f5f9",
+		Accent:     "#a78bfa",
+		Success:    "#34d399",
+		Warning:    "#fbbf24",
+		Error:      "#f87171",
+		Muted:      "#64748b",
+	}
+}
+
+// ForestColorScheme returns the nature-inspired palette (emerald primary,
+// teal secondary, green-50 background).
+func ForestColorScheme() ColorScheme {
+	return ColorScheme{
+		Primary:    "#10b981",
+		Secondary:  "#14b8a6",
+		Background: "#f0fdf4",
+		Text:       "#14532d",
+		Accent:     "#059669",
+		Success:    "#22c55e",
+		Warning:    "#f59e0b",
+		Error:      "#ef4444",
+		Muted:      "#86efac",
+	}
+}
+
+// MinimalColorScheme returns the grayscale palette used by the "minimal"
+// preset.
+func MinimalColorScheme() ColorScheme {
+	return ColorScheme{
+		Primary:    "#6b7280",
+		Secondary:  "#64748b",
+		Background: "#ffffff",
+		Text:       "#1f2937",
+		Accent:     "#9ca3af",
+		Success:    "#10b981",
+		Warning:    "#f59e0b",
+		Error:      "#ef4444",
+		Muted:      "#d1d5db",
+	}
+}
+
+// ModernGraphVizTheme returns the GraphViz styling for the "modern" preset.
+func ModernGraphVizTheme() GraphVizTheme {
+	return GraphVizTheme{
+		NodeColor:    "#6366f1",
+		EdgeColor:    "#64748b",
+		BgColor:      "transparent",
+		FontName:     "Arial",
+		NodeShape:    "record",
+		NodeStyle:    "filled,rounded",
+		EdgeStyle:    "solid",
+		UseGradients: true,
+		UseClusters:  false,
+	}
+}
+
+// DarkGraphVizTheme returns the GraphViz styling for the "dark" preset.
+func DarkGraphVizTheme() GraphVizTheme {
+	return GraphVizTheme{
+		NodeColor:    "#8b5cf6",
+		EdgeColor:    "#64748b",
+		BgColor:      "#1e1b4b",
+		FontName:     "Arial",
+		NodeShape:    "record",
+		NodeStyle:    "filled,rounded",
+		EdgeStyle:    "solid",
+		UseGradients: true,
+		UseClusters:  false,
+	}
+}
+
+// ForestGraphVizTheme returns the GraphViz styling for the "forest" preset.
+func ForestGraphVizTheme() GraphVizTheme {
+	return GraphVizTheme{
+		NodeColor:    "#10b981",
+		EdgeColor:    "#059669",
+		BgColor:      "transparent",
+		FontName:     "Arial",
+		NodeShape:    "record",
+		NodeStyle:    "filled,rounded",
+		EdgeStyle:    "solid",
+		UseGradients: true,
+		UseClusters:  false,
+	}
+}
+
+// MinimalGraphVizTheme returns the GraphViz styling for the "minimal" preset.
+func MinimalGraphVizTheme() GraphVizTheme {
+	return GraphVizTheme{
+		NodeColor:    "#6b7280",
+		EdgeColor:    "#9ca3af",
+		BgColor:      "transparent",
+		FontName:     "Arial",
+		NodeShape:    "record",
+		NodeStyle:    "filled",
+		EdgeStyle:    "solid",
+		UseGradients: false,
+		UseClusters:  false,
+	}
+}
+
+// ModernMermaidTheme returns the Mermaid styling for the "modern" preset.
+func ModernMermaidTheme() MermaidTheme {
+	return MermaidTheme{
+		ThemeName:      "default",
+		PrimaryColor:   "#6366f1",
+		SecondaryColor: "#ec4899",
+		UseCustomCSS:   true,
+	}
+}
+
+// DarkMermaidTheme returns the Mermaid styling for the "dark" preset.
+func DarkMermaidTheme() MermaidTheme {
+	return MermaidTheme{
+		ThemeName:      "dark",
+		PrimaryColor:   "#8b5cf6",
+		SecondaryColor: "#d946ef",
+		UseCustomCSS:   true,
+	}
+}
+
+// ForestMermaidTheme returns the Mermaid styling for the "forest" preset.
+func ForestMermaidTheme() MermaidTheme {
+	return MermaidTheme{
+		ThemeName:      "forest",
+		PrimaryColor:   "#10b981",
+		SecondaryColor: "#14b8a6",
+		UseCustomCSS:   true,
+	}
+}
+
+// MinimalMermaidTheme returns the Mermaid styling for the "minimal" preset.
+func MinimalMermaidTheme() MermaidTheme {
+	return MermaidTheme{
+		ThemeName:      "neutral",
+		PrimaryColor:   "#6b7280",
+		SecondaryColor: "#64748b",
+		UseCustomCSS:   true,
+	}
+}
+
+// ModernASCIITheme returns the ASCII styling for the "modern" preset
+// (rounded unicode boxes, colors, and icons enabled).
+func ModernASCIITheme() ASCIITheme {
+	return ASCIITheme{
+		BoxStyle:    "rounded",
+		UseUnicode:  true,
+		UseColors:   true,
+		UseIcons:    true,
+		ColorScheme: "default",
+	}
+}
+
+// DarkASCIITheme returns the ASCII styling for the "dark" preset.
+func DarkASCIITheme() ASCIITheme {
+	return ASCIITheme{
+		BoxStyle:    "rounded",
+		UseUnicode:  true,
+		UseColors:   true,
+		UseIcons:    true,
+		ColorScheme: "dark",
+	}
+}
+
+// ForestASCIITheme returns the ASCII styling for the "forest" preset.
+func ForestASCIITheme() ASCIITheme {
+	return ASCIITheme{
+		BoxStyle:    "rounded",
+		UseUnicode:  true,
+		UseColors:   true,
+		UseIcons:    true,
+		ColorScheme: "forest",
+	}
+}
+
+// MinimalASCIITheme returns the ASCII styling for the "minimal" preset
+// (single-line boxes, no colors, no icons).
+func MinimalASCIITheme() ASCIITheme {
+	return ASCIITheme{
+		BoxStyle:    "single",
+		UseUnicode:  true,
+		UseColors:   false,
+		UseIcons:    false,
+		ColorScheme: "minimal",
+	}
+}
+
+// ModernTheme returns the "modern" bundled theme.
+func ModernTheme() Theme {
+	return Theme{
+		Name:        "modern",
+		Description: "Clean, professional design with indigo and pink accents",
+		Colors:      ModernColorScheme(),
+		GraphViz:    ModernGraphVizTheme(),
+		Mermaid:     ModernMermaidTheme(),
+		ASCII:       ModernASCIITheme(),
+	}
+}
+
+// DarkTheme returns the "dark" bundled theme.
+func DarkTheme() Theme {
+	return Theme{
+		Name:        "dark",
+		Description: "Dark background theme with violet and fuchsia for dark mode environments",
+		Colors:      DarkColorScheme(),
+		GraphViz:    DarkGraphVizTheme(),
+		Mermaid:     DarkMermaidTheme(),
+		ASCII:       DarkASCIITheme(),
+	}
+}
+
+// ForestTheme returns the "forest" bundled theme.
+func ForestTheme() Theme {
+	return Theme{
+		Name:        "forest",
+		Description: "Nature-inspired theme with emerald and teal on light green background",
+		Colors:      ForestColorScheme(),
+		GraphViz:    ForestGraphVizTheme(),
+		Mermaid:     ForestMermaidTheme(),
+		ASCII:       ForestASCIITheme(),
+	}
+}
+
+// MinimalTheme returns the "minimal" bundled theme.
+func MinimalTheme() Theme {
+	return Theme{
+		Name:        "minimal",
+		Description: "Minimalist grayscale theme with subtle styling",
+		Colors:      MinimalColorScheme(),
+		GraphViz:    MinimalGraphVizTheme(),
+		Mermaid:     MinimalMermaidTheme(),
+		ASCII:       MinimalASCIITheme(),
+	}
+}
+
+// GetTheme returns a preset theme by name. Recognised names are "modern",
+// "dark", "forest", and "minimal". Unknown names return a wrapped
+// ErrValidation.
+func GetTheme(name string) (Theme, error) {
+	switch name {
+	case "modern":
+		return ModernTheme(), nil
+	case "dark":
+		return DarkTheme(), nil
+	case "forest":
+		return ForestTheme(), nil
+	case "minimal":
+		return MinimalTheme(), nil
+	}
+	available := ListThemes()
+	return Theme{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+		"unknown theme %q. Available themes: %v", name, available)
+}
+
+// ListThemes returns the names of every built-in preset, sorted
+// alphabetically.
+func ListThemes() []string {
+	names := []string{"dark", "forest", "minimal", "modern"}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/surql/schema/utils.go
+++ b/pkg/surql/schema/utils.go
@@ -1,0 +1,219 @@
+package schema
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ansiEscapePattern matches ANSI CSI escape sequences so that display-width
+// calculations ignore color codes.
+var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// displayWidth returns the approximate terminal column width of text,
+// stripping ANSI escape codes and counting East Asian Wide / Fullwidth
+// characters as two columns. Emoji fall into the Wide category on most
+// terminals.
+func displayWidth(text string) int {
+	stripped := ansiEscapePattern.ReplaceAllString(text, "")
+	width := 0
+	for _, r := range stripped {
+		if r < 0x20 {
+			continue
+		}
+		if isWideRune(r) {
+			width += 2
+			continue
+		}
+		width++
+	}
+	return width
+}
+
+// isWideRune reports whether r occupies two terminal columns. Implemented as
+// a conservative range table covering the CJK, Fullwidth, emoji, and
+// Miscellaneous Symbols and Pictographs blocks used by the emoji icons
+// produced by the visualizer.
+func isWideRune(r rune) bool {
+	if r < 0x1100 {
+		return false
+	}
+	switch {
+	case r >= 0x1100 && r <= 0x115F: // Hangul Jamo
+		return true
+	case r >= 0x2E80 && r <= 0x303E: // CJK Radicals Supplement, Kangxi
+		return true
+	case r >= 0x3041 && r <= 0x33FF: // Hiragana through CJK Compatibility
+		return true
+	case r >= 0x3400 && r <= 0x4DBF: // CJK Unified Ideographs Extension A
+		return true
+	case r >= 0x4E00 && r <= 0x9FFF: // CJK Unified Ideographs
+		return true
+	case r >= 0xA000 && r <= 0xA4CF: // Yi Syllables
+		return true
+	case r >= 0xAC00 && r <= 0xD7A3: // Hangul Syllables
+		return true
+	case r >= 0xF900 && r <= 0xFAFF: // CJK Compatibility Ideographs
+		return true
+	case r >= 0xFE30 && r <= 0xFE4F: // CJK Compatibility Forms
+		return true
+	case r >= 0xFF00 && r <= 0xFF60: // Fullwidth Forms
+		return true
+	case r >= 0xFFE0 && r <= 0xFFE6: // Fullwidth Signs
+		return true
+	case r >= 0x1F300 && r <= 0x1F64F: // Misc Symbols and Pictographs + Emoticons
+		return true
+	case r >= 0x1F680 && r <= 0x1F6FF: // Transport and Map Symbols
+		return true
+	case r >= 0x1F900 && r <= 0x1F9FF: // Supplemental Symbols and Pictographs
+		return true
+	case r >= 0x1FA70 && r <= 0x1FAFF: // Symbols and Pictographs Extended-A
+		return true
+	case r >= 0x20000 && r <= 0x2FFFD: // CJK Unified Ideographs Extension B-F
+		return true
+	case r >= 0x30000 && r <= 0x3FFFD: // CJK Unified Ideographs Extension G
+		return true
+	}
+	return false
+}
+
+// fieldConstraint returns the constraint suffix (PK, FK, UK) that should be
+// displayed next to a field in diagrams. An empty string means the field has
+// no constraint.
+//
+// The rules mirror surql-py: "id" is always PK; a field that appears alone in
+// a unique index is UK; a FieldTypeRecord field is FK.
+func fieldConstraint(fieldName string, table TableDefinition) string {
+	if fieldName == "id" {
+		return "PK"
+	}
+	for _, idx := range table.Indexes {
+		if idx.Type != IndexTypeUnique {
+			continue
+		}
+		for _, col := range idx.Columns {
+			if col == fieldName {
+				return "UK"
+			}
+		}
+	}
+	for _, f := range table.Fields {
+		if f.Name == fieldName && f.Type == FieldTypeRecord {
+			return "FK"
+		}
+	}
+	return ""
+}
+
+// fieldTypeString returns the user-facing string form of a FieldType
+// (currently the enum value as a lowercase keyword).
+func fieldTypeString(t FieldType) string {
+	return string(t)
+}
+
+// centerPad returns text padded with spaces so the visible display-width is
+// width. Padding is split to match Python's str.center, which places the
+// extra space on the LEFT when padding is odd. Text wider than width is
+// returned unchanged.
+func centerPad(text string, width int) (left, right int) {
+	visible := displayWidth(text)
+	if visible >= width {
+		return 0, 0
+	}
+	padding := width - visible
+	right = padding / 2
+	left = padding - right
+	return left, right
+}
+
+// boxChars returns the box drawing characters to use for the supplied ASCII
+// theme. When the theme is the zero value or has UseUnicode disabled, it
+// returns plain ASCII characters.
+func boxChars(theme ASCIITheme) map[string]string {
+	if !theme.UseUnicode {
+		return map[string]string{
+			"tl": "+", "tr": "+", "bl": "+", "br": "+",
+			"h": "-", "v": "|", "ml": "+", "mr": "+",
+		}
+	}
+	switch theme.BoxStyle {
+	case "double":
+		return map[string]string{
+			"tl": "╔", "tr": "╗", "bl": "╚", "br": "╝",
+			"h": "═", "v": "║", "ml": "╠", "mr": "╣",
+		}
+	case "rounded":
+		return map[string]string{
+			"tl": "╭", "tr": "╮", "bl": "╰", "br": "╯",
+			"h": "─", "v": "│", "ml": "├", "mr": "┤",
+		}
+	case "heavy":
+		return map[string]string{
+			"tl": "┏", "tr": "┓", "bl": "┗", "br": "┛",
+			"h": "━", "v": "┃", "ml": "┣", "mr": "┫",
+		}
+	default: // "single" (and anything unknown)
+		return map[string]string{
+			"tl": "┌", "tr": "┐", "bl": "└", "br": "┘",
+			"h": "─", "v": "│", "ml": "├", "mr": "┤",
+		}
+	}
+}
+
+// ansi color codes used when ASCIITheme.UseColors is true.
+const (
+	ansiPK     = "\x1b[91m"
+	ansiFK     = "\x1b[94m"
+	ansiUK     = "\x1b[95m"
+	ansiHeader = "\x1b[1m"
+	ansiReset  = "\x1b[0m"
+)
+
+// colorize wraps text in an ANSI color sequence based on color_type. If the
+// theme disables colors, text is returned unchanged.
+func colorize(theme ASCIITheme, text, colorType string) string {
+	if !theme.UseColors {
+		return text
+	}
+	var code string
+	switch strings.ToLower(colorType) {
+	case "pk":
+		code = ansiPK
+	case "fk":
+		code = ansiFK
+	case "uk":
+		code = ansiUK
+	case "header":
+		code = ansiHeader
+	case "field", "":
+		return text
+	default:
+		return text
+	}
+	return code + text + ansiReset
+}
+
+// constraintIcon returns the unicode icon used next to a constraint label in
+// ASCII diagrams, or an empty string when the theme disables icons.
+func constraintIcon(theme ASCIITheme, constraint string) string {
+	if !theme.UseIcons {
+		return ""
+	}
+	switch constraint {
+	case "PK":
+		return "🔑 "
+	case "FK":
+		return "🔗 "
+	case "UK":
+		return "⭐ "
+	}
+	return ""
+}
+
+// repeatRune returns a string containing n copies of s. It is a convenience
+// helper for building box top/bottom/middle lines.
+func repeatRune(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return strings.Repeat(s, n)
+}

--- a/pkg/surql/schema/visualize.go
+++ b/pkg/surql/schema/visualize.go
@@ -1,0 +1,520 @@
+package schema
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// VisualizeOptions controls optional inclusion of fields and edges in the
+// generated diagram. The zero value includes both.
+type VisualizeOptions struct {
+	// IncludeFields, when false, omits per-field rows from the diagram.
+	// Default: true (represented as the zero value via a nil *bool pattern
+	// would be awkward, so callers opt in/out with WithIncludeFields.)
+	IncludeFields bool
+	// IncludeEdges, when false, omits edge/relationship output.
+	IncludeEdges bool
+	fieldsSet    bool
+	edgesSet     bool
+}
+
+// VisualizeOption customises a VisualizeOptions.
+type VisualizeOption func(*VisualizeOptions)
+
+// WithIncludeFields toggles inclusion of field definitions.
+func WithIncludeFields(include bool) VisualizeOption {
+	return func(o *VisualizeOptions) {
+		o.IncludeFields = include
+		o.fieldsSet = true
+	}
+}
+
+// WithIncludeEdges toggles inclusion of edge relationships.
+func WithIncludeEdges(include bool) VisualizeOption {
+	return func(o *VisualizeOptions) {
+		o.IncludeEdges = include
+		o.edgesSet = true
+	}
+}
+
+// resolveOptions applies opts and substitutes defaults for flags that were
+// never explicitly set.
+func resolveOptions(opts []VisualizeOption) VisualizeOptions {
+	o := VisualizeOptions{}
+	for _, fn := range opts {
+		fn(&o)
+	}
+	if !o.fieldsSet {
+		o.IncludeFields = true
+	}
+	if !o.edgesSet {
+		o.IncludeEdges = true
+	}
+	return o
+}
+
+// sortedTableMap returns a stable iteration order for tables.
+func sortedTableMap(tables map[string]TableDefinition) []string {
+	names := make([]string, 0, len(tables))
+	for k := range tables {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// sortedEdgeMap returns a stable iteration order for edges.
+func sortedEdgeMap(edges map[string]EdgeDefinition) []string {
+	names := make([]string, 0, len(edges))
+	for k := range edges {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// registryTables snapshots the registry tables into a map keyed by name.
+func registryTables(r *SchemaRegistry) map[string]TableDefinition {
+	out := map[string]TableDefinition{}
+	for _, t := range r.Tables() {
+		out[t.Name] = t
+	}
+	return out
+}
+
+// registryEdges snapshots the registry edges into a map keyed by name.
+func registryEdges(r *SchemaRegistry) map[string]EdgeDefinition {
+	out := map[string]EdgeDefinition{}
+	for _, e := range r.Edges() {
+		out[e.Name] = e
+	}
+	return out
+}
+
+// GenerateMermaid renders a Mermaid ER diagram from registry using theme.
+// The diagram contains entity blocks for every table (always showing the
+// implicit id PK row) and any relationships derived from edges. Pass an
+// empty MermaidTheme to suppress the %%{init}%% directive.
+func GenerateMermaid(r *SchemaRegistry, theme MermaidTheme, opts ...VisualizeOption) string {
+	return GenerateMermaidFromMaps(registryTables(r), registryEdges(r), theme, opts...)
+}
+
+// GenerateMermaidFromMaps is like GenerateMermaid but operates on raw
+// table/edge maps, matching the surql-py entry point signature.
+func GenerateMermaidFromMaps(
+	tables map[string]TableDefinition,
+	edges map[string]EdgeDefinition,
+	theme MermaidTheme,
+	opts ...VisualizeOption,
+) string {
+	options := resolveOptions(opts)
+	var b strings.Builder
+
+	if theme.ThemeName != "" {
+		fmt.Fprintf(&b, "%%%%{init: {'theme':'%s'}}%%%%\n", theme.ThemeName)
+	}
+	b.WriteString("erDiagram")
+
+	for _, name := range sortedTableMap(tables) {
+		table := tables[name]
+		b.WriteString("\n    ")
+		b.WriteString(name)
+		b.WriteString(" {")
+		if options.IncludeFields {
+			b.WriteString("\n        string id PK")
+			for _, f := range table.Fields {
+				constraint := fieldConstraint(f.Name, table)
+				constraintStr := ""
+				if constraint != "" {
+					constraintStr = " " + constraint
+				}
+				fmt.Fprintf(&b, "\n        %s %s%s", fieldTypeString(f.Type), f.Name, constraintStr)
+			}
+		}
+		b.WriteString("\n    }")
+	}
+
+	for _, name := range sortedEdgeMap(edges) {
+		edge := edges[name]
+		if !options.IncludeFields || len(edge.Fields) == 0 {
+			continue
+		}
+		b.WriteString("\n    ")
+		b.WriteString(name)
+		b.WriteString(" {")
+		for _, f := range edge.Fields {
+			fmt.Fprintf(&b, "\n        %s %s", fieldTypeString(f.Type), f.Name)
+		}
+		b.WriteString("\n    }")
+	}
+
+	if options.IncludeEdges {
+		b.WriteString("\n")
+		for _, name := range sortedEdgeMap(edges) {
+			edge := edges[name]
+			from := edge.FromTable
+			if from == "" {
+				from = "unknown"
+			}
+			to := edge.ToTable
+			if to == "" {
+				to = "unknown"
+			}
+			if _, ok := tables[from]; !ok && from != "unknown" {
+				continue
+			}
+			if _, ok := tables[to]; !ok && to != "unknown" {
+				continue
+			}
+			cardinality := mermaidCardinality(edge)
+			fmt.Fprintf(&b, "\n    %s %s %s : %s", from, cardinality, to, name)
+		}
+	}
+
+	return b.String()
+}
+
+// mermaidCardinality picks a Mermaid cardinality symbol based on edge
+// semantics. Self-referential edges (from == to) are rendered many-to-many;
+// everything else defaults to one-to-many.
+func mermaidCardinality(edge EdgeDefinition) string {
+	if edge.FromTable != "" && edge.FromTable == edge.ToTable {
+		return "}o--o{"
+	}
+	return "||--o{"
+}
+
+// GenerateGraphViz renders a GraphViz DOT diagram from registry using theme.
+func GenerateGraphViz(r *SchemaRegistry, theme GraphVizTheme, opts ...VisualizeOption) string {
+	return GenerateGraphVizFromMaps(registryTables(r), registryEdges(r), theme, opts...)
+}
+
+// GenerateGraphVizFromMaps is like GenerateGraphViz but operates on raw
+// table/edge maps.
+func GenerateGraphVizFromMaps(
+	tables map[string]TableDefinition,
+	edges map[string]EdgeDefinition,
+	theme GraphVizTheme,
+	opts ...VisualizeOption,
+) string {
+	options := resolveOptions(opts)
+	var b strings.Builder
+	b.WriteString("digraph schema {\n")
+	b.WriteString("    rankdir=LR;\n")
+
+	applyTheme := theme.UseGradients || (theme.NodeStyle != "" && theme.NodeStyle != "filled,rounded")
+	if applyTheme {
+		if theme.BgColor != "" && theme.BgColor != "transparent" {
+			fmt.Fprintf(&b, "    bgcolor=%q;\n", theme.BgColor)
+		}
+		fmt.Fprintf(&b, "    fontname=%q;\n", theme.FontName)
+
+		nodeAttrs := []string{fmt.Sprintf("shape=%s", theme.NodeShape)}
+		if theme.NodeStyle != "" {
+			nodeAttrs = append(nodeAttrs, fmt.Sprintf("style=%q", theme.NodeStyle))
+		}
+		nodeAttrs = append(nodeAttrs, fmt.Sprintf("fontname=%q", theme.FontName))
+		nodeAttrs = append(nodeAttrs, `pad="0.5"`, `margin="0.2"`)
+		fmt.Fprintf(&b, "    node [%s];\n", strings.Join(nodeAttrs, ", "))
+
+		edgeAttrs := []string{fmt.Sprintf("color=%q", theme.EdgeColor)}
+		if theme.EdgeStyle != "" {
+			edgeAttrs = append(edgeAttrs, fmt.Sprintf("style=%s", theme.EdgeStyle))
+		}
+		edgeAttrs = append(edgeAttrs, fmt.Sprintf("fontname=%q", theme.FontName))
+		fmt.Fprintf(&b, "    edge [%s];\n", strings.Join(edgeAttrs, ", "))
+	} else {
+		b.WriteString("    node [shape=record];\n")
+	}
+
+	b.WriteString("\n")
+
+	for _, name := range sortedTableMap(tables) {
+		table := tables[name]
+		label := buildGraphVizTableLabel(name, table, options.IncludeFields, theme)
+		fmt.Fprintf(&b, "    %s [label=%s];\n", name, label)
+	}
+	for _, name := range sortedEdgeMap(edges) {
+		edge := edges[name]
+		if !options.IncludeFields || len(edge.Fields) == 0 {
+			continue
+		}
+		label := buildGraphVizEdgeLabel(name, edge, theme)
+		fmt.Fprintf(&b, "    %s [label=%s];\n", name, label)
+	}
+
+	b.WriteString("\n")
+
+	if options.IncludeEdges {
+		modern := ModernTheme()
+		for _, name := range sortedEdgeMap(edges) {
+			edge := edges[name]
+			from := edge.FromTable
+			to := edge.ToTable
+			if from == "" || to == "" {
+				continue
+			}
+			if _, ok := tables[from]; !ok {
+				continue
+			}
+			if _, ok := tables[to]; !ok {
+				continue
+			}
+			style := graphVizEdgeStyle(edge, theme, modern.Colors)
+			fmt.Fprintf(&b, "    %s -> %s [label=%q%s];\n", from, to, name, style)
+		}
+	}
+
+	b.WriteString("}")
+	return b.String()
+}
+
+func buildGraphVizTableLabel(
+	tableName string,
+	table TableDefinition,
+	includeFields bool,
+	theme GraphVizTheme,
+) string {
+	if !includeFields {
+		return fmt.Sprintf("%q", tableName)
+	}
+	if theme.UseGradients {
+		return buildGraphVizHTMLLabel(tableName, table, theme)
+	}
+	parts := []string{tableName, "id : string (PK)\\l"}
+	for _, f := range table.Fields {
+		constraint := fieldConstraint(f.Name, table)
+		constraintStr := ""
+		if constraint != "" {
+			constraintStr = " (" + constraint + ")"
+		}
+		parts = append(parts, fmt.Sprintf("%s : %s%s\\l", f.Name, fieldTypeString(f.Type), constraintStr))
+	}
+	return `"{` + strings.Join(parts, "|") + `}"`
+}
+
+func buildGraphVizHTMLLabel(tableName string, table TableDefinition, theme GraphVizTheme) string {
+	modern := ModernTheme()
+	var b strings.Builder
+	b.WriteString("<")
+	b.WriteString(`<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4">`)
+	fmt.Fprintf(&b, `<TR><TD BGCOLOR="%s" COLSPAN="2">`, theme.NodeColor)
+	fmt.Fprintf(&b, `<FONT COLOR="#FFFFFF"><B>%s</B></FONT>`, tableName)
+	b.WriteString("</TD></TR>")
+
+	b.WriteString("<TR>")
+	b.WriteString(`<TD ALIGN="LEFT">id</TD>`)
+	b.WriteString(`<TD ALIGN="LEFT">`)
+	fmt.Fprintf(&b, `<FONT COLOR="%s">string</FONT>`, modern.Colors.Muted)
+	fmt.Fprintf(&b, ` <FONT COLOR="%s">PK</FONT>`, modern.Colors.Error)
+	b.WriteString("</TD></TR>")
+
+	for _, f := range table.Fields {
+		constraint := fieldConstraint(f.Name, table)
+		fieldColor := fieldTypeColor(f.Type, modern.Colors)
+
+		b.WriteString("<TR>")
+		fmt.Fprintf(&b, `<TD ALIGN="LEFT">%s</TD>`, f.Name)
+		b.WriteString(`<TD ALIGN="LEFT">`)
+		fmt.Fprintf(&b, `<FONT COLOR="%s">%s</FONT>`, fieldColor, fieldTypeString(f.Type))
+		if constraint != "" {
+			constraintColor := constraintColor(constraint, modern.Colors)
+			fmt.Fprintf(&b, ` <FONT COLOR="%s">%s</FONT>`, constraintColor, constraint)
+		}
+		b.WriteString("</TD></TR>")
+	}
+	b.WriteString("</TABLE>>")
+	return b.String()
+}
+
+func buildGraphVizEdgeLabel(edgeName string, edge EdgeDefinition, theme GraphVizTheme) string {
+	if theme.UseGradients {
+		modern := ModernTheme()
+		var b strings.Builder
+		b.WriteString("<")
+		b.WriteString(`<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4">`)
+		fmt.Fprintf(&b, `<TR><TD BGCOLOR="%s" COLSPAN="2">`, theme.NodeColor)
+		fmt.Fprintf(&b, `<FONT COLOR="#FFFFFF"><B>%s</B></FONT>`, edgeName)
+		b.WriteString("</TD></TR>")
+		for _, f := range edge.Fields {
+			fieldColor := fieldTypeColor(f.Type, modern.Colors)
+			b.WriteString("<TR>")
+			fmt.Fprintf(&b, `<TD ALIGN="LEFT">%s</TD>`, f.Name)
+			fmt.Fprintf(&b, `<TD ALIGN="LEFT"><FONT COLOR="%s">%s</FONT></TD>`, fieldColor, fieldTypeString(f.Type))
+			b.WriteString("</TR>")
+		}
+		b.WriteString("</TABLE>>")
+		return b.String()
+	}
+	parts := []string{edgeName}
+	for _, f := range edge.Fields {
+		parts = append(parts, fmt.Sprintf("%s : %s\\l", f.Name, fieldTypeString(f.Type)))
+	}
+	return `"{` + strings.Join(parts, "|") + `}"`
+}
+
+func graphVizEdgeStyle(edge EdgeDefinition, theme GraphVizTheme, colors ColorScheme) string {
+	if edge.FromTable != "" && edge.FromTable == edge.ToTable {
+		if theme.UseGradients {
+			return fmt.Sprintf(`, style=dashed, color=%q`, colors.Secondary)
+		}
+		return ", style=dashed"
+	}
+	return ""
+}
+
+func fieldTypeColor(t FieldType, c ColorScheme) string {
+	switch t {
+	case FieldTypeString:
+		return c.Success
+	case FieldTypeInt, FieldTypeFloat, FieldTypeDecimal, FieldTypeNumber:
+		return c.Warning
+	case FieldTypeBool:
+		return c.Accent
+	case FieldTypeDatetime, FieldTypeDuration:
+		return c.Secondary
+	case FieldTypeRecord:
+		return c.Primary
+	case FieldTypeObject, FieldTypeArray:
+		return c.Muted
+	}
+	return c.Text
+}
+
+func constraintColor(constraint string, c ColorScheme) string {
+	switch constraint {
+	case "PK":
+		return c.Error
+	case "FK":
+		return c.Primary
+	case "UK":
+		return c.Accent
+	}
+	return c.Text
+}
+
+// GenerateASCII renders a plain-text ASCII diagram for registry using theme.
+func GenerateASCII(r *SchemaRegistry, theme ASCIITheme, opts ...VisualizeOption) string {
+	return GenerateASCIIFromMaps(registryTables(r), registryEdges(r), theme, opts...)
+}
+
+// GenerateASCIIFromMaps is like GenerateASCII but operates on raw
+// table/edge maps.
+func GenerateASCIIFromMaps(
+	tables map[string]TableDefinition,
+	edges map[string]EdgeDefinition,
+	theme ASCIITheme,
+	opts ...VisualizeOption,
+) string {
+	options := resolveOptions(opts)
+
+	// Resolve the effective theme (zero value means "no unicode, no colors,
+	// no icons" which matches surql-py's default behaviour).
+	var lines []string
+	for _, name := range sortedTableMap(tables) {
+		box := buildASCIITableBox(name, tables[name], options.IncludeFields, theme)
+		lines = append(lines, box...)
+		lines = append(lines, "")
+	}
+
+	if options.IncludeEdges && len(edges) > 0 {
+		lines = append(lines, "Relationships:")
+		lines = append(lines, strings.Repeat("-", 40))
+		for _, name := range sortedEdgeMap(edges) {
+			edge := edges[name]
+			from := edge.FromTable
+			if from == "" {
+				from = "?"
+			}
+			to := edge.ToTable
+			if to == "" {
+				to = "?"
+			}
+			lines = append(lines, fmt.Sprintf("  %s --[%s]--> %s", from, name, to))
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func buildASCIITableBox(
+	name string,
+	table TableDefinition,
+	includeFields bool,
+	theme ASCIITheme,
+) []string {
+	chars := boxChars(theme)
+
+	var fieldLines []string
+	if includeFields {
+		pkIcon := constraintIcon(theme, "PK")
+		pkText := colorize(theme, fmt.Sprintf("%s(PK)", pkIcon), "pk")
+		fieldLines = append(fieldLines, fmt.Sprintf("id : string %s", pkText))
+		for _, f := range table.Fields {
+			constraint := fieldConstraint(f.Name, table)
+			constraintStr := ""
+			if constraint != "" {
+				icon := constraintIcon(theme, constraint)
+				colorType := strings.ToLower(constraint)
+				label := colorize(theme, fmt.Sprintf("%s(%s)", icon, constraint), colorType)
+				constraintStr = " " + label
+			}
+			fieldLines = append(fieldLines, fmt.Sprintf("%s : %s%s", f.Name, fieldTypeString(f.Type), constraintStr))
+		}
+	}
+
+	minWidth := len(name) + 4
+	if minWidth < 20 {
+		minWidth = 20
+	}
+	contentWidth := 0
+	for _, l := range fieldLines {
+		w := displayWidth(l)
+		if w > contentWidth {
+			contentWidth = w
+		}
+	}
+	width := minWidth
+	if contentWidth+2 > width {
+		width = contentWidth + 2
+	}
+
+	top := chars["tl"] + repeatRune(chars["h"], width) + chars["tr"]
+	bottom := chars["bl"] + repeatRune(chars["h"], width) + chars["br"]
+	out := []string{top}
+
+	styledName := colorize(theme, centerText(name, width), "header")
+	leftPad, rightPad := centerPad(styledName, width)
+	out = append(out, chars["v"]+strings.Repeat(" ", leftPad)+styledName+strings.Repeat(" ", rightPad)+chars["v"])
+
+	if includeFields {
+		separator := chars["ml"] + repeatRune(chars["h"], width) + chars["mr"]
+		out = append(out, separator)
+		for _, line := range fieldLines {
+			visible := displayWidth(line)
+			padding := width - visible - 1
+			if padding < 0 {
+				padding = 0
+			}
+			out = append(out, fmt.Sprintf("%s %s%s%s", chars["v"], line, strings.Repeat(" ", padding), chars["v"]))
+		}
+	}
+	out = append(out, bottom)
+	return out
+}
+
+// centerText produces a string whose display-width is >= width, centring
+// text within that width using plain space padding. Matches Python
+// str.center which places the extra padding char on the LEFT when the
+// padding amount is odd.
+func centerText(text string, width int) string {
+	visible := displayWidth(text)
+	if visible >= width {
+		return text
+	}
+	padding := width - visible
+	right := padding / 2
+	left := padding - right
+	return strings.Repeat(" ", left) + text + strings.Repeat(" ", right)
+}

--- a/pkg/surql/schema/visualize_test.go
+++ b/pkg/surql/schema/visualize_test.go
@@ -1,0 +1,713 @@
+package schema
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// -------------------- Helpers --------------------
+
+func newRegistryWith(
+	t *testing.T,
+	tables []TableDefinition,
+	edges []EdgeDefinition,
+) *SchemaRegistry {
+	t.Helper()
+	r := NewSchemaRegistry()
+	for _, tbl := range tables {
+		if err := r.RegisterTable(tbl); err != nil {
+			t.Fatalf("RegisterTable(%q): %v", tbl.Name, err)
+		}
+	}
+	for _, e := range edges {
+		if err := r.RegisterEdge(e); err != nil {
+			t.Fatalf("RegisterEdge(%q): %v", e.Name, err)
+		}
+	}
+	return r
+}
+
+func mustEqual(t *testing.T, got, want, label string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s mismatch\nwant:\n%q\n\ngot:\n%q", label, want, got)
+	}
+}
+
+// userTable returns a TableDefinition named "user" with a single string field.
+func userTable() TableDefinition {
+	return NewTable("user", WithFields(StringField("email")))
+}
+
+// -------------------- Theme presets --------------------
+
+func TestModernThemeConstants(t *testing.T) {
+	th := ModernTheme()
+	if th.Name != "modern" {
+		t.Errorf("modern.Name = %q", th.Name)
+	}
+	if th.Colors.Primary != "#6366f1" {
+		t.Errorf("modern.Colors.Primary = %q", th.Colors.Primary)
+	}
+	if th.GraphViz.NodeColor != "#6366f1" {
+		t.Errorf("modern.GraphViz.NodeColor = %q", th.GraphViz.NodeColor)
+	}
+	if th.Mermaid.ThemeName != "default" {
+		t.Errorf("modern.Mermaid.ThemeName = %q", th.Mermaid.ThemeName)
+	}
+	if th.ASCII.BoxStyle != "rounded" {
+		t.Errorf("modern.ASCII.BoxStyle = %q", th.ASCII.BoxStyle)
+	}
+	if !th.ASCII.UseUnicode || !th.ASCII.UseColors || !th.ASCII.UseIcons {
+		t.Errorf("modern.ASCII flags = %+v", th.ASCII)
+	}
+}
+
+func TestDarkThemeConstants(t *testing.T) {
+	th := DarkTheme()
+	if th.Name != "dark" {
+		t.Errorf("dark.Name = %q", th.Name)
+	}
+	if th.Colors.Primary != "#8b5cf6" {
+		t.Errorf("dark.Colors.Primary = %q", th.Colors.Primary)
+	}
+	if th.GraphViz.BgColor != "#1e1b4b" {
+		t.Errorf("dark.GraphViz.BgColor = %q", th.GraphViz.BgColor)
+	}
+	if th.Mermaid.ThemeName != "dark" {
+		t.Errorf("dark.Mermaid.ThemeName = %q", th.Mermaid.ThemeName)
+	}
+}
+
+func TestForestThemeConstants(t *testing.T) {
+	th := ForestTheme()
+	if th.Name != "forest" {
+		t.Errorf("forest.Name = %q", th.Name)
+	}
+	if th.Colors.Primary != "#10b981" {
+		t.Errorf("forest.Colors.Primary = %q", th.Colors.Primary)
+	}
+	if th.GraphViz.NodeColor != "#10b981" {
+		t.Errorf("forest.GraphViz.NodeColor = %q", th.GraphViz.NodeColor)
+	}
+	if th.Mermaid.ThemeName != "forest" {
+		t.Errorf("forest.Mermaid.ThemeName = %q", th.Mermaid.ThemeName)
+	}
+}
+
+func TestMinimalThemeConstants(t *testing.T) {
+	th := MinimalTheme()
+	if th.Name != "minimal" {
+		t.Errorf("minimal.Name = %q", th.Name)
+	}
+	if th.Colors.Primary != "#6b7280" {
+		t.Errorf("minimal.Colors.Primary = %q", th.Colors.Primary)
+	}
+	if th.Mermaid.ThemeName != "neutral" {
+		t.Errorf("minimal.Mermaid.ThemeName = %q", th.Mermaid.ThemeName)
+	}
+	if th.ASCII.BoxStyle != "single" {
+		t.Errorf("minimal.ASCII.BoxStyle = %q", th.ASCII.BoxStyle)
+	}
+	if th.ASCII.UseColors || th.ASCII.UseIcons {
+		t.Errorf("minimal.ASCII flags = %+v", th.ASCII)
+	}
+	if th.GraphViz.UseGradients {
+		t.Errorf("minimal.GraphViz.UseGradients = true, want false")
+	}
+}
+
+func TestGetThemeKnown(t *testing.T) {
+	for _, name := range []string{"modern", "dark", "forest", "minimal"} {
+		th, err := GetTheme(name)
+		if err != nil {
+			t.Fatalf("GetTheme(%q) error: %v", name, err)
+		}
+		if th.Name != name {
+			t.Errorf("GetTheme(%q).Name = %q", name, th.Name)
+		}
+	}
+}
+
+func TestGetThemeUnknown(t *testing.T) {
+	_, err := GetTheme("solarized")
+	if err == nil {
+		t.Fatalf("GetTheme(\"solarized\") error = nil, want non-nil")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("GetTheme unknown error kind = %v, want ErrValidation", err)
+	}
+	if !strings.Contains(err.Error(), "solarized") {
+		t.Errorf("GetTheme error = %q, want to contain %q", err.Error(), "solarized")
+	}
+}
+
+func TestListThemes(t *testing.T) {
+	names := ListThemes()
+	wantSorted := []string{"dark", "forest", "minimal", "modern"}
+	if len(names) != len(wantSorted) {
+		t.Fatalf("ListThemes length = %d, want %d", len(names), len(wantSorted))
+	}
+	for i, n := range wantSorted {
+		if names[i] != n {
+			t.Errorf("ListThemes[%d] = %q, want %q", i, names[i], n)
+		}
+	}
+}
+
+// -------------------- utils --------------------
+
+func TestFieldConstraintID(t *testing.T) {
+	tbl := NewTable("x")
+	if got := fieldConstraint("id", tbl); got != "PK" {
+		t.Errorf("id => %q, want PK", got)
+	}
+}
+
+func TestFieldConstraintUK(t *testing.T) {
+	tbl := NewTable("user",
+		WithFields(StringField("email")),
+		WithIndexes(UniqueIndex("u_email", []string{"email"})),
+	)
+	if got := fieldConstraint("email", tbl); got != "UK" {
+		t.Errorf("email UK => %q, want UK", got)
+	}
+}
+
+func TestFieldConstraintFK(t *testing.T) {
+	tbl := NewTable("post",
+		WithFields(RecordField("author", "user")),
+	)
+	if got := fieldConstraint("author", tbl); got != "FK" {
+		t.Errorf("author record => %q, want FK", got)
+	}
+}
+
+func TestFieldConstraintNone(t *testing.T) {
+	tbl := NewTable("user", WithFields(StringField("email")))
+	if got := fieldConstraint("email", tbl); got != "" {
+		t.Errorf("email no constraint => %q, want empty", got)
+	}
+}
+
+func TestDisplayWidthPlain(t *testing.T) {
+	if w := displayWidth("hello"); w != 5 {
+		t.Errorf("displayWidth hello = %d, want 5", w)
+	}
+}
+
+func TestDisplayWidthEmoji(t *testing.T) {
+	if w := displayWidth("🔑"); w != 2 {
+		t.Errorf("displayWidth 🔑 = %d, want 2", w)
+	}
+	if w := displayWidth("a🔑b"); w != 4 {
+		t.Errorf("displayWidth a🔑b = %d, want 4", w)
+	}
+}
+
+func TestDisplayWidthANSIStripped(t *testing.T) {
+	in := "\x1b[91m🔑 (PK)\x1b[0m"
+	// 🔑 = 2, " (PK)" = 5 => 7
+	if w := displayWidth(in); w != 7 {
+		t.Errorf("displayWidth with ANSI = %d, want 7", w)
+	}
+}
+
+func TestCenterPadPythonCompatible(t *testing.T) {
+	// Python str.center puts EXTRA on the left when padding is odd.
+	l, r := centerPad("post", 25)
+	if l != 11 || r != 10 {
+		t.Errorf("centerPad(post, 25) = (%d, %d), want (11, 10)", l, r)
+	}
+	l, r = centerPad("user", 20)
+	if l != 8 || r != 8 {
+		t.Errorf("centerPad(user, 20) = (%d, %d), want (8, 8)", l, r)
+	}
+}
+
+func TestBoxCharsUnicodeRounded(t *testing.T) {
+	th := ASCIITheme{BoxStyle: "rounded", UseUnicode: true}
+	ch := boxChars(th)
+	if ch["tl"] != "╭" || ch["br"] != "╯" {
+		t.Errorf("rounded box = %+v", ch)
+	}
+}
+
+func TestBoxCharsASCIIFallback(t *testing.T) {
+	ch := boxChars(ASCIITheme{}) // zero value => UseUnicode=false
+	if ch["tl"] != "+" || ch["h"] != "-" || ch["v"] != "|" {
+		t.Errorf("ascii fallback = %+v", ch)
+	}
+}
+
+func TestBoxCharsDouble(t *testing.T) {
+	th := ASCIITheme{BoxStyle: "double", UseUnicode: true}
+	ch := boxChars(th)
+	if ch["tl"] != "╔" || ch["h"] != "═" {
+		t.Errorf("double box = %+v", ch)
+	}
+}
+
+func TestBoxCharsHeavy(t *testing.T) {
+	th := ASCIITheme{BoxStyle: "heavy", UseUnicode: true}
+	ch := boxChars(th)
+	if ch["tl"] != "┏" || ch["h"] != "━" {
+		t.Errorf("heavy box = %+v", ch)
+	}
+}
+
+func TestColorizeDisabled(t *testing.T) {
+	th := ASCIITheme{UseColors: false}
+	if got := colorize(th, "x", "pk"); got != "x" {
+		t.Errorf("colorize off = %q", got)
+	}
+}
+
+func TestColorizeEnabled(t *testing.T) {
+	th := ASCIITheme{UseColors: true}
+	got := colorize(th, "(PK)", "pk")
+	want := "\x1b[91m(PK)\x1b[0m"
+	if got != want {
+		t.Errorf("colorize pk = %q, want %q", got, want)
+	}
+}
+
+func TestConstraintIconEnabled(t *testing.T) {
+	th := ASCIITheme{UseIcons: true}
+	if got := constraintIcon(th, "PK"); got != "🔑 " {
+		t.Errorf("icon PK = %q", got)
+	}
+	if got := constraintIcon(th, "FK"); got != "🔗 " {
+		t.Errorf("icon FK = %q", got)
+	}
+	if got := constraintIcon(th, "UK"); got != "⭐ " {
+		t.Errorf("icon UK = %q", got)
+	}
+}
+
+func TestConstraintIconDisabled(t *testing.T) {
+	th := ASCIITheme{UseIcons: false}
+	if got := constraintIcon(th, "PK"); got != "" {
+		t.Errorf("icon off PK = %q", got)
+	}
+}
+
+// -------------------- Mermaid --------------------
+
+func TestMermaidEmpty(t *testing.T) {
+	r := NewSchemaRegistry()
+	got := GenerateMermaid(r, MermaidTheme{})
+	want := "erDiagram\n"
+	mustEqual(t, got, want, "mermaid empty")
+}
+
+func TestMermaidUserNoTheme(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateMermaid(r, MermaidTheme{})
+	want := "erDiagram\n    user {\n        string id PK\n        string email\n    }\n"
+	mustEqual(t, got, want, "mermaid user no theme")
+}
+
+func TestMermaidUserModern(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateMermaid(r, ModernMermaidTheme())
+	want := "%%{init: {'theme':'default'}}%%\nerDiagram\n    user {\n        string id PK\n        string email\n    }\n"
+	mustEqual(t, got, want, "mermaid user modern")
+}
+
+func TestMermaidUserDark(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateMermaid(r, DarkMermaidTheme())
+	want := "%%{init: {'theme':'dark'}}%%\nerDiagram\n    user {\n        string id PK\n        string email\n    }\n"
+	mustEqual(t, got, want, "mermaid user dark")
+}
+
+func TestMermaidUserForest(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateMermaid(r, ForestMermaidTheme())
+	want := "%%{init: {'theme':'forest'}}%%\nerDiagram\n    user {\n        string id PK\n        string email\n    }\n"
+	mustEqual(t, got, want, "mermaid user forest")
+}
+
+func TestMermaidUserMinimal(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateMermaid(r, MinimalMermaidTheme())
+	want := "%%{init: {'theme':'neutral'}}%%\nerDiagram\n    user {\n        string id PK\n        string email\n    }\n"
+	mustEqual(t, got, want, "mermaid user minimal")
+}
+
+func TestMermaidUserUniqueIndex(t *testing.T) {
+	user := NewTable("user",
+		WithFields(StringField("email"), StringField("name")),
+		WithIndexes(UniqueIndex("u_email", []string{"email"})),
+	)
+	r := newRegistryWith(t, []TableDefinition{user}, nil)
+	got := GenerateMermaid(r, MermaidTheme{})
+	want := "erDiagram\n    user {\n        string id PK\n        string email UK\n        string name\n    }\n"
+	mustEqual(t, got, want, "mermaid user unique")
+}
+
+func TestMermaidEdgesBasic(t *testing.T) {
+	user := NewTable("user", WithFields(StringField("email")))
+	post := NewTable("post",
+		WithFields(StringField("title"), RecordField("author", "user")),
+	)
+	wrote := TypedEdge("wrote", "user", "post", WithEdgeFields(DatetimeField("at")))
+	follows := TypedEdge("follows", "user", "user")
+	r := newRegistryWith(t, []TableDefinition{user, post}, []EdgeDefinition{wrote, follows})
+
+	got := GenerateMermaid(r, ModernMermaidTheme())
+	want := "%%{init: {'theme':'default'}}%%\n" +
+		"erDiagram\n    post {\n        string id PK\n        string title\n        record author FK\n    }\n" +
+		"    user {\n        string id PK\n        string email\n    }\n" +
+		"    wrote {\n        datetime at\n    }\n" +
+		"\n    user }o--o{ user : follows" +
+		"\n    user ||--o{ post : wrote"
+	mustEqual(t, got, want, "mermaid edges")
+}
+
+func TestMermaidIncludeFieldsFalse(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateMermaid(r, MermaidTheme{}, WithIncludeFields(false))
+	want := "erDiagram\n    user {\n    }\n"
+	mustEqual(t, got, want, "mermaid include_fields=false")
+}
+
+func TestMermaidIncludeEdgesFalse(t *testing.T) {
+	user := NewTable("user", WithFields(StringField("email")))
+	post := NewTable("post", WithFields(StringField("title")))
+	e := TypedEdge("wrote", "user", "post")
+	r := newRegistryWith(t, []TableDefinition{user, post}, []EdgeDefinition{e})
+	got := GenerateMermaid(r, MermaidTheme{}, WithIncludeEdges(false))
+	// Tables are emitted in alphabetical order: post, user.
+	want := "erDiagram\n    post {\n        string id PK\n        string title\n    }\n" +
+		"    user {\n        string id PK\n        string email\n    }"
+	// With IncludeEdges=false we do not emit the blank line separator that
+	// precedes the edges section (Python: the empty-string list element is
+	// appended only when include_edges is true).
+	mustEqual(t, got, want, "mermaid include_edges=false")
+}
+
+// Skip-if-table-missing test: edge referencing unknown table is dropped.
+func TestMermaidEdgeDroppedWhenTableMissing(t *testing.T) {
+	user := NewTable("user", WithFields(StringField("email")))
+	e := TypedEdge("wrote", "user", "missing")
+	r := newRegistryWith(t, []TableDefinition{user}, []EdgeDefinition{e})
+	got := GenerateMermaid(r, MermaidTheme{})
+	want := "erDiagram\n    user {\n        string id PK\n        string email\n    }\n"
+	mustEqual(t, got, want, "mermaid missing table edge dropped")
+}
+
+// -------------------- GraphViz --------------------
+
+func TestGraphVizEmpty(t *testing.T) {
+	r := NewSchemaRegistry()
+	got := GenerateGraphViz(r, GraphVizTheme{})
+	want := "digraph schema {\n    rankdir=LR;\n    node [shape=record];\n\n\n}"
+	mustEqual(t, got, want, "graphviz empty")
+}
+
+func TestGraphVizUserDefault(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateGraphViz(r, GraphVizTheme{})
+	want := "digraph schema {\n    rankdir=LR;\n    node [shape=record];\n\n" +
+		"    user [label=\"{user|id : string (PK)\\l|email : string\\l}\"];\n\n}"
+	mustEqual(t, got, want, "graphviz user default")
+}
+
+func TestGraphVizUserModern(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateGraphViz(r, ModernGraphVizTheme())
+	want := `digraph schema {
+    rankdir=LR;
+    fontname="Arial";
+    node [shape=record, style="filled,rounded", fontname="Arial", pad="0.5", margin="0.2"];
+    edge [color="#64748b", style=solid, fontname="Arial"];
+
+    user [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4"><TR><TD BGCOLOR="#6366f1" COLSPAN="2"><FONT COLOR="#FFFFFF"><B>user</B></FONT></TD></TR><TR><TD ALIGN="LEFT">id</TD><TD ALIGN="LEFT"><FONT COLOR="#94a3b8">string</FONT> <FONT COLOR="#ef4444">PK</FONT></TD></TR><TR><TD ALIGN="LEFT">email</TD><TD ALIGN="LEFT"><FONT COLOR="#10b981">string</FONT></TD></TR></TABLE>>];
+
+}`
+	mustEqual(t, got, want, "graphviz user modern")
+}
+
+func TestGraphVizUserDark(t *testing.T) {
+	user := NewTable("user",
+		WithFields(StringField("email"), StringField("name")),
+		WithIndexes(UniqueIndex("u_email", []string{"email"})),
+	)
+	r := newRegistryWith(t, []TableDefinition{user}, nil)
+	got := GenerateGraphViz(r, DarkGraphVizTheme())
+	want := `digraph schema {
+    rankdir=LR;
+    bgcolor="#1e1b4b";
+    fontname="Arial";
+    node [shape=record, style="filled,rounded", fontname="Arial", pad="0.5", margin="0.2"];
+    edge [color="#64748b", style=solid, fontname="Arial"];
+
+    user [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4"><TR><TD BGCOLOR="#8b5cf6" COLSPAN="2"><FONT COLOR="#FFFFFF"><B>user</B></FONT></TD></TR><TR><TD ALIGN="LEFT">id</TD><TD ALIGN="LEFT"><FONT COLOR="#94a3b8">string</FONT> <FONT COLOR="#ef4444">PK</FONT></TD></TR><TR><TD ALIGN="LEFT">email</TD><TD ALIGN="LEFT"><FONT COLOR="#10b981">string</FONT> <FONT COLOR="#8b5cf6">UK</FONT></TD></TR><TR><TD ALIGN="LEFT">name</TD><TD ALIGN="LEFT"><FONT COLOR="#10b981">string</FONT></TD></TR></TABLE>>];
+
+}`
+	mustEqual(t, got, want, "graphviz user dark unique")
+}
+
+func TestGraphVizUserForest(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateGraphViz(r, ForestGraphVizTheme())
+	want := `digraph schema {
+    rankdir=LR;
+    fontname="Arial";
+    node [shape=record, style="filled,rounded", fontname="Arial", pad="0.5", margin="0.2"];
+    edge [color="#059669", style=solid, fontname="Arial"];
+
+    user [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4"><TR><TD BGCOLOR="#10b981" COLSPAN="2"><FONT COLOR="#FFFFFF"><B>user</B></FONT></TD></TR><TR><TD ALIGN="LEFT">id</TD><TD ALIGN="LEFT"><FONT COLOR="#94a3b8">string</FONT> <FONT COLOR="#ef4444">PK</FONT></TD></TR><TR><TD ALIGN="LEFT">email</TD><TD ALIGN="LEFT"><FONT COLOR="#10b981">string</FONT></TD></TR></TABLE>>];
+
+}`
+	mustEqual(t, got, want, "graphviz user forest")
+}
+
+func TestGraphVizUserMinimal(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateGraphViz(r, MinimalGraphVizTheme())
+	want := `digraph schema {
+    rankdir=LR;
+    fontname="Arial";
+    node [shape=record, style="filled", fontname="Arial", pad="0.5", margin="0.2"];
+    edge [color="#9ca3af", style=solid, fontname="Arial"];
+
+    user [label="{user|id : string (PK)\l|email : string\l}"];
+
+}`
+	mustEqual(t, got, want, "graphviz user minimal")
+}
+
+func TestGraphVizEdgesDefault(t *testing.T) {
+	user := NewTable("user", WithFields(StringField("email")))
+	post := NewTable("post",
+		WithFields(StringField("title"), RecordField("author", "user")),
+	)
+	wrote := TypedEdge("wrote", "user", "post", WithEdgeFields(DatetimeField("at")))
+	follows := TypedEdge("follows", "user", "user")
+	r := newRegistryWith(t, []TableDefinition{user, post}, []EdgeDefinition{wrote, follows})
+	got := GenerateGraphViz(r, GraphVizTheme{})
+	want := "digraph schema {\n    rankdir=LR;\n    node [shape=record];\n\n" +
+		"    post [label=\"{post|id : string (PK)\\l|title : string\\l|author : record (FK)\\l}\"];\n" +
+		"    user [label=\"{user|id : string (PK)\\l|email : string\\l}\"];\n" +
+		"    wrote [label=\"{wrote|at : datetime\\l}\"];\n\n" +
+		"    user -> user [label=\"follows\", style=dashed];\n" +
+		"    user -> post [label=\"wrote\"];\n}"
+	mustEqual(t, got, want, "graphviz edges default")
+}
+
+func TestGraphVizEdgesModernGradient(t *testing.T) {
+	// Self-referential follows edge picks up dashed + secondary color.
+	user := NewTable("user", WithFields(StringField("email")))
+	follows := TypedEdge("follows", "user", "user")
+	r := newRegistryWith(t, []TableDefinition{user}, []EdgeDefinition{follows})
+	got := GenerateGraphViz(r, ModernGraphVizTheme())
+	if !strings.Contains(got, `user -> user [label="follows", style=dashed, color="#ec4899"];`) {
+		t.Errorf("graphviz modern self-edge = %q", got)
+	}
+}
+
+func TestGraphVizIncludeFieldsFalse(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateGraphViz(r, GraphVizTheme{}, WithIncludeFields(false))
+	want := "digraph schema {\n    rankdir=LR;\n    node [shape=record];\n\n" +
+		"    user [label=\"user\"];\n\n}"
+	mustEqual(t, got, want, "graphviz no fields")
+}
+
+// -------------------- ASCII --------------------
+
+func TestASCIIEmpty(t *testing.T) {
+	r := NewSchemaRegistry()
+	got := GenerateASCII(r, ASCIITheme{})
+	if got != "" {
+		t.Errorf("ascii empty = %q, want empty", got)
+	}
+}
+
+func TestASCIIUserNoTheme(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateASCII(r, ASCIITheme{})
+	want := "+--------------------+\n" +
+		"|        user        |\n" +
+		"+--------------------+\n" +
+		"| id : string (PK)   |\n" +
+		"| email : string     |\n" +
+		"+--------------------+\n"
+	mustEqual(t, got, want, "ascii user no theme")
+}
+
+func TestASCIIUserMinimal(t *testing.T) {
+	user := NewTable("user",
+		WithFields(StringField("email"), StringField("name")),
+		WithIndexes(UniqueIndex("u_email", []string{"email"})),
+	)
+	r := newRegistryWith(t, []TableDefinition{user}, nil)
+	got := GenerateASCII(r, MinimalASCIITheme())
+	want := "┌─────────────────────┐\n" +
+		"│         user        │\n" +
+		"├─────────────────────┤\n" +
+		"│ id : string (PK)    │\n" +
+		"│ email : string (UK) │\n" +
+		"│ name : string       │\n" +
+		"└─────────────────────┘\n"
+	mustEqual(t, got, want, "ascii user minimal")
+}
+
+func TestASCIIUserModern(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateASCII(r, ModernASCIITheme())
+	want := "╭─────────────────────╮\n" +
+		"│\x1b[1m         user        \x1b[0m│\n" +
+		"├─────────────────────┤\n" +
+		"│ id : string \x1b[91m🔑 (PK)\x1b[0m │\n" +
+		"│ email : string      │\n" +
+		"╰─────────────────────╯\n"
+	mustEqual(t, got, want, "ascii user modern")
+}
+
+func TestASCIIUserDark(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateASCII(r, DarkASCIITheme())
+	want := "╭─────────────────────╮\n" +
+		"│\x1b[1m         user        \x1b[0m│\n" +
+		"├─────────────────────┤\n" +
+		"│ id : string \x1b[91m🔑 (PK)\x1b[0m │\n" +
+		"│ email : string      │\n" +
+		"╰─────────────────────╯\n"
+	mustEqual(t, got, want, "ascii user dark")
+}
+
+func TestASCIIUserForest(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateASCII(r, ForestASCIITheme())
+	want := "╭─────────────────────╮\n" +
+		"│\x1b[1m         user        \x1b[0m│\n" +
+		"├─────────────────────┤\n" +
+		"│ id : string \x1b[91m🔑 (PK)\x1b[0m │\n" +
+		"│ email : string      │\n" +
+		"╰─────────────────────╯\n"
+	mustEqual(t, got, want, "ascii user forest")
+}
+
+func TestASCIIPostModernFKConstraint(t *testing.T) {
+	post := NewTable("post",
+		WithFields(StringField("title"), RecordField("author", "user")),
+	)
+	r := newRegistryWith(t, []TableDefinition{post}, nil)
+	got := GenerateASCII(r, ModernASCIITheme())
+	want := "╭─────────────────────────╮\n" +
+		"│\x1b[1m           post          \x1b[0m│\n" +
+		"├─────────────────────────┤\n" +
+		"│ id : string \x1b[91m🔑 (PK)\x1b[0m     │\n" +
+		"│ title : string          │\n" +
+		"│ author : record \x1b[94m🔗 (FK)\x1b[0m │\n" +
+		"╰─────────────────────────╯\n"
+	mustEqual(t, got, want, "ascii post modern")
+}
+
+func TestASCIIRelationshipsSection(t *testing.T) {
+	user := NewTable("user", WithFields(StringField("email")))
+	post := NewTable("post", WithFields(StringField("title")))
+	wrote := TypedEdge("wrote", "user", "post")
+	r := newRegistryWith(t, []TableDefinition{user, post}, []EdgeDefinition{wrote})
+	got := GenerateASCII(r, MinimalASCIITheme())
+	if !strings.Contains(got, "Relationships:\n") {
+		t.Errorf("ascii missing Relationships header:\n%s", got)
+	}
+	if !strings.Contains(got, "  user --[wrote]--> post") {
+		t.Errorf("ascii missing edge line:\n%s", got)
+	}
+	if !strings.Contains(got, strings.Repeat("-", 40)) {
+		t.Errorf("ascii missing separator")
+	}
+}
+
+func TestASCIIIncludeFieldsFalse(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateASCII(r, MinimalASCIITheme(), WithIncludeFields(false))
+	// Minimal at width 20 (len('user')+4 < 20).
+	want := "┌────────────────────┐\n" +
+		"│        user        │\n" +
+		"└────────────────────┘\n"
+	mustEqual(t, got, want, "ascii no fields")
+}
+
+func TestASCIIIncludeEdgesFalse(t *testing.T) {
+	user := NewTable("user", WithFields(StringField("email")))
+	post := NewTable("post", WithFields(StringField("title")))
+	wrote := TypedEdge("wrote", "user", "post")
+	r := newRegistryWith(t, []TableDefinition{user, post}, []EdgeDefinition{wrote})
+	got := GenerateASCII(r, MinimalASCIITheme(), WithIncludeEdges(false))
+	if strings.Contains(got, "Relationships:") {
+		t.Errorf("ascii should not contain Relationships section:\n%s", got)
+	}
+}
+
+func TestASCIIManyFields(t *testing.T) {
+	// Longer field list to exercise box-width calculation.
+	fields := []FieldDefinition{
+		StringField("first_name"),
+		StringField("last_name"),
+		IntField("age"),
+		BoolField("active"),
+		DatetimeField("created_at"),
+	}
+	user := NewTable("user", WithFields(fields...))
+	r := newRegistryWith(t, []TableDefinition{user}, nil)
+	got := GenerateASCII(r, MinimalASCIITheme())
+	for _, name := range []string{"first_name", "last_name", "age", "active", "created_at"} {
+		if !strings.Contains(got, name) {
+			t.Errorf("ascii many fields missing %q:\n%s", name, got)
+		}
+	}
+	if !strings.Contains(got, "id : string (PK)") {
+		t.Errorf("ascii many fields missing id PK row:\n%s", got)
+	}
+}
+
+// -------------------- Registry plumbing --------------------
+
+func TestGenerateFromMapsMatchesRegistry(t *testing.T) {
+	user := NewTable("user", WithFields(StringField("email")))
+	r := newRegistryWith(t, []TableDefinition{user}, nil)
+	fromRegistry := GenerateMermaid(r, ModernMermaidTheme())
+	fromMaps := GenerateMermaidFromMaps(
+		map[string]TableDefinition{"user": user},
+		map[string]EdgeDefinition{},
+		ModernMermaidTheme(),
+	)
+	mustEqual(t, fromMaps, fromRegistry, "registry vs maps parity")
+}
+
+func TestWithIncludeFlagsApplyOrder(t *testing.T) {
+	// Repeated options should take the last value (standard functional-opt
+	// pattern).
+	o := resolveOptions([]VisualizeOption{
+		WithIncludeFields(true),
+		WithIncludeFields(false),
+		WithIncludeEdges(false),
+		WithIncludeEdges(true),
+	})
+	if o.IncludeFields != false {
+		t.Errorf("IncludeFields = %v, want false", o.IncludeFields)
+	}
+	if o.IncludeEdges != true {
+		t.Errorf("IncludeEdges = %v, want true", o.IncludeEdges)
+	}
+}
+
+func TestResolveOptionsDefaults(t *testing.T) {
+	o := resolveOptions(nil)
+	if !o.IncludeFields {
+		t.Errorf("default IncludeFields = false, want true")
+	}
+	if !o.IncludeEdges {
+		t.Errorf("default IncludeEdges = false, want true")
+	}
+}


### PR DESCRIPTION
Closes #19.

## Summary
Port surql-py/src/surql/schema/{visualize,themes,utils}.py.

- **\`schema/themes.go\`**: \`ColorScheme\`, \`GraphVizTheme\`, \`MermaidTheme\`, \`ASCIITheme\`, \`Theme\` structs + per-format builders (\`ModernMermaidTheme()\`, etc.) for all four presets. \`GetTheme(name)\` returns \`ErrValidation\` on unknowns.
- **\`schema/visualize.go\`**: \`GenerateMermaid\`, \`GenerateGraphViz\`, \`GenerateASCII\` + \`*FromMaps\` variants. Output matches Python byte-for-byte: Mermaid ER with cardinality inference, GraphViz DOT with HTML-like gradient labels + self-edge dashed styling, ASCII boxes with ANSI + emoji-aware padding.
- **\`schema/utils.go\`**: \`fieldConstraint\`, \`fieldTypeString\`, \`displayWidth\` (ANSI-strip + East-Asian-Wide emoji), \`centerPad\` (matches Python \`str.center\` left-bias), \`boxChars\`, \`colorize\`, \`constraintIcon\`.

## Deviations
- Python \`str.center\` places the extra space on the LEFT for odd-padding, opposite the obvious \`padding/2\` split. Reproduced exactly for golden-output parity.

## Test plan
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./... -race\` — **56 new tests green** (theme presets, util functions, golden outputs per format × theme + edge cases)
- [ ] CI green