### PR TITLE
feat(migration): port models + discovery

### DIFF
--- a/pkg/surql/migration/discovery.go
+++ b/pkg/surql/migration/discovery.go
@@ -1,0 +1,335 @@
+package migration
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// Section markers used inside migration files.
+const (
+	markerUp          = "-- @up"
+	markerDown        = "-- @down"
+	markerDescription = "-- @description:"
+	markerDependsOn   = "-- @depends_on:"
+)
+
+// filenameRe matches the YYYYMMDD_HHMMSS_description.surql convention.
+// The description may contain additional underscores and alphanumerics.
+var filenameRe = regexp.MustCompile(`^(\d{8})_(\d{6})_([A-Za-z0-9][A-Za-z0-9_-]*)\.surql$`)
+
+// DiscoverMigrations scans directory for `.surql` migration files and returns
+// them sorted by version (timestamp).
+//
+// Files whose names do not conform to the YYYYMMDD_HHMMSS_*.surql convention
+// are skipped silently (mirroring the Python port's glob-plus-validate
+// behaviour). A non-existent directory is not an error and yields an empty
+// slice. A path that exists but is not a directory returns a wrapped
+// surqlerrors.ErrMigrationDiscovery.
+func DiscoverMigrations(directory string) ([]Migration, error) {
+	info, err := os.Stat(directory)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []Migration{}, nil
+		}
+		return nil, surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationDiscovery, err,
+			"cannot stat migration directory %q", directory,
+		)
+	}
+	if !info.IsDir() {
+		return nil, surqlerrors.Newf(
+			surqlerrors.ErrMigrationDiscovery,
+			"path is not a directory: %q", directory,
+		)
+	}
+
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return nil, surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationDiscovery, err,
+			"cannot read migration directory %q", directory,
+		)
+	}
+
+	migrations := make([]Migration, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !ValidateMigrationName(name) {
+			continue
+		}
+		full := filepath.Join(directory, name)
+		m, err := LoadMigration(full)
+		if err != nil {
+			return nil, surqlerrors.Wrapf(
+				surqlerrors.ErrMigrationDiscovery, err,
+				"failed to load migration %q", full,
+			)
+		}
+		migrations = append(migrations, m)
+	}
+
+	sort.SliceStable(migrations, func(i, j int) bool {
+		return migrations[i].Version < migrations[j].Version
+	})
+	return migrations, nil
+}
+
+// LoadMigration loads a single `.surql` migration file.
+//
+// The file must contain `-- @up` and `-- @down` section markers. Optional
+// `-- @description:` and `-- @depends_on:` header lines override the values
+// derived from the file name.
+func LoadMigration(path string) (Migration, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Migration{}, surqlerrors.Newf(
+				surqlerrors.ErrMigrationLoad,
+				"migration file not found: %q", path,
+			)
+		}
+		return Migration{}, surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationLoad, err,
+			"cannot stat migration file %q", path,
+		)
+	}
+	if info.IsDir() {
+		return Migration{}, surqlerrors.Newf(
+			surqlerrors.ErrMigrationLoad,
+			"path is not a file: %q", path,
+		)
+	}
+
+	filename := filepath.Base(path)
+	if !ValidateMigrationName(filename) {
+		return Migration{}, surqlerrors.Newf(
+			surqlerrors.ErrMigrationLoad,
+			"invalid migration filename: %q", filename,
+		)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return Migration{}, surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationLoad, err,
+			"cannot read migration file %q", path,
+		)
+	}
+
+	parsed, err := parseMigrationContent(string(content))
+	if err != nil {
+		return Migration{}, surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationLoad, err,
+			"failed to parse migration %q", path,
+		)
+	}
+
+	version, _ := GetVersionFromFilename(filename)
+	description := parsed.description
+	if description == "" {
+		desc, _ := GetDescriptionFromFilename(filename)
+		description = humanizeDescription(desc)
+	}
+
+	return Migration{
+		Version:        version,
+		Description:    description,
+		Path:           path,
+		UpStatements:   parsed.up,
+		DownStatements: parsed.down,
+		Checksum:       sha256Hex(content),
+		DependsOn:      parsed.dependsOn,
+	}, nil
+}
+
+// ValidateMigrationName reports whether filename matches the
+// YYYYMMDD_HHMMSS_description.surql convention.
+func ValidateMigrationName(filename string) bool {
+	return filenameRe.MatchString(filename)
+}
+
+// GetVersionFromFilename returns the YYYYMMDD_HHMMSS version component of a
+// migration file name. The boolean is false when the filename does not match
+// the expected convention.
+func GetVersionFromFilename(filename string) (string, bool) {
+	m := filenameRe.FindStringSubmatch(filename)
+	if m == nil {
+		return "", false
+	}
+	return m[1] + "_" + m[2], true
+}
+
+// GetDescriptionFromFilename returns the description component of a
+// migration file name. The boolean is false when the filename does not match
+// the expected convention.
+func GetDescriptionFromFilename(filename string) (string, bool) {
+	m := filenameRe.FindStringSubmatch(filename)
+	if m == nil {
+		return "", false
+	}
+	return m[3], true
+}
+
+// parsed holds the three logical sections extracted from a migration file.
+type parsed struct {
+	description string
+	dependsOn   []string
+	up          []string
+	down        []string
+}
+
+// parseMigrationContent splits a migration file body into header, up, and
+// down sections and returns cleaned statement slices.
+func parseMigrationContent(body string) (parsed, error) {
+	var p parsed
+
+	// Normalize line endings and split.
+	body = strings.ReplaceAll(body, "\r\n", "\n")
+	lines := strings.Split(body, "\n")
+
+	// Locate section markers. Markers are expected on their own line (after
+	// any leading whitespace).
+	upIdx, downIdx := -1, -1
+	for i, raw := range lines {
+		trim := strings.TrimSpace(raw)
+		switch {
+		case trim == markerUp:
+			if upIdx != -1 {
+				return parsed{}, surqlerrors.New(
+					surqlerrors.ErrMigrationLoad,
+					"duplicate '-- @up' marker",
+				)
+			}
+			upIdx = i
+		case trim == markerDown:
+			if downIdx != -1 {
+				return parsed{}, surqlerrors.New(
+					surqlerrors.ErrMigrationLoad,
+					"duplicate '-- @down' marker",
+				)
+			}
+			downIdx = i
+		}
+	}
+
+	if upIdx == -1 {
+		return parsed{}, surqlerrors.New(
+			surqlerrors.ErrMigrationLoad,
+			"missing '-- @up' section marker",
+		)
+	}
+	if downIdx == -1 {
+		return parsed{}, surqlerrors.New(
+			surqlerrors.ErrMigrationLoad,
+			"missing '-- @down' section marker",
+		)
+	}
+	if downIdx < upIdx {
+		return parsed{}, surqlerrors.New(
+			surqlerrors.ErrMigrationLoad,
+			"'-- @down' marker must follow '-- @up'",
+		)
+	}
+
+	// Header lines: everything above upIdx.
+	for _, raw := range lines[:upIdx] {
+		trim := strings.TrimSpace(raw)
+		switch {
+		case strings.HasPrefix(trim, markerDescription):
+			p.description = strings.TrimSpace(strings.TrimPrefix(trim, markerDescription))
+		case strings.HasPrefix(trim, markerDependsOn):
+			p.dependsOn = splitCSV(strings.TrimPrefix(trim, markerDependsOn))
+		}
+	}
+
+	// Up / down sections.
+	p.up = splitStatements(lines[upIdx+1 : downIdx])
+	p.down = splitStatements(lines[downIdx+1:])
+
+	return p, nil
+}
+
+// splitStatements joins the given lines, removes pure-comment and blank
+// lines, and splits the remainder on `;` boundaries, trimming whitespace.
+func splitStatements(lines []string) []string {
+	cleaned := make([]string, 0, len(lines))
+	for _, raw := range lines {
+		trim := strings.TrimSpace(raw)
+		if trim == "" {
+			continue
+		}
+		if strings.HasPrefix(trim, "--") {
+			continue
+		}
+		cleaned = append(cleaned, raw)
+	}
+	if len(cleaned) == 0 {
+		return nil
+	}
+	joined := strings.Join(cleaned, "\n")
+	parts := strings.Split(joined, ";")
+
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		stmt := strings.TrimSpace(part)
+		if stmt == "" {
+			continue
+		}
+		out = append(out, stmt+";")
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// splitCSV splits a comma-separated header value, trimming whitespace and
+// dropping empty entries. Returns nil when the input has no values.
+func splitCSV(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	raw := strings.Split(s, ",")
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		out = append(out, v)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// humanizeDescription converts an underscore/dash-separated slug into a
+// space-separated label: `create_user_table` -> `create user table`.
+func humanizeDescription(slug string) string {
+	if slug == "" {
+		return ""
+	}
+	slug = strings.ReplaceAll(slug, "-", " ")
+	slug = strings.ReplaceAll(slug, "_", " ")
+	// Collapse duplicated whitespace.
+	fields := strings.Fields(slug)
+	return strings.Join(fields, " ")
+}
+
+// sha256Hex returns the hex-encoded SHA-256 digest of the given bytes.
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/surql/migration/discovery_test.go
+++ b/pkg/surql/migration/discovery_test.go
@@ -1,0 +1,615 @@
+package migration
+
+import (
+	stdErrors "errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// writeFile is a small test helper that creates a file with the given body.
+func writeFile(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+const sampleMigration = `-- @description: create user table
+-- @depends_on: 20260101_000000_init
+-- @up
+DEFINE TABLE user SCHEMAFULL;
+DEFINE FIELD email ON user TYPE string;
+-- @down
+REMOVE TABLE user;
+`
+
+const sampleNoHeaders = `-- @up
+DEFINE TABLE foo SCHEMAFULL;
+-- @down
+REMOVE TABLE foo;
+`
+
+func TestValidateMigrationName_Valid(t *testing.T) {
+	cases := []string{
+		"20260102_120000_create_user.surql",
+		"20260101_000000_init.surql",
+		"20991231_235959_create_user_table.surql",
+		"20260102_120000_name-with-dash.surql",
+	}
+	for _, name := range cases {
+		if !ValidateMigrationName(name) {
+			t.Errorf("expected %q to be valid", name)
+		}
+	}
+}
+
+func TestValidateMigrationName_Invalid(t *testing.T) {
+	cases := []string{
+		"",
+		"invalid.surql",
+		"20260102_120000.surql",
+		"20260102_120000_.surql",
+		"2026010_120000_x.surql",
+		"20260102_12000_x.surql",
+		"20260102-120000_x.surql",
+		"20260102_120000_create_user.py",
+		"20260102_120000_create_user",
+		"_20260102_120000_create_user.surql",
+		"20260102_120000_bad!.surql",
+	}
+	for _, name := range cases {
+		if ValidateMigrationName(name) {
+			t.Errorf("expected %q to be invalid", name)
+		}
+	}
+}
+
+func TestGetVersionFromFilename(t *testing.T) {
+	v, ok := GetVersionFromFilename("20260102_120000_create_user.surql")
+	if !ok || v != "20260102_120000" {
+		t.Errorf("version = %q, ok = %v", v, ok)
+	}
+	if _, ok := GetVersionFromFilename("invalid.surql"); ok {
+		t.Errorf("expected ok = false for invalid name")
+	}
+}
+
+func TestGetDescriptionFromFilename(t *testing.T) {
+	d, ok := GetDescriptionFromFilename("20260102_120000_create_user_table.surql")
+	if !ok || d != "create_user_table" {
+		t.Errorf("description = %q, ok = %v", d, ok)
+	}
+	if _, ok := GetDescriptionFromFilename("invalid.surql"); ok {
+		t.Errorf("expected ok = false for invalid name")
+	}
+}
+
+func TestLoadMigration_Happy(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_create_user_table.surql", sampleMigration)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if m.Version != "20260102_120000" {
+		t.Errorf("version = %q", m.Version)
+	}
+	if m.Description != "create user table" {
+		t.Errorf("description = %q", m.Description)
+	}
+	if m.Path != p {
+		t.Errorf("path = %q", m.Path)
+	}
+	if len(m.UpStatements) != 2 {
+		t.Fatalf("up statements = %d, want 2", len(m.UpStatements))
+	}
+	if m.UpStatements[0] != "DEFINE TABLE user SCHEMAFULL;" {
+		t.Errorf("up[0] = %q", m.UpStatements[0])
+	}
+	if m.UpStatements[1] != "DEFINE FIELD email ON user TYPE string;" {
+		t.Errorf("up[1] = %q", m.UpStatements[1])
+	}
+	if len(m.DownStatements) != 1 || m.DownStatements[0] != "REMOVE TABLE user;" {
+		t.Errorf("down = %+v", m.DownStatements)
+	}
+	if len(m.DependsOn) != 1 || m.DependsOn[0] != "20260101_000000_init" {
+		t.Errorf("depends_on = %+v", m.DependsOn)
+	}
+	if len(m.Checksum) != 64 {
+		t.Errorf("checksum len = %d", len(m.Checksum))
+	}
+}
+
+func TestLoadMigration_DescriptionFallback(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_create_user_table.surql", sampleNoHeaders)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	// No explicit description header -> derived from filename, humanized.
+	// Note that filename description is "create_user_table".
+	if m.Description != "create user table" {
+		t.Errorf("description fallback = %q", m.Description)
+	}
+	if len(m.DependsOn) != 0 {
+		t.Errorf("depends_on = %+v", m.DependsOn)
+	}
+}
+
+func TestLoadMigration_FileNotFound(t *testing.T) {
+	dir := t.TempDir()
+	_, err := LoadMigration(filepath.Join(dir, "missing.surql"))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestLoadMigration_DirectoryRejected(t *testing.T) {
+	dir := t.TempDir()
+	_, err := LoadMigration(dir)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestLoadMigration_InvalidFilename(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "bad_name.surql", sampleMigration)
+
+	_, err := LoadMigration(p)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestLoadMigration_MissingUpMarker(t *testing.T) {
+	body := `-- @description: x
+DEFINE TABLE foo;
+-- @down
+REMOVE TABLE foo;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_x.surql", body)
+
+	_, err := LoadMigration(p)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestLoadMigration_MissingDownMarker(t *testing.T) {
+	body := `-- @up
+DEFINE TABLE foo;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_x.surql", body)
+
+	_, err := LoadMigration(p)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestLoadMigration_DownBeforeUp(t *testing.T) {
+	body := `-- @down
+REMOVE TABLE foo;
+-- @up
+DEFINE TABLE foo;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_x.surql", body)
+
+	_, err := LoadMigration(p)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestLoadMigration_DuplicateUpMarker(t *testing.T) {
+	body := `-- @up
+DEFINE TABLE foo;
+-- @up
+DEFINE TABLE bar;
+-- @down
+REMOVE TABLE foo;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_x.surql", body)
+
+	_, err := LoadMigration(p)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestLoadMigration_DuplicateDownMarker(t *testing.T) {
+	body := `-- @up
+DEFINE TABLE foo;
+-- @down
+REMOVE TABLE foo;
+-- @down
+REMOVE TABLE bar;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_x.surql", body)
+
+	_, err := LoadMigration(p)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestLoadMigration_CRLFEndings(t *testing.T) {
+	body := "-- @up\r\nDEFINE TABLE foo;\r\n-- @down\r\nREMOVE TABLE foo;\r\n"
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_crlf_test.surql", body)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if len(m.UpStatements) != 1 || m.UpStatements[0] != "DEFINE TABLE foo;" {
+		t.Errorf("up = %+v", m.UpStatements)
+	}
+	if len(m.DownStatements) != 1 || m.DownStatements[0] != "REMOVE TABLE foo;" {
+		t.Errorf("down = %+v", m.DownStatements)
+	}
+}
+
+func TestLoadMigration_MultiStatementLine(t *testing.T) {
+	body := `-- @up
+DEFINE TABLE a; DEFINE TABLE b;
+DEFINE TABLE c;
+-- @down
+REMOVE TABLE c; REMOVE TABLE b; REMOVE TABLE a;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_multi.surql", body)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if len(m.UpStatements) != 3 {
+		t.Errorf("up len = %d: %+v", len(m.UpStatements), m.UpStatements)
+	}
+	if len(m.DownStatements) != 3 {
+		t.Errorf("down len = %d: %+v", len(m.DownStatements), m.DownStatements)
+	}
+}
+
+func TestLoadMigration_CommentsAndBlankLinesDropped(t *testing.T) {
+	body := `-- @up
+-- this is a comment
+
+DEFINE TABLE a;
+
+-- another comment
+DEFINE TABLE b;
+-- @down
+REMOVE TABLE b;
+REMOVE TABLE a;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_comments.surql", body)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if len(m.UpStatements) != 2 {
+		t.Errorf("up = %+v", m.UpStatements)
+	}
+	if m.UpStatements[0] != "DEFINE TABLE a;" || m.UpStatements[1] != "DEFINE TABLE b;" {
+		t.Errorf("up contents = %+v", m.UpStatements)
+	}
+}
+
+func TestLoadMigration_ExplicitDescriptionOverridesFilename(t *testing.T) {
+	body := `-- @description: Shiny user table
+-- @up
+DEFINE TABLE user;
+-- @down
+REMOVE TABLE user;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_create_user.surql", body)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if m.Description != "Shiny user table" {
+		t.Errorf("description = %q", m.Description)
+	}
+}
+
+func TestLoadMigration_DependsOnMultipleValues(t *testing.T) {
+	body := `-- @depends_on: 20260101_000000_init,  20260101_010000_seed
+-- @up
+SELECT 1;
+-- @down
+SELECT 0;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_multi_dep.surql", body)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if len(m.DependsOn) != 2 {
+		t.Fatalf("depends_on len = %d: %+v", len(m.DependsOn), m.DependsOn)
+	}
+	if m.DependsOn[0] != "20260101_000000_init" || m.DependsOn[1] != "20260101_010000_seed" {
+		t.Errorf("depends_on = %+v", m.DependsOn)
+	}
+}
+
+func TestLoadMigration_DependsOnEmptyValue(t *testing.T) {
+	body := `-- @depends_on:
+-- @up
+SELECT 1;
+-- @down
+SELECT 0;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_empty_dep.surql", body)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if len(m.DependsOn) != 0 {
+		t.Errorf("depends_on = %+v", m.DependsOn)
+	}
+}
+
+func TestLoadMigration_ChecksumStableAcrossReads(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_stable.surql", sampleMigration)
+
+	m1, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	m2, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	if m1.Checksum != m2.Checksum {
+		t.Errorf("checksum mismatch: %q vs %q", m1.Checksum, m2.Checksum)
+	}
+}
+
+func TestLoadMigration_ChecksumChangesWithContent(t *testing.T) {
+	dir := t.TempDir()
+	p1 := writeFile(t, dir, "20260102_120000_one.surql", sampleMigration)
+	p2 := writeFile(t, dir, "20260102_120001_two.surql", sampleNoHeaders)
+
+	m1, err := LoadMigration(p1)
+	if err != nil {
+		t.Fatalf("load p1: %v", err)
+	}
+	m2, err := LoadMigration(p2)
+	if err != nil {
+		t.Fatalf("load p2: %v", err)
+	}
+	if m1.Checksum == m2.Checksum {
+		t.Errorf("different content produced identical checksum")
+	}
+}
+
+func TestDiscoverMigrations_EmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	ms, err := DiscoverMigrations(dir)
+	if err != nil {
+		t.Fatalf("DiscoverMigrations: %v", err)
+	}
+	if len(ms) != 0 {
+		t.Errorf("expected empty, got %d", len(ms))
+	}
+}
+
+func TestDiscoverMigrations_NonexistentDirectory(t *testing.T) {
+	ms, err := DiscoverMigrations(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatalf("DiscoverMigrations: %v", err)
+	}
+	if len(ms) != 0 {
+		t.Errorf("expected empty, got %d", len(ms))
+	}
+}
+
+func TestDiscoverMigrations_PathIsFileRejected(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_x.surql", sampleMigration)
+
+	_, err := DiscoverMigrations(p)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationDiscovery) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestDiscoverMigrations_SortedByVersion(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "20260103_120000_c.surql", sampleNoHeaders)
+	writeFile(t, dir, "20260101_120000_a.surql", sampleNoHeaders)
+	writeFile(t, dir, "20260102_120000_b.surql", sampleNoHeaders)
+
+	ms, err := DiscoverMigrations(dir)
+	if err != nil {
+		t.Fatalf("DiscoverMigrations: %v", err)
+	}
+	if len(ms) != 3 {
+		t.Fatalf("len = %d", len(ms))
+	}
+	wantOrder := []string{"20260101_120000", "20260102_120000", "20260103_120000"}
+	for i, want := range wantOrder {
+		if ms[i].Version != want {
+			t.Errorf("ms[%d].Version = %q, want %q", i, ms[i].Version, want)
+		}
+	}
+}
+
+func TestDiscoverMigrations_SkipsInvalidNames(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "20260102_120000_ok.surql", sampleNoHeaders)
+	writeFile(t, dir, "not-a-migration.surql", "random body")
+	writeFile(t, dir, "README.md", "hi")
+	writeFile(t, dir, ".hidden.surql", "SELECT 1;")
+
+	ms, err := DiscoverMigrations(dir)
+	if err != nil {
+		t.Fatalf("DiscoverMigrations: %v", err)
+	}
+	if len(ms) != 1 || ms[0].Version != "20260102_120000" {
+		t.Errorf("unexpected result: %+v", ms)
+	}
+}
+
+func TestDiscoverMigrations_SkipsSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "20260102_120000_looks_like_migration.surql")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeFile(t, dir, "20260103_120000_real.surql", sampleNoHeaders)
+
+	ms, err := DiscoverMigrations(dir)
+	if err != nil {
+		t.Fatalf("DiscoverMigrations: %v", err)
+	}
+	if len(ms) != 1 || ms[0].Version != "20260103_120000" {
+		t.Errorf("unexpected result: %+v", ms)
+	}
+}
+
+func TestDiscoverMigrations_PropagatesLoadError(t *testing.T) {
+	dir := t.TempDir()
+	// Valid filename but no markers -> load error.
+	writeFile(t, dir, "20260102_120000_broken.surql", "SELECT 1;\n")
+
+	_, err := DiscoverMigrations(dir)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationDiscovery) {
+		t.Errorf("discovery kind not found: %v", err)
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("load kind not found in chain: %v", err)
+	}
+}
+
+func TestDiscoverMigrations_MultipleValidFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "20260101_000000_init.surql", sampleNoHeaders)
+	writeFile(t, dir, "20260102_120000_create_user_table.surql", sampleMigration)
+
+	ms, err := DiscoverMigrations(dir)
+	if err != nil {
+		t.Fatalf("DiscoverMigrations: %v", err)
+	}
+	if len(ms) != 2 {
+		t.Fatalf("len = %d", len(ms))
+	}
+	if ms[0].Version != "20260101_000000" || ms[1].Version != "20260102_120000" {
+		t.Errorf("unexpected versions: %+v", ms)
+	}
+	if ms[1].Description != "create user table" {
+		t.Errorf("description = %q", ms[1].Description)
+	}
+}
+
+func TestLoadMigration_EmptyUpSectionAllowed(t *testing.T) {
+	// An empty up section is unusual but not structurally illegal; it just
+	// yields nil statements. We assert the parser doesn't crash and caller
+	// gets back an empty slice, not an error.
+	body := `-- @up
+-- @down
+REMOVE TABLE foo;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_empty_up.surql", body)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if len(m.UpStatements) != 0 {
+		t.Errorf("expected empty up, got %+v", m.UpStatements)
+	}
+	if len(m.DownStatements) != 1 {
+		t.Errorf("down = %+v", m.DownStatements)
+	}
+}
+
+func TestLoadMigration_TrailingWhitespaceInStatements(t *testing.T) {
+	body := "-- @up\n   DEFINE TABLE foo ;   \n-- @down\nREMOVE TABLE foo;\n"
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_ws.surql", body)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if len(m.UpStatements) != 1 || m.UpStatements[0] != "DEFINE TABLE foo;" {
+		t.Errorf("up = %+v", m.UpStatements)
+	}
+}
+
+func TestHumanizeDescriptionFallback_Empty(t *testing.T) {
+	// If somehow the filename regex succeeds with an empty description (it
+	// cannot today), the helper should still behave sensibly. We test the
+	// exported path via a filename whose description is a single word.
+	dir := t.TempDir()
+	body := `-- @up
+SELECT 1;
+-- @down
+SELECT 0;
+`
+	p := writeFile(t, dir, "20260102_120000_single.surql", body)
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if m.Description != "single" {
+		t.Errorf("description = %q", m.Description)
+	}
+}

--- a/pkg/surql/migration/doc.go
+++ b/pkg/surql/migration/doc.go
@@ -1,0 +1,38 @@
+// Package migration provides schema migration primitives for surql.
+//
+// This package is a Go port of surql-py/src/surql/migration/. The current
+// increment covers only migration models and file-system discovery. Diff,
+// executor, generator, history store, hooks, rollback, squash, versioning,
+// and watcher tooling are tracked in follow-up work.
+//
+// # File format
+//
+// Python loads `.py` migration files at runtime and invokes `up()` / `down()`
+// callables plus a `metadata` dict. Go has no equivalent dynamic-import
+// mechanism, so the Go port switches to a flat-file `.surql` format with
+// section markers:
+//
+//	-- @description: create user table
+//	-- @depends_on: 20260101_000000_init
+//	-- @up
+//	DEFINE TABLE user SCHEMAFULL;
+//	DEFINE FIELD email ON user TYPE string;
+//	-- @down
+//	REMOVE TABLE user;
+//
+// Rules:
+//
+//   - The file name follows the Python convention:
+//     YYYYMMDD_HHMMSS_description.surql.
+//   - `-- @up` and `-- @down` markers are required; content above `-- @up`
+//     is header metadata, content between `-- @up` and `-- @down` is the
+//     forward migration, and content after `-- @down` is the rollback.
+//   - Statements are split on semicolons; empty statements and pure
+//     comment lines inside a section are discarded.
+//   - `-- @description:` and `-- @depends_on:` headers are optional.
+//     When missing, description falls back to the filename-derived value
+//     and depends_on defaults to the empty slice.
+//
+// The migration Checksum is a SHA-256 digest of the raw file contents,
+// matching the Python port for cross-language compatibility.
+package migration

--- a/pkg/surql/migration/models.go
+++ b/pkg/surql/migration/models.go
@@ -1,0 +1,164 @@
+package migration
+
+import (
+	"time"
+)
+
+// MigrationState is the state of a migration in the execution lifecycle.
+type MigrationState string
+
+// MigrationState values mirrored from surql-py MigrationState enum.
+const (
+	MigrationStatePending MigrationState = "pending"
+	MigrationStateApplied MigrationState = "applied"
+	MigrationStateFailed  MigrationState = "failed"
+)
+
+// IsValid reports whether the receiver is one of the defined MigrationState
+// constants.
+func (s MigrationState) IsValid() bool {
+	switch s {
+	case MigrationStatePending, MigrationStateApplied, MigrationStateFailed:
+		return true
+	}
+	return false
+}
+
+// String returns the serialized form of the state.
+func (s MigrationState) String() string { return string(s) }
+
+// MigrationDirection indicates whether a migration is applied forward (up)
+// or rolled back (down).
+type MigrationDirection string
+
+// MigrationDirection values mirrored from surql-py MigrationDirection enum.
+const (
+	MigrationDirectionUp   MigrationDirection = "up"
+	MigrationDirectionDown MigrationDirection = "down"
+)
+
+// IsValid reports whether the receiver is one of the defined
+// MigrationDirection constants.
+func (d MigrationDirection) IsValid() bool {
+	switch d {
+	case MigrationDirectionUp, MigrationDirectionDown:
+		return true
+	}
+	return false
+}
+
+// String returns the serialized form of the direction.
+func (d MigrationDirection) String() string { return string(d) }
+
+// DiffOperation enumerates the kinds of schema changes a diff can produce.
+type DiffOperation string
+
+// DiffOperation values mirrored from surql-py DiffOperation enum.
+const (
+	DiffOperationAddTable          DiffOperation = "add_table"
+	DiffOperationDropTable         DiffOperation = "drop_table"
+	DiffOperationAddField          DiffOperation = "add_field"
+	DiffOperationDropField         DiffOperation = "drop_field"
+	DiffOperationModifyField       DiffOperation = "modify_field"
+	DiffOperationAddIndex          DiffOperation = "add_index"
+	DiffOperationDropIndex         DiffOperation = "drop_index"
+	DiffOperationAddEvent          DiffOperation = "add_event"
+	DiffOperationDropEvent         DiffOperation = "drop_event"
+	DiffOperationModifyPermissions DiffOperation = "modify_permissions"
+)
+
+// IsValid reports whether the receiver is one of the defined DiffOperation
+// constants.
+func (o DiffOperation) IsValid() bool {
+	switch o {
+	case DiffOperationAddTable, DiffOperationDropTable,
+		DiffOperationAddField, DiffOperationDropField, DiffOperationModifyField,
+		DiffOperationAddIndex, DiffOperationDropIndex,
+		DiffOperationAddEvent, DiffOperationDropEvent,
+		DiffOperationModifyPermissions:
+		return true
+	}
+	return false
+}
+
+// String returns the serialized form of the operation.
+func (o DiffOperation) String() string { return string(o) }
+
+// Migration is a single migration definition, parsed from a `.surql` file.
+//
+// Unlike the Python port (which carries Python callables), the Go model
+// stores pre-parsed SurrealQL statement slices for the forward and rollback
+// directions. This keeps the struct trivially serializable and thread-safe.
+type Migration struct {
+	// Version is the timestamp-based version string (YYYYMMDD_HHMMSS).
+	Version string `json:"version"`
+	// Description is a short human-readable summary.
+	Description string `json:"description"`
+	// Path is the absolute or relative path the migration was loaded from.
+	// Empty when the migration was constructed in memory.
+	Path string `json:"path,omitempty"`
+	// UpStatements are the SurrealQL statements executed for a forward migration.
+	UpStatements []string `json:"up_statements"`
+	// DownStatements are the SurrealQL statements executed on rollback.
+	DownStatements []string `json:"down_statements"`
+	// Checksum is a SHA-256 digest of the raw file contents, used to detect
+	// drift between applied and on-disk migrations. Empty when unknown.
+	Checksum string `json:"checksum,omitempty"`
+	// DependsOn lists version strings this migration requires to be applied
+	// first. Empty when there are no explicit dependencies.
+	DependsOn []string `json:"depends_on,omitempty"`
+}
+
+// MigrationHistory is a record of a migration that has been applied to the
+// database. It is intended to be persisted (JSON-serializable).
+type MigrationHistory struct {
+	Version         string    `json:"version"`
+	Description     string    `json:"description"`
+	AppliedAt       time.Time `json:"applied_at"`
+	Checksum        string    `json:"checksum"`
+	ExecutionTimeMs *int64    `json:"execution_time_ms,omitempty"`
+}
+
+// MigrationPlan is an ordered list of migrations with a direction.
+type MigrationPlan struct {
+	Migrations []Migration        `json:"migrations"`
+	Direction  MigrationDirection `json:"direction"`
+}
+
+// Count returns the number of migrations in the plan.
+func (p MigrationPlan) Count() int { return len(p.Migrations) }
+
+// IsEmpty reports whether the plan contains no migrations.
+func (p MigrationPlan) IsEmpty() bool { return len(p.Migrations) == 0 }
+
+// MigrationMetadata is the parsed header metadata of a migration file,
+// mirroring the Python MigrationMetadata model.
+type MigrationMetadata struct {
+	Version     string   `json:"version"`
+	Description string   `json:"description"`
+	Author      string   `json:"author,omitempty"`
+	DependsOn   []string `json:"depends_on,omitempty"`
+}
+
+// MigrationStatus combines a migration definition with its observed state,
+// optionally with the application timestamp and a last-error message.
+type MigrationStatus struct {
+	Migration Migration      `json:"migration"`
+	State     MigrationState `json:"state"`
+	AppliedAt *time.Time     `json:"applied_at,omitempty"`
+	Error     string         `json:"error,omitempty"`
+}
+
+// SchemaDiff represents a single difference between two schema versions,
+// carrying both the forward and backward SurrealQL to apply / revert it.
+type SchemaDiff struct {
+	Operation   DiffOperation  `json:"operation"`
+	Table       string         `json:"table"`
+	Field       string         `json:"field,omitempty"`
+	Index       string         `json:"index,omitempty"`
+	Event       string         `json:"event,omitempty"`
+	Description string         `json:"description"`
+	ForwardSQL  string         `json:"forward_sql"`
+	BackwardSQL string         `json:"backward_sql"`
+	Details     map[string]any `json:"details,omitempty"`
+}

--- a/pkg/surql/migration/models_test.go
+++ b/pkg/surql/migration/models_test.go
@@ -1,0 +1,355 @@
+package migration
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestMigrationState_IsValid(t *testing.T) {
+	cases := []struct {
+		in   MigrationState
+		want bool
+	}{
+		{MigrationStatePending, true},
+		{MigrationStateApplied, true},
+		{MigrationStateFailed, true},
+		{MigrationState(""), false},
+		{MigrationState("bogus"), false},
+	}
+	for _, tc := range cases {
+		if got := tc.in.IsValid(); got != tc.want {
+			t.Errorf("MigrationState(%q).IsValid() = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMigrationState_String(t *testing.T) {
+	pairs := map[MigrationState]string{
+		MigrationStatePending: "pending",
+		MigrationStateApplied: "applied",
+		MigrationStateFailed:  "failed",
+	}
+	for state, want := range pairs {
+		if got := state.String(); got != want {
+			t.Errorf("MigrationState(%q).String() = %q, want %q", state, got, want)
+		}
+	}
+}
+
+func TestMigrationDirection_IsValid(t *testing.T) {
+	cases := []struct {
+		in   MigrationDirection
+		want bool
+	}{
+		{MigrationDirectionUp, true},
+		{MigrationDirectionDown, true},
+		{MigrationDirection(""), false},
+		{MigrationDirection("sideways"), false},
+	}
+	for _, tc := range cases {
+		if got := tc.in.IsValid(); got != tc.want {
+			t.Errorf("MigrationDirection(%q).IsValid() = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMigrationDirection_String(t *testing.T) {
+	if MigrationDirectionUp.String() != "up" {
+		t.Errorf("up direction string = %q", MigrationDirectionUp.String())
+	}
+	if MigrationDirectionDown.String() != "down" {
+		t.Errorf("down direction string = %q", MigrationDirectionDown.String())
+	}
+}
+
+func TestDiffOperation_IsValid(t *testing.T) {
+	valid := []DiffOperation{
+		DiffOperationAddTable,
+		DiffOperationDropTable,
+		DiffOperationAddField,
+		DiffOperationDropField,
+		DiffOperationModifyField,
+		DiffOperationAddIndex,
+		DiffOperationDropIndex,
+		DiffOperationAddEvent,
+		DiffOperationDropEvent,
+		DiffOperationModifyPermissions,
+	}
+	for _, op := range valid {
+		if !op.IsValid() {
+			t.Errorf("DiffOperation(%q) should be valid", op)
+		}
+	}
+	invalid := []DiffOperation{"", "unknown", "ADD_TABLE"}
+	for _, op := range invalid {
+		if op.IsValid() {
+			t.Errorf("DiffOperation(%q) should be invalid", op)
+		}
+	}
+}
+
+func TestDiffOperation_String(t *testing.T) {
+	if DiffOperationAddTable.String() != "add_table" {
+		t.Errorf("add_table string = %q", DiffOperationAddTable.String())
+	}
+}
+
+func TestMigrationPlan_CountAndIsEmpty(t *testing.T) {
+	empty := MigrationPlan{Direction: MigrationDirectionUp}
+	if empty.Count() != 0 {
+		t.Errorf("empty plan Count = %d", empty.Count())
+	}
+	if !empty.IsEmpty() {
+		t.Errorf("empty plan IsEmpty = false")
+	}
+
+	full := MigrationPlan{
+		Migrations: []Migration{
+			{Version: "20260101_000000", Description: "a"},
+			{Version: "20260102_000000", Description: "b"},
+		},
+		Direction: MigrationDirectionDown,
+	}
+	if full.Count() != 2 {
+		t.Errorf("full plan Count = %d", full.Count())
+	}
+	if full.IsEmpty() {
+		t.Errorf("full plan IsEmpty = true")
+	}
+}
+
+func TestMigration_JSONRoundTrip(t *testing.T) {
+	m := Migration{
+		Version:        "20260102_120000",
+		Description:    "create user table",
+		Path:           "migrations/20260102_120000_create_user_table.surql",
+		UpStatements:   []string{"DEFINE TABLE user SCHEMAFULL;"},
+		DownStatements: []string{"REMOVE TABLE user;"},
+		Checksum:       "abc123",
+		DependsOn:      []string{"20260101_000000_init"},
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round Migration
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if round.Version != m.Version || round.Description != m.Description {
+		t.Errorf("mismatch after round trip: %+v vs %+v", round, m)
+	}
+	if len(round.UpStatements) != 1 || round.UpStatements[0] != m.UpStatements[0] {
+		t.Errorf("up statements mismatch: %+v", round.UpStatements)
+	}
+	if len(round.DownStatements) != 1 || round.DownStatements[0] != m.DownStatements[0] {
+		t.Errorf("down statements mismatch: %+v", round.DownStatements)
+	}
+	if round.Checksum != m.Checksum {
+		t.Errorf("checksum mismatch: %q", round.Checksum)
+	}
+	if len(round.DependsOn) != 1 || round.DependsOn[0] != m.DependsOn[0] {
+		t.Errorf("depends_on mismatch: %+v", round.DependsOn)
+	}
+}
+
+func TestMigration_JSONOmitsEmptyOptionalFields(t *testing.T) {
+	m := Migration{
+		Version:        "20260102_120000",
+		Description:    "noop",
+		UpStatements:   []string{"SELECT 1;"},
+		DownStatements: []string{"SELECT 1;"},
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(data)
+	for _, key := range []string{`"path":`, `"checksum":`, `"depends_on":`} {
+		if contains(s, key) {
+			t.Errorf("expected %s to be omitted, got %s", key, s)
+		}
+	}
+}
+
+func TestMigrationHistory_JSONRoundTrip(t *testing.T) {
+	execMs := int64(1234)
+	applied := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+	h := MigrationHistory{
+		Version:         "20260102_120000",
+		Description:     "create user",
+		AppliedAt:       applied,
+		Checksum:        "deadbeef",
+		ExecutionTimeMs: &execMs,
+	}
+	data, err := json.Marshal(h)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round MigrationHistory
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !round.AppliedAt.Equal(applied) {
+		t.Errorf("applied_at mismatch: %v", round.AppliedAt)
+	}
+	if round.ExecutionTimeMs == nil || *round.ExecutionTimeMs != execMs {
+		t.Errorf("execution_time_ms mismatch: %v", round.ExecutionTimeMs)
+	}
+}
+
+func TestMigrationHistory_OmitsExecutionTimeWhenNil(t *testing.T) {
+	h := MigrationHistory{
+		Version:     "20260102_120000",
+		Description: "x",
+		AppliedAt:   time.Unix(0, 0).UTC(),
+		Checksum:    "x",
+	}
+	data, err := json.Marshal(h)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if contains(string(data), `"execution_time_ms":`) {
+		t.Errorf("execution_time_ms should be omitted: %s", data)
+	}
+}
+
+func TestMigrationPlan_JSONRoundTrip(t *testing.T) {
+	p := MigrationPlan{
+		Migrations: []Migration{
+			{
+				Version:        "20260102_120000",
+				Description:    "x",
+				UpStatements:   []string{"SELECT 1;"},
+				DownStatements: []string{"SELECT 0;"},
+			},
+		},
+		Direction: MigrationDirectionUp,
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round MigrationPlan
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if round.Direction != MigrationDirectionUp {
+		t.Errorf("direction mismatch: %v", round.Direction)
+	}
+	if len(round.Migrations) != 1 {
+		t.Errorf("migrations len = %d", len(round.Migrations))
+	}
+}
+
+func TestMigrationMetadata_JSONRoundTrip(t *testing.T) {
+	md := MigrationMetadata{
+		Version:     "20260102_120000",
+		Description: "test",
+		Author:      "surql",
+		DependsOn:   []string{"20260101_000000_init"},
+	}
+	data, err := json.Marshal(md)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round MigrationMetadata
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if round.Version != md.Version || round.Description != md.Description || round.Author != md.Author {
+		t.Errorf("scalars mismatch: %+v vs %+v", round, md)
+	}
+	if len(round.DependsOn) != 1 || round.DependsOn[0] != md.DependsOn[0] {
+		t.Errorf("depends_on mismatch: %+v", round.DependsOn)
+	}
+}
+
+func TestMigrationStatus_JSONRoundTrip(t *testing.T) {
+	applied := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	s := MigrationStatus{
+		Migration: Migration{
+			Version:        "20260102_120000",
+			Description:    "x",
+			UpStatements:   []string{"SELECT 1;"},
+			DownStatements: []string{"SELECT 0;"},
+		},
+		State:     MigrationStateApplied,
+		AppliedAt: &applied,
+		Error:     "",
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round MigrationStatus
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if round.State != MigrationStateApplied {
+		t.Errorf("state mismatch: %v", round.State)
+	}
+	if round.AppliedAt == nil || !round.AppliedAt.Equal(applied) {
+		t.Errorf("applied_at mismatch: %v", round.AppliedAt)
+	}
+}
+
+func TestSchemaDiff_JSONRoundTrip(t *testing.T) {
+	d := SchemaDiff{
+		Operation:   DiffOperationAddTable,
+		Table:       "user",
+		Description: "add user table",
+		ForwardSQL:  "DEFINE TABLE user SCHEMAFULL;",
+		BackwardSQL: "REMOVE TABLE user;",
+		Details:     map[string]any{"mode": "schemafull"},
+	}
+	data, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round SchemaDiff
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if round.Operation != DiffOperationAddTable {
+		t.Errorf("operation mismatch: %v", round.Operation)
+	}
+	if round.Table != "user" || round.ForwardSQL != "DEFINE TABLE user SCHEMAFULL;" {
+		t.Errorf("scalars mismatch: %+v", round)
+	}
+	if got := round.Details["mode"]; got != "schemafull" {
+		t.Errorf("details[mode] = %v", got)
+	}
+}
+
+func TestSchemaDiff_OmitsEmptyOptionalFields(t *testing.T) {
+	d := SchemaDiff{
+		Operation:   DiffOperationAddTable,
+		Table:       "user",
+		Description: "x",
+		ForwardSQL:  "SELECT 1;",
+		BackwardSQL: "SELECT 0;",
+	}
+	data, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(data)
+	for _, key := range []string{`"field":`, `"index":`, `"event":`, `"details":`} {
+		if contains(s, key) {
+			t.Errorf("expected %s omitted, got %s", key, s)
+		}
+	}
+}
+
+// contains is a tiny substring helper to avoid pulling in strings in tests
+// that only need this one check.
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #21.

## Summary
Port surql-py/src/surql/migration/{models,discovery}.py. Migration executor / generator / history / hooks / rollback / squash / versioning / watcher follow in separate PRs.

- **\`migration/models.go\`**: \`Migration\`, \`MigrationHistory\`, \`MigrationPlan\`, \`MigrationMetadata\`, \`MigrationStatus\`, \`SchemaDiff\` + \`MigrationState\` / \`MigrationDirection\` / \`DiffOperation\` string enums with \`IsValid()\` / \`String()\`. JSON-tagged with \`omitempty\`.
- **\`migration/discovery.go\`**: \`DiscoverMigrations\`, \`LoadMigration\`, \`ValidateMigrationName\`, \`GetVersionFromFilename\`, \`GetDescriptionFromFilename\`. SHA-256 file checksum matches Python for cross-language history compatibility.

## File format decision
Python loads \`.py\` modules dynamically; Go can't. Migrations are now \`.surql\` files with \`-- @up\` / \`-- @down\` section markers plus optional \`-- @description:\` / \`-- @depends_on:\` headers. Pre-parsed \`UpStatements []string\` / \`DownStatements []string\` stored in \`Migration\`. Documented in \`doc.go\`.

## Test plan
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./... -race\` — **49 new tests green** covering enum validity, JSON round-trips, filename validation, CRLF handling, comment/blank-line stripping, checksum stability, empty/nonexistent/file-as-dir directories, sort-by-version, invalid-name skipping.
- [ ] CI green