### PR TITLE
feat(migration): port schema diff engine

### DIFF
--- a/pkg/surql/migration/diff.go
+++ b/pkg/surql/migration/diff.go
@@ -1,0 +1,898 @@
+package migration
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/schema"
+)
+
+// safeDefaultPattern mirrors the Python _SAFE_DEFAULT_PATTERN. It matches
+// SurrealDB default-value expressions that are safe to interpolate into a
+// DEFINE FIELD statement or a backfill UPDATE:
+//
+//   - function calls (e.g. time::now(), rand::uuid())
+//   - numeric literals (42, 3.14, -1)
+//   - boolean literals (true, false)
+//   - NONE / NULL sentinels
+//   - single-quoted strings
+//   - parameter references ($session_id)
+var safeDefaultPattern = regexp.MustCompile(
+	`^(` +
+		`[a-zA-Z_][a-zA-Z0-9_]*(?:::[a-zA-Z_][a-zA-Z0-9_]*)*\([^;]*\)` + // function calls
+		`|-?\d+(?:\.\d+)?` + // numeric literals
+		`|true|false` + // boolean literals
+		`|NONE|NULL` + // null sentinels
+		`|'(?:[^'\\]|\\.)*'` + // single-quoted strings
+		`|\$[a-zA-Z_][a-zA-Z0-9_]*` + // parameter references
+		`)$`,
+)
+
+// SchemaSnapshot is a whole-schema view consumed by DiffSchemas. It carries
+// the ordered set of tables and edges that make up a schema revision (code
+// side) or the remote database state.
+//
+// The snapshot deliberately mirrors the shape of surql-py's implicit "list of
+// tables + list of edges" contract rather than introducing a new Python
+// concept; it simply gives the Go port a concrete type to compare against.
+type SchemaSnapshot struct {
+	Tables []schema.TableDefinition
+	Edges  []schema.EdgeDefinition
+}
+
+// validateEventExpression rejects event condition or action expressions that
+// smell like SQL injection attempts (statement separators, SQL comments).
+func validateEventExpression(expr, label string) error {
+	stripped := strings.TrimSpace(expr)
+	if strings.Contains(stripped, "; ") ||
+		strings.Contains(stripped, ";--") ||
+		strings.HasSuffix(stripped, ";") {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"unsafe event %s: %q must not contain statement separators", label, expr)
+	}
+	if strings.Contains(stripped, "--") {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"unsafe event %s: %q must not contain SQL comments", label, expr)
+	}
+	return nil
+}
+
+// validateDefaultValue ensures a field default / value expression matches the
+// safe-default allow-list. Returns ErrValidation when the default could be
+// used as an SQL injection vector.
+func validateDefaultValue(expr string) error {
+	if !safeDefaultPattern.MatchString(strings.TrimSpace(expr)) {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"unsafe default value expression: %q; defaults must be function calls, literals, or parameter references",
+			expr)
+	}
+	return nil
+}
+
+// DiffTables compares two TableDefinition snapshots and returns the list of
+// SchemaDiff operations needed to evolve old -> new.
+//
+// Passing nil for old produces ADD diffs (table, fields, indexes, events,
+// permissions) while nil for new yields a single DROP diff. When both are
+// non-nil, field / index / event / permission diffs are produced.
+func DiffTables(oldTable, newTable *schema.TableDefinition) ([]SchemaDiff, error) {
+	switch {
+	case oldTable == nil && newTable != nil:
+		return generateAddTableDiffs(*newTable)
+	case oldTable != nil && newTable == nil:
+		return []SchemaDiff{generateDropTableDiff(*oldTable)}, nil
+	case oldTable != nil && newTable != nil:
+		diffs := make([]SchemaDiff, 0)
+		fieldDiffs, err := DiffFields(*oldTable, *newTable)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, fieldDiffs...)
+
+		idxDiffs, err := DiffIndexes(*oldTable, *newTable)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, idxDiffs...)
+
+		evtDiffs, err := DiffEvents(*oldTable, *newTable)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, evtDiffs...)
+
+		diffs = append(diffs, DiffPermissions(*oldTable, *newTable)...)
+		return diffs, nil
+	}
+	return nil, nil
+}
+
+// DiffFields computes per-field differences between two tables. The diff uses
+// structural field equality (name, type, assertion, default, value, readonly,
+// flexible) and produces ADD / DROP / MODIFY entries in a stable order
+// (additions in new-table order, drops in old-table order, modifications in
+// sorted field-name order).
+func DiffFields(oldTable, newTable schema.TableDefinition) ([]SchemaDiff, error) {
+	oldFields := make(map[string]schema.FieldDefinition, len(oldTable.Fields))
+	for _, f := range oldTable.Fields {
+		oldFields[f.Name] = f
+	}
+	newFields := make(map[string]schema.FieldDefinition, len(newTable.Fields))
+	for _, f := range newTable.Fields {
+		newFields[f.Name] = f
+	}
+
+	diffs := make([]SchemaDiff, 0)
+
+	// Added: iterate in new-table order for determinism.
+	for _, f := range newTable.Fields {
+		if _, ok := oldFields[f.Name]; ok {
+			continue
+		}
+		d, err := generateAddFieldDiff(newTable.Name, f)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+
+	// Dropped: iterate in old-table order.
+	for _, f := range oldTable.Fields {
+		if _, ok := newFields[f.Name]; ok {
+			continue
+		}
+		d, err := generateDropFieldDiff(newTable.Name, f)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+
+	// Modified: intersection in sorted order for deterministic output.
+	intersect := make([]string, 0)
+	for name := range oldFields {
+		if _, ok := newFields[name]; ok {
+			intersect = append(intersect, name)
+		}
+	}
+	sort.Strings(intersect)
+	for _, name := range intersect {
+		oldF := oldFields[name]
+		newF := newFields[name]
+		if fieldsEqual(oldF, newF) {
+			continue
+		}
+		d, err := generateModifyFieldDiff(newTable.Name, oldF, newF)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+
+	return diffs, nil
+}
+
+// DiffIndexes computes per-index differences between two tables. Indexes are
+// keyed by name; MTREE and HNSW flavours produce their specialised DEFINE
+// INDEX statements.
+func DiffIndexes(oldTable, newTable schema.TableDefinition) ([]SchemaDiff, error) {
+	oldIdx := make(map[string]schema.IndexDefinition, len(oldTable.Indexes))
+	for _, i := range oldTable.Indexes {
+		oldIdx[i.Name] = i
+	}
+	newIdx := make(map[string]schema.IndexDefinition, len(newTable.Indexes))
+	for _, i := range newTable.Indexes {
+		newIdx[i.Name] = i
+	}
+
+	diffs := make([]SchemaDiff, 0)
+
+	for _, idx := range newTable.Indexes {
+		if _, ok := oldIdx[idx.Name]; ok {
+			continue
+		}
+		d, err := generateAddIndexDiff(newTable.Name, idx)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+
+	for _, idx := range oldTable.Indexes {
+		if _, ok := newIdx[idx.Name]; ok {
+			continue
+		}
+		d, err := generateDropIndexDiff(newTable.Name, idx)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+
+	return diffs, nil
+}
+
+// DiffEvents computes per-event differences between two tables. Event
+// expressions are validated against the safe-expression allow-list; an unsafe
+// expression returns ErrValidation.
+func DiffEvents(oldTable, newTable schema.TableDefinition) ([]SchemaDiff, error) {
+	oldEv := make(map[string]schema.EventDefinition, len(oldTable.Events))
+	for _, e := range oldTable.Events {
+		oldEv[e.Name] = e
+	}
+	newEv := make(map[string]schema.EventDefinition, len(newTable.Events))
+	for _, e := range newTable.Events {
+		newEv[e.Name] = e
+	}
+
+	diffs := make([]SchemaDiff, 0)
+
+	for _, ev := range newTable.Events {
+		if _, ok := oldEv[ev.Name]; ok {
+			continue
+		}
+		d, err := generateAddEventDiff(newTable.Name, ev)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+
+	for _, ev := range oldTable.Events {
+		if _, ok := newEv[ev.Name]; ok {
+			continue
+		}
+		d, err := generateDropEventDiff(newTable.Name, ev)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+
+	return diffs, nil
+}
+
+// DiffPermissions compares the permission map of two tables and returns a
+// single MODIFY_PERMISSIONS diff when they differ (or an empty slice when
+// they match). Forward SQL reflects the new permissions; backward SQL the
+// old. The empty map and a nil map compare equal.
+func DiffPermissions(oldTable, newTable schema.TableDefinition) []SchemaDiff {
+	if permissionsEqual(oldTable.Permissions, newTable.Permissions) {
+		return nil
+	}
+	return []SchemaDiff{
+		generateModifyPermissionsDiff(newTable.Name, newTable.Permissions, oldTable.Permissions),
+	}
+}
+
+// DiffEdges compares two EdgeDefinition snapshots by delegating the field,
+// index, event, and permission comparisons to the table diff helpers via a
+// TableDefinition adapter. Adding or dropping an edge produces the full
+// suite of child diffs (not just a DROP TABLE).
+func DiffEdges(oldEdge, newEdge *schema.EdgeDefinition) ([]SchemaDiff, error) {
+	switch {
+	case oldEdge == nil && newEdge != nil:
+		return generateAddEdgeDiffs(*newEdge)
+	case oldEdge != nil && newEdge == nil:
+		return []SchemaDiff{generateDropEdgeDiff(*oldEdge)}, nil
+	case oldEdge != nil && newEdge != nil:
+		oldProxy := edgeToTableProxy(*oldEdge)
+		newProxy := edgeToTableProxy(*newEdge)
+
+		diffs := make([]SchemaDiff, 0)
+		fieldDiffs, err := DiffFields(oldProxy, newProxy)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, fieldDiffs...)
+
+		idxDiffs, err := DiffIndexes(oldProxy, newProxy)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, idxDiffs...)
+
+		evtDiffs, err := DiffEvents(oldProxy, newProxy)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, evtDiffs...)
+
+		diffs = append(diffs, DiffPermissions(oldProxy, newProxy)...)
+		return diffs, nil
+	}
+	return nil, nil
+}
+
+// DiffSchemas aggregates DiffTables and DiffEdges across two whole snapshots.
+// Tables and edges are matched by name; the "code" side is treated as the
+// desired state and the "db" side as the current state, so ADD diffs refer
+// to entries present in code but missing in db.
+//
+// The returned slice is ordered: added tables, dropped tables, modified
+// tables (in sorted name order), then the same for edges. Within each entry
+// the child ordering mirrors DiffTables / DiffEdges.
+func DiffSchemas(code, db SchemaSnapshot) ([]SchemaDiff, error) {
+	codeTables := make(map[string]schema.TableDefinition, len(code.Tables))
+	for _, t := range code.Tables {
+		codeTables[t.Name] = t
+	}
+	dbTables := make(map[string]schema.TableDefinition, len(db.Tables))
+	for _, t := range db.Tables {
+		dbTables[t.Name] = t
+	}
+
+	diffs := make([]SchemaDiff, 0)
+
+	// Added tables (code but not db).
+	for _, t := range code.Tables {
+		if _, ok := dbTables[t.Name]; ok {
+			continue
+		}
+		added, err := DiffTables(nil, tablePtr(t))
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, added...)
+	}
+
+	// Dropped tables (db but not code).
+	for _, t := range db.Tables {
+		if _, ok := codeTables[t.Name]; ok {
+			continue
+		}
+		dropped, err := DiffTables(tablePtr(t), nil)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, dropped...)
+	}
+
+	// Modified tables (present on both sides).
+	intersectT := make([]string, 0)
+	for name := range dbTables {
+		if _, ok := codeTables[name]; ok {
+			intersectT = append(intersectT, name)
+		}
+	}
+	sort.Strings(intersectT)
+	for _, name := range intersectT {
+		oldT := dbTables[name]
+		newT := codeTables[name]
+		modified, err := DiffTables(&oldT, &newT)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, modified...)
+	}
+
+	codeEdges := make(map[string]schema.EdgeDefinition, len(code.Edges))
+	for _, e := range code.Edges {
+		codeEdges[e.Name] = e
+	}
+	dbEdges := make(map[string]schema.EdgeDefinition, len(db.Edges))
+	for _, e := range db.Edges {
+		dbEdges[e.Name] = e
+	}
+
+	for _, e := range code.Edges {
+		if _, ok := dbEdges[e.Name]; ok {
+			continue
+		}
+		added, err := DiffEdges(nil, edgePtr(e))
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, added...)
+	}
+
+	for _, e := range db.Edges {
+		if _, ok := codeEdges[e.Name]; ok {
+			continue
+		}
+		dropped, err := DiffEdges(edgePtr(e), nil)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, dropped...)
+	}
+
+	intersectE := make([]string, 0)
+	for name := range dbEdges {
+		if _, ok := codeEdges[name]; ok {
+			intersectE = append(intersectE, name)
+		}
+	}
+	sort.Strings(intersectE)
+	for _, name := range intersectE {
+		oldE := dbEdges[name]
+		newE := codeEdges[name]
+		modified, err := DiffEdges(&oldE, &newE)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, modified...)
+	}
+
+	return diffs, nil
+}
+
+// --- internal helpers ---
+
+func tablePtr(t schema.TableDefinition) *schema.TableDefinition { return &t }
+func edgePtr(e schema.EdgeDefinition) *schema.EdgeDefinition    { return &e }
+
+func edgeToTableProxy(e schema.EdgeDefinition) schema.TableDefinition {
+	return schema.TableDefinition{
+		Name:        e.Name,
+		Fields:      append([]schema.FieldDefinition(nil), e.Fields...),
+		Indexes:     append([]schema.IndexDefinition(nil), e.Indexes...),
+		Events:      append([]schema.EventDefinition(nil), e.Events...),
+		Permissions: copyPermissions(e.Permissions),
+	}
+}
+
+func copyPermissions(p map[string]string) map[string]string {
+	if p == nil {
+		return nil
+	}
+	out := make(map[string]string, len(p))
+	for k, v := range p {
+		out[k] = v
+	}
+	return out
+}
+
+func permissionsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || bv != v {
+			return false
+		}
+	}
+	return true
+}
+
+func fieldsEqual(a, b schema.FieldDefinition) bool {
+	return a.Name == b.Name &&
+		a.Type == b.Type &&
+		a.Assertion == b.Assertion &&
+		a.Default == b.Default &&
+		a.Value == b.Value &&
+		a.ReadOnly == b.ReadOnly &&
+		a.Flexible == b.Flexible
+}
+
+func generateAddTableDiffs(t schema.TableDefinition) ([]SchemaDiff, error) {
+	mode := string(t.Mode)
+	if mode == "" {
+		mode = string(schema.TableModeSchemafull)
+	}
+	diffs := make([]SchemaDiff, 0, 1+len(t.Fields)+len(t.Indexes)+len(t.Events)+1)
+	diffs = append(diffs, SchemaDiff{
+		Operation:   DiffOperationAddTable,
+		Table:       t.Name,
+		Description: fmt.Sprintf("Add table %s", t.Name),
+		ForwardSQL:  fmt.Sprintf("DEFINE TABLE %s %s;", t.Name, mode),
+		BackwardSQL: fmt.Sprintf("REMOVE TABLE %s;", t.Name),
+	})
+
+	for _, f := range t.Fields {
+		d, err := generateAddFieldDiff(t.Name, f)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+	for _, i := range t.Indexes {
+		d, err := generateAddIndexDiff(t.Name, i)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+	for _, e := range t.Events {
+		d, err := generateAddEventDiff(t.Name, e)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+	if len(t.Permissions) > 0 {
+		diffs = append(diffs, generateModifyPermissionsDiff(t.Name, t.Permissions, nil))
+	}
+	return diffs, nil
+}
+
+func generateDropTableDiff(t schema.TableDefinition) SchemaDiff {
+	mode := string(t.Mode)
+	if mode == "" {
+		mode = string(schema.TableModeSchemafull)
+	}
+	return SchemaDiff{
+		Operation:   DiffOperationDropTable,
+		Table:       t.Name,
+		Description: fmt.Sprintf("Drop table %s", t.Name),
+		ForwardSQL:  fmt.Sprintf("REMOVE TABLE %s;", t.Name),
+		BackwardSQL: fmt.Sprintf("DEFINE TABLE %s %s;", t.Name, mode),
+	}
+}
+
+func generateAddFieldDiff(tableName string, f schema.FieldDefinition) (SchemaDiff, error) {
+	forwardSQL, err := fieldToSQL(tableName, f)
+	if err != nil {
+		return SchemaDiff{}, err
+	}
+	if f.Default != "" {
+		if err := validateDefaultValue(f.Default); err != nil {
+			return SchemaDiff{}, err
+		}
+		forwardSQL = fmt.Sprintf(
+			"%s\nUPDATE %s SET %s = %s WHERE %s IS NONE;",
+			forwardSQL, tableName, f.Name, f.Default, f.Name,
+		)
+	}
+	return SchemaDiff{
+		Operation:   DiffOperationAddField,
+		Table:       tableName,
+		Field:       f.Name,
+		Description: fmt.Sprintf("Add field %s to %s", f.Name, tableName),
+		ForwardSQL:  forwardSQL,
+		BackwardSQL: fmt.Sprintf("REMOVE FIELD %s ON TABLE %s;", f.Name, tableName),
+		Details:     map[string]any{"type": string(f.Type)},
+	}, nil
+}
+
+func generateDropFieldDiff(tableName string, f schema.FieldDefinition) (SchemaDiff, error) {
+	backwardSQL, err := fieldToSQL(tableName, f)
+	if err != nil {
+		return SchemaDiff{}, err
+	}
+	return SchemaDiff{
+		Operation:   DiffOperationDropField,
+		Table:       tableName,
+		Field:       f.Name,
+		Description: fmt.Sprintf("Drop field %s from %s", f.Name, tableName),
+		ForwardSQL:  fmt.Sprintf("REMOVE FIELD %s ON TABLE %s;", f.Name, tableName),
+		BackwardSQL: backwardSQL,
+	}, nil
+}
+
+func generateModifyFieldDiff(tableName string, oldF, newF schema.FieldDefinition) (SchemaDiff, error) {
+	forwardSQL, err := fieldToSQL(tableName, newF)
+	if err != nil {
+		return SchemaDiff{}, err
+	}
+	backwardSQL, err := fieldToSQL(tableName, oldF)
+	if err != nil {
+		return SchemaDiff{}, err
+	}
+	return SchemaDiff{
+		Operation:   DiffOperationModifyField,
+		Table:       tableName,
+		Field:       newF.Name,
+		Description: fmt.Sprintf("Modify field %s in %s", newF.Name, tableName),
+		ForwardSQL:  forwardSQL,
+		BackwardSQL: backwardSQL,
+		Details: map[string]any{
+			"old_type": string(oldF.Type),
+			"new_type": string(newF.Type),
+		},
+	}, nil
+}
+
+func generateAddIndexDiff(tableName string, idx schema.IndexDefinition) (SchemaDiff, error) {
+	forwardSQL, err := indexToSQL(tableName, idx)
+	if err != nil {
+		return SchemaDiff{}, err
+	}
+	return SchemaDiff{
+		Operation:   DiffOperationAddIndex,
+		Table:       tableName,
+		Index:       idx.Name,
+		Description: fmt.Sprintf("Add index %s to %s", idx.Name, tableName),
+		ForwardSQL:  forwardSQL,
+		BackwardSQL: fmt.Sprintf("REMOVE INDEX %s ON TABLE %s;", idx.Name, tableName),
+	}, nil
+}
+
+func generateDropIndexDiff(tableName string, idx schema.IndexDefinition) (SchemaDiff, error) {
+	backwardSQL, err := indexToSQL(tableName, idx)
+	if err != nil {
+		return SchemaDiff{}, err
+	}
+	return SchemaDiff{
+		Operation:   DiffOperationDropIndex,
+		Table:       tableName,
+		Index:       idx.Name,
+		Description: fmt.Sprintf("Drop index %s from %s", idx.Name, tableName),
+		ForwardSQL:  fmt.Sprintf("REMOVE INDEX %s ON TABLE %s;", idx.Name, tableName),
+		BackwardSQL: backwardSQL,
+	}, nil
+}
+
+func generateAddEventDiff(tableName string, ev schema.EventDefinition) (SchemaDiff, error) {
+	if err := validateEventExpression(ev.Condition, "condition"); err != nil {
+		return SchemaDiff{}, err
+	}
+	if err := validateEventExpression(ev.Action, "action"); err != nil {
+		return SchemaDiff{}, err
+	}
+	return SchemaDiff{
+		Operation: DiffOperationAddEvent,
+		Table:     tableName,
+		Event:     ev.Name,
+		Description: fmt.Sprintf(
+			"Add event %s to %s", ev.Name, tableName,
+		),
+		ForwardSQL: fmt.Sprintf(
+			"DEFINE EVENT %s ON TABLE %s WHEN %s THEN { %s };",
+			ev.Name, tableName, ev.Condition, ev.Action,
+		),
+		BackwardSQL: fmt.Sprintf("REMOVE EVENT %s ON TABLE %s;", ev.Name, tableName),
+	}, nil
+}
+
+func generateDropEventDiff(tableName string, ev schema.EventDefinition) (SchemaDiff, error) {
+	if err := validateEventExpression(ev.Condition, "condition"); err != nil {
+		return SchemaDiff{}, err
+	}
+	if err := validateEventExpression(ev.Action, "action"); err != nil {
+		return SchemaDiff{}, err
+	}
+	return SchemaDiff{
+		Operation:   DiffOperationDropEvent,
+		Table:       tableName,
+		Event:       ev.Name,
+		Description: fmt.Sprintf("Drop event %s from %s", ev.Name, tableName),
+		ForwardSQL:  fmt.Sprintf("REMOVE EVENT %s ON TABLE %s;", ev.Name, tableName),
+		BackwardSQL: fmt.Sprintf(
+			"DEFINE EVENT %s ON TABLE %s WHEN %s THEN { %s };",
+			ev.Name, tableName, ev.Condition, ev.Action,
+		),
+	}, nil
+}
+
+// generateModifyPermissionsDiff renders a single MODIFY_PERMISSIONS diff.
+// Forward SQL is the concatenation of DEFINE FIELD PERMISSIONS statements for
+// permissions (the desired state); backward SQL reproduces old_permissions.
+// Keys are emitted in sorted order for stable output.
+func generateModifyPermissionsDiff(tableName string, permissions, oldPermissions map[string]string) SchemaDiff {
+	return SchemaDiff{
+		Operation:   DiffOperationModifyPermissions,
+		Table:       tableName,
+		Description: fmt.Sprintf("Modify permissions for %s", tableName),
+		ForwardSQL:  permissionsToSQL(tableName, permissions),
+		BackwardSQL: permissionsToSQL(tableName, oldPermissions),
+	}
+}
+
+func permissionsToSQL(tableName string, permissions map[string]string) string {
+	if len(permissions) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(permissions))
+	for k := range permissions {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, op := range keys {
+		parts = append(parts, fmt.Sprintf(
+			"DEFINE FIELD PERMISSIONS FOR %s ON TABLE %s WHERE %s;",
+			strings.ToUpper(op), tableName, permissions[op],
+		))
+	}
+	return strings.Join(parts, " ")
+}
+
+func generateAddEdgeDiffs(e schema.EdgeDefinition) ([]SchemaDiff, error) {
+	diffs := make([]SchemaDiff, 0, 1+len(e.Fields)+len(e.Indexes)+len(e.Events))
+
+	var forwardSQL string
+	switch e.Mode {
+	case schema.EdgeModeRelation:
+		forwardSQL = fmt.Sprintf("DEFINE TABLE %s TYPE RELATION", e.Name)
+		if e.FromTable != "" {
+			forwardSQL += " FROM " + e.FromTable
+		}
+		if e.ToTable != "" {
+			forwardSQL += " TO " + e.ToTable
+		}
+		forwardSQL += ";"
+	case schema.EdgeModeSchemafull:
+		forwardSQL = fmt.Sprintf("DEFINE TABLE %s SCHEMAFULL;", e.Name)
+	case schema.EdgeModeSchemaless:
+		forwardSQL = fmt.Sprintf("DEFINE TABLE %s SCHEMALESS;", e.Name)
+	default:
+		// Unrecognised modes default to RELATION to mirror NewEdge's default.
+		forwardSQL = fmt.Sprintf("DEFINE TABLE %s TYPE RELATION;", e.Name)
+	}
+
+	diffs = append(diffs, SchemaDiff{
+		Operation:   DiffOperationAddTable,
+		Table:       e.Name,
+		Description: fmt.Sprintf("Add edge %s", e.Name),
+		ForwardSQL:  forwardSQL,
+		BackwardSQL: fmt.Sprintf("REMOVE TABLE %s;", e.Name),
+	})
+
+	for _, f := range e.Fields {
+		d, err := generateAddFieldDiff(e.Name, f)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+	for _, i := range e.Indexes {
+		d, err := generateAddIndexDiff(e.Name, i)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+	for _, ev := range e.Events {
+		d, err := generateAddEventDiff(e.Name, ev)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+	return diffs, nil
+}
+
+func generateDropEdgeDiff(e schema.EdgeDefinition) SchemaDiff {
+	return SchemaDiff{
+		Operation:   DiffOperationDropTable,
+		Table:       e.Name,
+		Description: fmt.Sprintf("Drop edge %s", e.Name),
+		ForwardSQL:  fmt.Sprintf("REMOVE TABLE %s;", e.Name),
+		BackwardSQL: "",
+	}
+}
+
+// fieldToSQL renders a standalone DEFINE FIELD statement matching the Python
+// port. It does not call FieldDefinition.ToSurql because that helper emits
+// clauses in a different order (assertion before default/value) — we preserve
+// the Python ordering plus the default/value allow-list validation.
+func fieldToSQL(tableName string, f schema.FieldDefinition) (string, error) {
+	var b strings.Builder
+	b.WriteString("DEFINE FIELD ")
+	b.WriteString(f.Name)
+	b.WriteString(" ON TABLE ")
+	b.WriteString(tableName)
+	b.WriteString(" TYPE ")
+	b.WriteString(string(f.Type))
+
+	if f.Assertion != "" {
+		b.WriteString(" ASSERT ")
+		b.WriteString(f.Assertion)
+	}
+	if f.Default != "" {
+		if err := validateDefaultValue(f.Default); err != nil {
+			return "", err
+		}
+		b.WriteString(" DEFAULT ")
+		b.WriteString(f.Default)
+	}
+	if f.Value != "" {
+		if err := validateDefaultValue(f.Value); err != nil {
+			return "", err
+		}
+		b.WriteString(" VALUE ")
+		b.WriteString(f.Value)
+	}
+	if f.ReadOnly {
+		b.WriteString(" READONLY")
+	}
+	if f.Flexible {
+		b.WriteString(" FLEXIBLE")
+	}
+	b.WriteString(";")
+	return b.String(), nil
+}
+
+// indexToSQL renders a DEFINE INDEX statement. Standard / UNIQUE / SEARCH
+// indexes use the basic form; MTREE and HNSW flavours route through their
+// dedicated helpers. Returns ErrValidation for MTREE / HNSW indexes missing
+// a dimension.
+func indexToSQL(tableName string, idx schema.IndexDefinition) (string, error) {
+	switch idx.Type {
+	case schema.IndexTypeMTree:
+		return mtreeIndexToSQL(tableName, idx)
+	case schema.IndexTypeHNSW:
+		return hnswIndexToSQL(tableName, idx)
+	}
+
+	var b strings.Builder
+	b.WriteString("DEFINE INDEX ")
+	b.WriteString(idx.Name)
+	b.WriteString(" ON TABLE ")
+	b.WriteString(tableName)
+	b.WriteString(" COLUMNS ")
+	b.WriteString(strings.Join(idx.Columns, ", "))
+
+	if string(idx.Type) != string(schema.IndexTypeStandard) && idx.Type != "" {
+		b.WriteString(" ")
+		b.WriteString(string(idx.Type))
+	}
+	b.WriteString(";")
+	return b.String(), nil
+}
+
+func mtreeIndexToSQL(tableName string, idx schema.IndexDefinition) (string, error) {
+	if idx.Dimension <= 0 {
+		return "", surqlerrors.Newf(surqlerrors.ErrValidation,
+			"MTREE index %q must have dimension specified", idx.Name)
+	}
+	field := ""
+	if len(idx.Columns) > 0 {
+		field = idx.Columns[0]
+	}
+
+	var b strings.Builder
+	b.WriteString("DEFINE INDEX ")
+	b.WriteString(idx.Name)
+	b.WriteString(" ON TABLE ")
+	b.WriteString(tableName)
+	b.WriteString(" COLUMNS ")
+	b.WriteString(field)
+	b.WriteString(" MTREE DIMENSION ")
+	b.WriteString(strconv.Itoa(idx.Dimension))
+	if idx.Distance != "" {
+		b.WriteString(" DIST ")
+		b.WriteString(string(idx.Distance))
+	}
+	if idx.VectorType != "" {
+		b.WriteString(" TYPE ")
+		b.WriteString(string(idx.VectorType))
+	}
+	b.WriteString(";")
+	return b.String(), nil
+}
+
+func hnswIndexToSQL(tableName string, idx schema.IndexDefinition) (string, error) {
+	if idx.Dimension <= 0 {
+		return "", surqlerrors.Newf(surqlerrors.ErrValidation,
+			"HNSW index %q must have dimension specified", idx.Name)
+	}
+	field := ""
+	if len(idx.Columns) > 0 {
+		field = idx.Columns[0]
+	}
+
+	var b strings.Builder
+	b.WriteString("DEFINE INDEX ")
+	b.WriteString(idx.Name)
+	b.WriteString(" ON TABLE ")
+	b.WriteString(tableName)
+	b.WriteString(" COLUMNS ")
+	b.WriteString(field)
+	b.WriteString(" HNSW DIMENSION ")
+	b.WriteString(strconv.Itoa(idx.Dimension))
+	if idx.HnswDistance != "" {
+		b.WriteString(" DIST ")
+		b.WriteString(string(idx.HnswDistance))
+	}
+	if idx.VectorType != "" {
+		b.WriteString(" TYPE ")
+		b.WriteString(string(idx.VectorType))
+	}
+	if idx.EFC > 0 {
+		b.WriteString(" EFC ")
+		b.WriteString(strconv.Itoa(idx.EFC))
+	}
+	if idx.M > 0 {
+		b.WriteString(" M ")
+		b.WriteString(strconv.Itoa(idx.M))
+	}
+	b.WriteString(";")
+	return b.String(), nil
+}

--- a/pkg/surql/migration/diff_test.go
+++ b/pkg/surql/migration/diff_test.go
@@ -1,0 +1,1187 @@
+package migration
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/schema"
+)
+
+// --- helpers -----------------------------------------------------------------
+
+func findByOp(diffs []SchemaDiff, op DiffOperation) []SchemaDiff {
+	out := make([]SchemaDiff, 0)
+	for _, d := range diffs {
+		if d.Operation == op {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// --- DiffTables --------------------------------------------------------------
+
+func TestDiffTablesAddOnly(t *testing.T) {
+	newT := schema.NewTable("user",
+		schema.WithMode(schema.TableModeSchemafull),
+		schema.WithFields(schema.StringField("email")),
+	)
+	diffs, err := DiffTables(nil, &newT)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 2 {
+		t.Fatalf("expected 2 diffs (table + field), got %d", len(diffs))
+	}
+	if diffs[0].Operation != DiffOperationAddTable {
+		t.Errorf("expected add_table first, got %s", diffs[0].Operation)
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "DEFINE TABLE user SCHEMAFULL") {
+		t.Errorf("unexpected forward sql: %s", diffs[0].ForwardSQL)
+	}
+	if diffs[0].BackwardSQL != "REMOVE TABLE user;" {
+		t.Errorf("unexpected backward sql: %s", diffs[0].BackwardSQL)
+	}
+	if diffs[1].Operation != DiffOperationAddField {
+		t.Errorf("expected add_field, got %s", diffs[1].Operation)
+	}
+}
+
+func TestDiffTablesAddWithIndexesEventsPermissions(t *testing.T) {
+	newT := schema.NewTable("post",
+		schema.WithFields(schema.StringField("title")),
+		schema.WithIndexes(schema.UniqueIndex("title_idx", []string{"title"})),
+		schema.WithEvents(schema.NewEvent("touch", "$before != $after", "UPDATE post SET updated = time::now()")),
+		schema.WithTablePermissions(map[string]string{"select": "true"}),
+	)
+	diffs, err := DiffTables(nil, &newT)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 5 {
+		t.Fatalf("expected 5 diffs, got %d (%v)", len(diffs), diffs)
+	}
+	got := make([]DiffOperation, len(diffs))
+	for i, d := range diffs {
+		got[i] = d.Operation
+	}
+	want := []DiffOperation{
+		DiffOperationAddTable, DiffOperationAddField,
+		DiffOperationAddIndex, DiffOperationAddEvent,
+		DiffOperationModifyPermissions,
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("diffs[%d] = %s, want %s", i, got[i], w)
+		}
+	}
+}
+
+func TestDiffTablesDropOnly(t *testing.T) {
+	oldT := schema.NewTable("legacy", schema.WithMode(schema.TableModeSchemaless))
+	diffs, err := DiffTables(&oldT, nil)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	d := diffs[0]
+	if d.Operation != DiffOperationDropTable {
+		t.Errorf("op = %s, want drop_table", d.Operation)
+	}
+	if d.ForwardSQL != "REMOVE TABLE legacy;" {
+		t.Errorf("forward sql = %q", d.ForwardSQL)
+	}
+	if d.BackwardSQL != "DEFINE TABLE legacy SCHEMALESS;" {
+		t.Errorf("backward sql = %q", d.BackwardSQL)
+	}
+}
+
+func TestDiffTablesBothNil(t *testing.T) {
+	diffs, err := DiffTables(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected empty diffs, got %d", len(diffs))
+	}
+}
+
+func TestDiffTablesNoChange(t *testing.T) {
+	old := schema.NewTable("user", schema.WithFields(schema.StringField("email")))
+	new := schema.NewTable("user", schema.WithFields(schema.StringField("email")))
+	diffs, err := DiffTables(&old, &new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %d: %v", len(diffs), diffs)
+	}
+}
+
+// --- DiffFields --------------------------------------------------------------
+
+func TestDiffFieldsAdded(t *testing.T) {
+	old := schema.NewTable("user")
+	new := schema.NewTable("user", schema.WithFields(schema.StringField("email")))
+	diffs, err := DiffFields(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationAddField {
+		t.Fatalf("expected 1 add_field, got %v", diffs)
+	}
+	if diffs[0].Field != "email" {
+		t.Errorf("field = %s", diffs[0].Field)
+	}
+}
+
+func TestDiffFieldsAddedWithDefaultBackfill(t *testing.T) {
+	old := schema.NewTable("user")
+	new := schema.NewTable("user", schema.WithFields(
+		schema.StringField("created_at", schema.WithDefault("time::now()")),
+	))
+	diffs, err := DiffFields(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "UPDATE user SET created_at = time::now() WHERE created_at IS NONE") {
+		t.Errorf("expected backfill in forward sql, got: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffFieldsAddedWithUnsafeDefault(t *testing.T) {
+	new := schema.NewTable("user", schema.WithFields(
+		schema.StringField("email", schema.WithDefault("'x'; DROP TABLE user; --")),
+	))
+	_, err := DiffFields(schema.NewTable("user"), new)
+	if err == nil {
+		t.Fatal("expected validation error for unsafe default")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestDiffFieldsDropped(t *testing.T) {
+	old := schema.NewTable("user", schema.WithFields(schema.StringField("email")))
+	new := schema.NewTable("user")
+	diffs, err := DiffFields(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationDropField {
+		t.Fatalf("expected 1 drop_field, got %v", diffs)
+	}
+	if !strings.Contains(diffs[0].BackwardSQL, "DEFINE FIELD email ON TABLE user TYPE string") {
+		t.Errorf("unexpected backward sql: %s", diffs[0].BackwardSQL)
+	}
+}
+
+func TestDiffFieldsModifiedType(t *testing.T) {
+	old := schema.NewTable("user", schema.WithFields(schema.StringField("age")))
+	new := schema.NewTable("user", schema.WithFields(schema.IntField("age")))
+	diffs, err := DiffFields(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	d := diffs[0]
+	if d.Operation != DiffOperationModifyField {
+		t.Errorf("op = %s", d.Operation)
+	}
+	if d.Details["old_type"] != "string" || d.Details["new_type"] != "int" {
+		t.Errorf("details = %v", d.Details)
+	}
+}
+
+func TestDiffFieldsModifiedAssertion(t *testing.T) {
+	old := schema.NewTable("user", schema.WithFields(
+		schema.StringField("email", schema.WithAssertion("string::is::email($value)")),
+	))
+	new := schema.NewTable("user", schema.WithFields(
+		schema.StringField("email", schema.WithAssertion("string::len($value) > 3")),
+	))
+	diffs, err := DiffFields(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationModifyField {
+		t.Fatalf("expected modify_field, got %v", diffs)
+	}
+}
+
+func TestDiffFieldsModifiedReadonlyFlexible(t *testing.T) {
+	old := schema.NewTable("user", schema.WithFields(schema.NewField("meta", schema.FieldTypeObject)))
+	new := schema.NewTable("user", schema.WithFields(schema.NewField("meta", schema.FieldTypeObject, schema.WithFlexible(true))))
+	diffs, err := DiffFields(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+}
+
+func TestDiffFieldsNoChange(t *testing.T) {
+	f := schema.StringField("email", schema.WithAssertion("string::len($value) > 0"))
+	old := schema.NewTable("user", schema.WithFields(f))
+	new := schema.NewTable("user", schema.WithFields(f))
+	diffs, err := DiffFields(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %v", diffs)
+	}
+}
+
+func TestDiffFieldsMixedOperations(t *testing.T) {
+	old := schema.NewTable("user", schema.WithFields(
+		schema.StringField("email"),
+		schema.StringField("legacy"),
+		schema.IntField("age"),
+	))
+	new := schema.NewTable("user", schema.WithFields(
+		schema.StringField("email"),
+		schema.FloatField("age"),   // modified
+		schema.BoolField("active"), // added
+	))
+	diffs, err := DiffFields(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 3 {
+		t.Fatalf("expected 3 diffs, got %d", len(diffs))
+	}
+	if len(findByOp(diffs, DiffOperationAddField)) != 1 {
+		t.Errorf("expected 1 add_field, got %d", len(findByOp(diffs, DiffOperationAddField)))
+	}
+	if len(findByOp(diffs, DiffOperationDropField)) != 1 {
+		t.Errorf("expected 1 drop_field, got %d", len(findByOp(diffs, DiffOperationDropField)))
+	}
+	if len(findByOp(diffs, DiffOperationModifyField)) != 1 {
+		t.Errorf("expected 1 modify_field, got %d", len(findByOp(diffs, DiffOperationModifyField)))
+	}
+}
+
+func TestFieldsEqualValueAndReadOnly(t *testing.T) {
+	a := schema.ComputedField("full", "string::concat(first, ' ', last)", schema.FieldTypeString)
+	b := schema.ComputedField("full", "string::concat(first, ' ', last)", schema.FieldTypeString)
+	if !fieldsEqual(a, b) {
+		t.Fatal("expected fields equal")
+	}
+	c := schema.ComputedField("full", "string::concat(first, last)", schema.FieldTypeString)
+	if fieldsEqual(a, c) {
+		t.Fatal("expected fields unequal when value differs")
+	}
+}
+
+// --- DiffIndexes -------------------------------------------------------------
+
+func TestDiffIndexesAddedStandard(t *testing.T) {
+	old := schema.NewTable("post")
+	new := schema.NewTable("post", schema.WithIndexes(
+		schema.NewIndex("title_idx", []string{"title"}, schema.IndexTypeStandard),
+	))
+	diffs, err := DiffIndexes(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationAddIndex {
+		t.Fatalf("expected 1 add_index, got %v", diffs)
+	}
+	if !strings.HasPrefix(diffs[0].ForwardSQL, "DEFINE INDEX title_idx ON TABLE post COLUMNS title") {
+		t.Errorf("unexpected sql: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffIndexesAddedUnique(t *testing.T) {
+	new := schema.NewTable("user", schema.WithIndexes(
+		schema.UniqueIndex("email_uq", []string{"email"}),
+	))
+	diffs, err := DiffIndexes(schema.NewTable("user"), new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "UNIQUE") {
+		t.Errorf("expected UNIQUE in sql: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffIndexesAddedMultiColumn(t *testing.T) {
+	new := schema.NewTable("event", schema.WithIndexes(
+		schema.NewIndex("by_ts_user", []string{"timestamp", "user_id"}, schema.IndexTypeStandard),
+	))
+	diffs, err := DiffIndexes(schema.NewTable("event"), new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "COLUMNS timestamp, user_id") {
+		t.Errorf("expected multi-column sql, got: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffIndexesDropped(t *testing.T) {
+	old := schema.NewTable("post", schema.WithIndexes(
+		schema.NewIndex("title_idx", []string{"title"}, schema.IndexTypeStandard),
+	))
+	new := schema.NewTable("post")
+	diffs, err := DiffIndexes(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationDropIndex {
+		t.Fatalf("expected drop_index, got %v", diffs)
+	}
+	if diffs[0].ForwardSQL != "REMOVE INDEX title_idx ON TABLE post;" {
+		t.Errorf("unexpected sql: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffIndexesNoChange(t *testing.T) {
+	idx := schema.UniqueIndex("email_uq", []string{"email"})
+	old := schema.NewTable("user", schema.WithIndexes(idx))
+	new := schema.NewTable("user", schema.WithIndexes(idx))
+	diffs, err := DiffIndexes(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %v", diffs)
+	}
+}
+
+// --- MTREE / HNSW ------------------------------------------------------------
+
+func TestDiffIndexesAddMTree(t *testing.T) {
+	new := schema.NewTable("documents", schema.WithIndexes(
+		schema.MTreeIndex("emb_idx", "embedding", 1536, schema.MTreeIndexOptions{}),
+	))
+	diffs, err := DiffIndexes(schema.NewTable("documents"), new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	expect := "DEFINE INDEX emb_idx ON TABLE documents COLUMNS embedding MTREE DIMENSION 1536 DIST EUCLIDEAN TYPE F64;"
+	if diffs[0].ForwardSQL != expect {
+		t.Errorf("mtree sql mismatch.\n  got:  %s\n  want: %s", diffs[0].ForwardSQL, expect)
+	}
+}
+
+func TestDiffIndexesAddMTreeCosine(t *testing.T) {
+	new := schema.NewTable("documents", schema.WithIndexes(
+		schema.MTreeIndex("emb", "embedding", 768, schema.MTreeIndexOptions{
+			Distance:   schema.MTreeDistanceCosine,
+			VectorType: schema.MTreeVectorF32,
+		}),
+	))
+	diffs, err := DiffIndexes(schema.NewTable("documents"), new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "DIST COSINE") ||
+		!strings.Contains(diffs[0].ForwardSQL, "TYPE F32") {
+		t.Errorf("unexpected sql: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffIndexesAddMTreeNoDimension(t *testing.T) {
+	new := schema.NewTable("documents", schema.WithIndexes(schema.IndexDefinition{
+		Name:    "bad",
+		Columns: []string{"embedding"},
+		Type:    schema.IndexTypeMTree,
+	}))
+	_, err := DiffIndexes(schema.NewTable("documents"), new)
+	if err == nil || !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestDiffIndexesDropMTree(t *testing.T) {
+	idx := schema.MTreeIndex("emb_idx", "embedding", 1536, schema.MTreeIndexOptions{})
+	old := schema.NewTable("documents", schema.WithIndexes(idx))
+	new := schema.NewTable("documents")
+	diffs, err := DiffIndexes(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if diffs[0].Operation != DiffOperationDropIndex {
+		t.Errorf("op = %s", diffs[0].Operation)
+	}
+	if !strings.Contains(diffs[0].BackwardSQL, "MTREE DIMENSION 1536") {
+		t.Errorf("expected MTREE restore in backward sql: %s", diffs[0].BackwardSQL)
+	}
+}
+
+func TestDiffIndexesAddHNSW(t *testing.T) {
+	new := schema.NewTable("vectors", schema.WithIndexes(
+		schema.HnswIndex("vec_idx", "vector", 512, schema.HnswIndexOptions{}),
+	))
+	diffs, err := DiffIndexes(schema.NewTable("vectors"), new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "HNSW DIMENSION 512") {
+		t.Errorf("hnsw sql: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffIndexesAddHNSWWithTuning(t *testing.T) {
+	new := schema.NewTable("vectors", schema.WithIndexes(
+		schema.HnswIndex("vec_idx", "vector", 128, schema.HnswIndexOptions{
+			Distance: schema.HnswDistanceCosine, EFC: 200, M: 32,
+		}),
+	))
+	diffs, err := DiffIndexes(schema.NewTable("vectors"), new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	sql := diffs[0].ForwardSQL
+	if !strings.Contains(sql, "EFC 200") || !strings.Contains(sql, "M 32") ||
+		!strings.Contains(sql, "DIST COSINE") {
+		t.Errorf("unexpected sql: %s", sql)
+	}
+}
+
+func TestDiffIndexesAddHNSWNoDimension(t *testing.T) {
+	new := schema.NewTable("v", schema.WithIndexes(schema.IndexDefinition{
+		Name: "x", Columns: []string{"vec"}, Type: schema.IndexTypeHNSW,
+	}))
+	_, err := DiffIndexes(schema.NewTable("v"), new)
+	if err == nil || !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestDiffIndexesDropHNSW(t *testing.T) {
+	idx := schema.HnswIndex("vec_idx", "vector", 256, schema.HnswIndexOptions{})
+	old := schema.NewTable("vectors", schema.WithIndexes(idx))
+	new := schema.NewTable("vectors")
+	diffs, err := DiffIndexes(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if !strings.Contains(diffs[0].BackwardSQL, "HNSW DIMENSION 256") {
+		t.Errorf("expected HNSW in backward: %s", diffs[0].BackwardSQL)
+	}
+}
+
+func TestDiffIndexesMixedTypes(t *testing.T) {
+	old := schema.NewTable("v")
+	new := schema.NewTable("v", schema.WithIndexes(
+		schema.UniqueIndex("name_uq", []string{"name"}),
+		schema.MTreeIndex("emb_idx", "embedding", 512, schema.MTreeIndexOptions{}),
+		schema.HnswIndex("vec_idx", "vector", 256, schema.HnswIndexOptions{}),
+	))
+	diffs, err := DiffIndexes(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 3 {
+		t.Fatalf("expected 3 add_index diffs, got %d", len(diffs))
+	}
+}
+
+// --- DiffEvents --------------------------------------------------------------
+
+func TestDiffEventsAdded(t *testing.T) {
+	new := schema.NewTable("user", schema.WithEvents(
+		schema.NewEvent("touch", "$before.updated != $after.updated", "UPDATE user SET updated_at = time::now()"),
+	))
+	diffs, err := DiffEvents(schema.NewTable("user"), new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationAddEvent {
+		t.Fatalf("expected add_event, got %v", diffs)
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "DEFINE EVENT touch ON TABLE user WHEN") {
+		t.Errorf("unexpected sql: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffEventsDropped(t *testing.T) {
+	old := schema.NewTable("user", schema.WithEvents(
+		schema.NewEvent("touch", "true", "UPDATE user SET t = time::now()"),
+	))
+	diffs, err := DiffEvents(old, schema.NewTable("user"))
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if diffs[0].Operation != DiffOperationDropEvent {
+		t.Errorf("op = %s", diffs[0].Operation)
+	}
+	if diffs[0].ForwardSQL != "REMOVE EVENT touch ON TABLE user;" {
+		t.Errorf("forward sql: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffEventsNoChange(t *testing.T) {
+	ev := schema.NewEvent("touch", "true", "UPDATE user SET t = time::now()")
+	old := schema.NewTable("user", schema.WithEvents(ev))
+	new := schema.NewTable("user", schema.WithEvents(ev))
+	diffs, err := DiffEvents(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %v", diffs)
+	}
+}
+
+func TestDiffEventsUnsafeCondition(t *testing.T) {
+	new := schema.NewTable("user", schema.WithEvents(
+		schema.NewEvent("bad", "true; DROP TABLE user;", "UPDATE user SET t = time::now()"),
+	))
+	_, err := DiffEvents(schema.NewTable("user"), new)
+	if err == nil || !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestDiffEventsUnsafeAction(t *testing.T) {
+	new := schema.NewTable("user", schema.WithEvents(
+		schema.NewEvent("bad", "true", "UPDATE user SET t = time::now() -- drop"),
+	))
+	_, err := DiffEvents(schema.NewTable("user"), new)
+	if err == nil || !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestValidateEventExpressionTrailingSemicolon(t *testing.T) {
+	if err := validateEventExpression("true;", "condition"); err == nil {
+		t.Error("expected error for trailing semicolon")
+	}
+}
+
+func TestValidateEventExpressionComment(t *testing.T) {
+	if err := validateEventExpression("true -- nope", "condition"); err == nil {
+		t.Error("expected error for SQL comment")
+	}
+}
+
+func TestValidateEventExpressionValid(t *testing.T) {
+	if err := validateEventExpression("$before != $after", "condition"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// --- DiffPermissions ---------------------------------------------------------
+
+func TestDiffPermissionsAdded(t *testing.T) {
+	old := schema.NewTable("user")
+	new := schema.NewTable("user", schema.WithTablePermissions(map[string]string{"select": "true"}))
+	diffs := DiffPermissions(old, new)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if diffs[0].Operation != DiffOperationModifyPermissions {
+		t.Errorf("op = %s", diffs[0].Operation)
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "DEFINE FIELD PERMISSIONS FOR SELECT ON TABLE user WHERE true") {
+		t.Errorf("unexpected forward sql: %s", diffs[0].ForwardSQL)
+	}
+	if diffs[0].BackwardSQL != "" {
+		t.Errorf("expected empty backward sql, got %q", diffs[0].BackwardSQL)
+	}
+}
+
+func TestDiffPermissionsChanged(t *testing.T) {
+	old := schema.NewTable("user", schema.WithTablePermissions(map[string]string{"select": "false"}))
+	new := schema.NewTable("user", schema.WithTablePermissions(map[string]string{"select": "true"}))
+	diffs := DiffPermissions(old, new)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if !strings.Contains(diffs[0].BackwardSQL, "WHERE false") {
+		t.Errorf("expected old perms in backward sql: %s", diffs[0].BackwardSQL)
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "WHERE true") {
+		t.Errorf("expected new perms in forward sql: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffPermissionsRemoved(t *testing.T) {
+	old := schema.NewTable("user", schema.WithTablePermissions(map[string]string{"select": "true"}))
+	new := schema.NewTable("user")
+	diffs := DiffPermissions(old, new)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if diffs[0].ForwardSQL != "" {
+		t.Errorf("expected empty forward sql, got %q", diffs[0].ForwardSQL)
+	}
+	if !strings.Contains(diffs[0].BackwardSQL, "WHERE true") {
+		t.Errorf("unexpected backward sql: %s", diffs[0].BackwardSQL)
+	}
+}
+
+func TestDiffPermissionsNoChange(t *testing.T) {
+	perms := map[string]string{"select": "true"}
+	old := schema.NewTable("user", schema.WithTablePermissions(perms))
+	new := schema.NewTable("user", schema.WithTablePermissions(perms))
+	diffs := DiffPermissions(old, new)
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %v", diffs)
+	}
+}
+
+func TestDiffPermissionsNilVsEmptyNoChange(t *testing.T) {
+	old := schema.NewTable("user")
+	new := schema.NewTable("user", schema.WithTablePermissions(map[string]string{}))
+	diffs := DiffPermissions(old, new)
+	if len(diffs) != 0 {
+		t.Errorf("expected nil and empty map to match, got %v", diffs)
+	}
+}
+
+func TestDiffPermissionsMultipleStableOrder(t *testing.T) {
+	new := schema.NewTable("user", schema.WithTablePermissions(map[string]string{
+		"select": "true", "update": "false", "create": "true",
+	}))
+	diffs := DiffPermissions(schema.NewTable("user"), new)
+	sql := diffs[0].ForwardSQL
+	// Sorted key order: create, select, update
+	iCreate := strings.Index(sql, "FOR CREATE")
+	iSelect := strings.Index(sql, "FOR SELECT")
+	iUpdate := strings.Index(sql, "FOR UPDATE")
+	if !(iCreate < iSelect && iSelect < iUpdate) {
+		t.Errorf("expected sorted order, got: %s", sql)
+	}
+}
+
+// --- DiffEdges ---------------------------------------------------------------
+
+func TestDiffEdgesAdded(t *testing.T) {
+	e := schema.TypedEdge("likes", "user", "post")
+	diffs, err := DiffEdges(nil, &e)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationAddTable {
+		t.Fatalf("expected 1 add_table for edge, got %v", diffs)
+	}
+	expect := "DEFINE TABLE likes TYPE RELATION FROM user TO post;"
+	if diffs[0].ForwardSQL != expect {
+		t.Errorf("edge sql = %q, want %q", diffs[0].ForwardSQL, expect)
+	}
+}
+
+func TestDiffEdgesAddedSchemafull(t *testing.T) {
+	e := schema.NewEdge("owns", schema.WithEdgeMode(schema.EdgeModeSchemafull))
+	diffs, err := DiffEdges(nil, &e)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if diffs[0].ForwardSQL != "DEFINE TABLE owns SCHEMAFULL;" {
+		t.Errorf("sql = %q", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffEdgesAddedSchemaless(t *testing.T) {
+	e := schema.NewEdge("rel", schema.WithEdgeMode(schema.EdgeModeSchemaless))
+	diffs, err := DiffEdges(nil, &e)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if diffs[0].ForwardSQL != "DEFINE TABLE rel SCHEMALESS;" {
+		t.Errorf("sql = %q", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffEdgesAddedWithFieldsIndexesEvents(t *testing.T) {
+	e := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgeFields(schema.IntField("weight")),
+		schema.WithEdgeIndexes(schema.NewIndex("w_idx", []string{"weight"}, schema.IndexTypeStandard)),
+		schema.WithEdgeEvents(schema.NewEvent("touch", "true", "UPDATE likes SET t = time::now()")),
+	)
+	diffs, err := DiffEdges(nil, &e)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 4 {
+		t.Fatalf("expected 4 diffs (table + field + index + event), got %d", len(diffs))
+	}
+}
+
+func TestDiffEdgesDropped(t *testing.T) {
+	e := schema.TypedEdge("likes", "user", "post")
+	diffs, err := DiffEdges(&e, nil)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationDropTable {
+		t.Fatalf("expected drop_table, got %v", diffs)
+	}
+	if diffs[0].BackwardSQL != "" {
+		t.Errorf("expected empty backward sql for dropped edge, got %q", diffs[0].BackwardSQL)
+	}
+}
+
+func TestDiffEdgesFieldAdded(t *testing.T) {
+	oldE := schema.TypedEdge("likes", "user", "post")
+	newE := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgeFields(schema.IntField("weight")))
+	diffs, err := DiffEdges(&oldE, &newE)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationAddField {
+		t.Fatalf("expected add_field, got %v", diffs)
+	}
+	if diffs[0].Field != "weight" {
+		t.Errorf("field = %s", diffs[0].Field)
+	}
+}
+
+func TestDiffEdgesFieldRemoved(t *testing.T) {
+	oldE := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgeFields(schema.IntField("weight")))
+	newE := schema.TypedEdge("likes", "user", "post")
+	diffs, err := DiffEdges(&oldE, &newE)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationDropField {
+		t.Fatalf("expected drop_field, got %v", diffs)
+	}
+}
+
+func TestDiffEdgesFieldModified(t *testing.T) {
+	oldE := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgeFields(schema.IntField("weight")))
+	newE := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgeFields(schema.FloatField("weight")))
+	diffs, err := DiffEdges(&oldE, &newE)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationModifyField {
+		t.Fatalf("expected modify_field, got %v", diffs)
+	}
+}
+
+func TestDiffEdgesIndexAdded(t *testing.T) {
+	oldE := schema.TypedEdge("likes", "user", "post")
+	newE := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgeIndexes(schema.NewIndex("w_idx", []string{"weight"}, schema.IndexTypeStandard)))
+	diffs, err := DiffEdges(&oldE, &newE)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if diffs[0].Operation != DiffOperationAddIndex {
+		t.Errorf("op = %s", diffs[0].Operation)
+	}
+}
+
+func TestDiffEdgesEventAdded(t *testing.T) {
+	oldE := schema.TypedEdge("likes", "user", "post")
+	newE := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgeEvents(schema.NewEvent("touch", "true", "UPDATE likes SET t = time::now()")))
+	diffs, err := DiffEdges(&oldE, &newE)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if diffs[0].Operation != DiffOperationAddEvent {
+		t.Errorf("op = %s", diffs[0].Operation)
+	}
+}
+
+func TestDiffEdgesPermissionsChanged(t *testing.T) {
+	oldE := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgePermissions(map[string]string{"select": "false"}))
+	newE := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgePermissions(map[string]string{"select": "true"}))
+	diffs, err := DiffEdges(&oldE, &newE)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationModifyPermissions {
+		t.Fatalf("expected modify_permissions, got %v", diffs)
+	}
+}
+
+func TestDiffEdgesNoChange(t *testing.T) {
+	e := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgeFields(schema.IntField("weight")))
+	diffs, err := DiffEdges(&e, &e)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %v", diffs)
+	}
+}
+
+func TestDiffEdgesBothNil(t *testing.T) {
+	diffs, err := DiffEdges(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diffs != nil && len(diffs) != 0 {
+		t.Errorf("expected empty, got %v", diffs)
+	}
+}
+
+// --- DiffSchemas -------------------------------------------------------------
+
+func TestDiffSchemasAddTable(t *testing.T) {
+	code := SchemaSnapshot{Tables: []schema.TableDefinition{schema.NewTable("user")}}
+	db := SchemaSnapshot{}
+	diffs, err := DiffSchemas(code, db)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationAddTable {
+		t.Fatalf("expected add_table, got %v", diffs)
+	}
+}
+
+func TestDiffSchemasDropTable(t *testing.T) {
+	code := SchemaSnapshot{}
+	db := SchemaSnapshot{Tables: []schema.TableDefinition{schema.NewTable("legacy")}}
+	diffs, err := DiffSchemas(code, db)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationDropTable {
+		t.Fatalf("expected drop_table, got %v", diffs)
+	}
+}
+
+func TestDiffSchemasModifyTable(t *testing.T) {
+	code := SchemaSnapshot{Tables: []schema.TableDefinition{
+		schema.NewTable("user", schema.WithFields(schema.StringField("email"), schema.IntField("age"))),
+	}}
+	db := SchemaSnapshot{Tables: []schema.TableDefinition{
+		schema.NewTable("user", schema.WithFields(schema.StringField("email"))),
+	}}
+	diffs, err := DiffSchemas(code, db)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationAddField {
+		t.Fatalf("expected add_field, got %v", diffs)
+	}
+}
+
+func TestDiffSchemasAddEdge(t *testing.T) {
+	code := SchemaSnapshot{Edges: []schema.EdgeDefinition{schema.TypedEdge("likes", "user", "post")}}
+	db := SchemaSnapshot{}
+	diffs, err := DiffSchemas(code, db)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationAddTable {
+		t.Fatalf("expected edge add_table, got %v", diffs)
+	}
+}
+
+func TestDiffSchemasDropEdge(t *testing.T) {
+	code := SchemaSnapshot{}
+	db := SchemaSnapshot{Edges: []schema.EdgeDefinition{schema.TypedEdge("likes", "user", "post")}}
+	diffs, err := DiffSchemas(code, db)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationDropTable {
+		t.Fatalf("expected drop_table, got %v", diffs)
+	}
+}
+
+func TestDiffSchemasEmptyBoth(t *testing.T) {
+	diffs, err := DiffSchemas(SchemaSnapshot{}, SchemaSnapshot{})
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected empty, got %v", diffs)
+	}
+}
+
+func TestDiffSchemasNoChange(t *testing.T) {
+	snap := SchemaSnapshot{
+		Tables: []schema.TableDefinition{schema.NewTable("user", schema.WithFields(schema.StringField("email")))},
+		Edges:  []schema.EdgeDefinition{schema.TypedEdge("likes", "user", "post")},
+	}
+	diffs, err := DiffSchemas(snap, snap)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %v", diffs)
+	}
+}
+
+func TestDiffSchemasComplex(t *testing.T) {
+	code := SchemaSnapshot{
+		Tables: []schema.TableDefinition{
+			schema.NewTable("user", schema.WithFields(schema.StringField("email"), schema.StringField("name"))),
+			schema.NewTable("post", schema.WithFields(schema.StringField("title"))),
+		},
+		Edges: []schema.EdgeDefinition{
+			schema.TypedEdge("likes", "user", "post"),
+		},
+	}
+	db := SchemaSnapshot{
+		Tables: []schema.TableDefinition{
+			schema.NewTable("user", schema.WithFields(schema.StringField("email"))),
+			schema.NewTable("legacy"),
+		},
+	}
+	diffs, err := DiffSchemas(code, db)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	// Expected: add post (table + title field), drop legacy, add user.name, add likes edge.
+	opsSeen := map[DiffOperation]int{}
+	for _, d := range diffs {
+		opsSeen[d.Operation]++
+	}
+	if opsSeen[DiffOperationAddTable] != 2 {
+		t.Errorf("add_table count = %d, want 2 (post + likes)", opsSeen[DiffOperationAddTable])
+	}
+	if opsSeen[DiffOperationDropTable] != 1 {
+		t.Errorf("drop_table count = %d, want 1 (legacy)", opsSeen[DiffOperationDropTable])
+	}
+	if opsSeen[DiffOperationAddField] != 2 {
+		t.Errorf("add_field count = %d, want 2 (post.title, user.name)", opsSeen[DiffOperationAddField])
+	}
+}
+
+func TestDiffSchemasModifyTableSortedOrder(t *testing.T) {
+	// Modified tables should be emitted in sorted name order for determinism.
+	code := SchemaSnapshot{Tables: []schema.TableDefinition{
+		schema.NewTable("zebra", schema.WithFields(schema.StringField("stripes"))),
+		schema.NewTable("alpha", schema.WithFields(schema.StringField("name"))),
+	}}
+	db := SchemaSnapshot{Tables: []schema.TableDefinition{
+		schema.NewTable("zebra"),
+		schema.NewTable("alpha"),
+	}}
+	diffs, err := DiffSchemas(code, db)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 2 {
+		t.Fatalf("expected 2 diffs, got %d", len(diffs))
+	}
+	if diffs[0].Table != "alpha" || diffs[1].Table != "zebra" {
+		t.Errorf("expected sorted table order, got %s, %s", diffs[0].Table, diffs[1].Table)
+	}
+}
+
+// --- Default-value validation ------------------------------------------------
+
+func TestValidateDefaultValueFunctionCall(t *testing.T) {
+	if err := validateDefaultValue("time::now()"); err != nil {
+		t.Errorf("unexpected: %v", err)
+	}
+	if err := validateDefaultValue("rand::uuid()"); err != nil {
+		t.Errorf("unexpected: %v", err)
+	}
+}
+
+func TestValidateDefaultValueLiterals(t *testing.T) {
+	cases := []string{"42", "-1", "3.14", "true", "false", "NONE", "NULL", "'hello'", "$session"}
+	for _, c := range cases {
+		if err := validateDefaultValue(c); err != nil {
+			t.Errorf("expected %q safe, got %v", c, err)
+		}
+	}
+}
+
+func TestValidateDefaultValueUnsafe(t *testing.T) {
+	cases := []string{
+		"'x'; DROP TABLE user; --",
+		"1; SELECT",
+		"foo + 1", // not a pure function call
+	}
+	for _, c := range cases {
+		if err := validateDefaultValue(c); err == nil {
+			t.Errorf("expected %q unsafe", c)
+		}
+	}
+}
+
+// --- Sanity: modify table routes all child diffs -----------------------------
+
+func TestDiffTablesModifyFieldAndIndex(t *testing.T) {
+	old := schema.NewTable("user",
+		schema.WithFields(schema.StringField("email")),
+		schema.WithIndexes(schema.UniqueIndex("email_uq", []string{"email"})),
+	)
+	new := schema.NewTable("user",
+		schema.WithFields(schema.StringField("email"), schema.IntField("age")),
+		schema.WithIndexes(
+			schema.UniqueIndex("email_uq", []string{"email"}),
+			schema.NewIndex("age_idx", []string{"age"}, schema.IndexTypeStandard),
+		),
+	)
+	diffs, err := DiffTables(&old, &new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(findByOp(diffs, DiffOperationAddField)) != 1 {
+		t.Errorf("expected 1 add_field, got %d", len(findByOp(diffs, DiffOperationAddField)))
+	}
+	if len(findByOp(diffs, DiffOperationAddIndex)) != 1 {
+		t.Errorf("expected 1 add_index, got %d", len(findByOp(diffs, DiffOperationAddIndex)))
+	}
+}


### PR DESCRIPTION
Closes #23.

## Summary
Port surql-py/src/surql/migration/diff.py.

- **\`migration/diff.go\`**: \`DiffTables\`, \`DiffFields\`, \`DiffIndexes\`, \`DiffEvents\`, \`DiffPermissions\`, \`DiffEdges\`, aggregator \`DiffSchemas(code, db SchemaSnapshot)\` + new \`SchemaSnapshot\` struct.
- Ports the Python \`_SAFE_DEFAULT_PATTERN\` regex and \`_validate_event_expression\` guards; unsafe defaults / event expressions return \`surqlerrors.ErrValidation\`.
- MTREE / HNSW index SQL matches Python byte-for-byte (\`DEFINE INDEX ... MTREE DIMENSION 1536 DIST EUCLIDEAN TYPE F64;\`).
- Deterministic output: additions in new-slice order, drops in old-slice order, modifications sorted by name, permission maps sorted.
- Edge diff reuses table diff via a \`TableDefinition\` proxy (same pattern as Python).

## Deviations
- Kept the existing \`SchemaDiff\` model shape (\`ForwardSQL\` / \`BackwardSQL\` / \`Details\`) from the previously-merged \`models.go\` rather than the ADD/REMOVE/MODIFY variant in the brief. Python's actual shape matches the existing one.

## Test plan
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./... -race\` — **69 new diff tests green**
- [ ] CI green