### PR TITLE
feat(migration): port versioning + snapshots

### DIFF
--- a/pkg/surql/migration/diff.go
+++ b/pkg/surql/migration/diff.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
 	"github.com/albedosehen/surql-go/pkg/surql/schema"
@@ -32,16 +33,29 @@ var safeDefaultPattern = regexp.MustCompile(
 		`)$`,
 )
 
-// SchemaSnapshot is a whole-schema view consumed by DiffSchemas. It carries
-// the ordered set of tables and edges that make up a schema revision (code
-// side) or the remote database state.
+// SchemaSnapshot is a point-in-time view of a SurrealDB schema.
 //
-// The snapshot deliberately mirrors the shape of surql-py's implicit "list of
-// tables + list of edges" contract rather than introducing a new Python
-// concept; it simply gives the Go port a concrete type to compare against.
+// In its simplest form (empty Version / Timestamp / Description / Accesses)
+// it is the whole-schema comparison input consumed by DiffSchemas; the Tables
+// and Edges slices drive the code-vs-db comparison.
+//
+// When used via the versioning API (CreateSnapshot / StoreSnapshot /
+// LoadSnapshot) the remaining fields record snapshot provenance:
+//
+//   - Version identifies the snapshot (YYYYMMDD_HHMMSS timestamp).
+//   - Timestamp is the UTC creation time.
+//   - Description is a human-readable summary.
+//   - Accesses holds DEFINE ACCESS definitions present at this point.
+//
+// The type is JSON-serialisable; fields with no semantic content are emitted
+// with `omitempty` so the DiffSchemas contract is preserved.
 type SchemaSnapshot struct {
-	Tables []schema.TableDefinition
-	Edges  []schema.EdgeDefinition
+	Version     string                    `json:"version,omitempty"`
+	Timestamp   time.Time                 `json:"timestamp,omitempty"`
+	Description string                    `json:"description,omitempty"`
+	Tables      []schema.TableDefinition  `json:"tables,omitempty"`
+	Edges       []schema.EdgeDefinition   `json:"edges,omitempty"`
+	Accesses    []schema.AccessDefinition `json:"accesses,omitempty"`
 }
 
 // validateEventExpression rejects event condition or action expressions that

--- a/pkg/surql/migration/versioning.go
+++ b/pkg/surql/migration/versioning.go
@@ -1,0 +1,525 @@
+package migration
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/schema"
+)
+
+// snapshotFileSuffix is the filename suffix used for persisted snapshots.
+// Snapshots are stored as "<version>.snapshot.json".
+const snapshotFileSuffix = ".snapshot.json"
+
+// snapshotClock is the clock source used by CreateSnapshot. Tests override it
+// to make Version / Timestamp deterministic; production code always uses
+// time.Now in UTC.
+var snapshotClock = func() time.Time { return time.Now().UTC() }
+
+// CreateSnapshot builds a SchemaSnapshot from the given SchemaRegistry.
+//
+// The Version is a UTC timestamp in YYYYMMDD_HHMMSS form matching the
+// migration file convention. Tables, Edges, and Accesses are copied from the
+// registry in deterministic (alphabetical) order. The snapshot captures the
+// registry as-of the call; subsequent registry mutations do not affect the
+// returned value.
+//
+// A nil registry is rejected with ErrValidation; an empty description is
+// allowed (matches surql-py where description is optional metadata).
+func CreateSnapshot(registry *schema.SchemaRegistry, description string) (SchemaSnapshot, error) {
+	if registry == nil {
+		return SchemaSnapshot{}, surqlerrors.New(surqlerrors.ErrValidation,
+			"cannot create snapshot from nil registry")
+	}
+
+	ts := snapshotClock()
+	version := ts.Format(timestampLayout)
+
+	return SchemaSnapshot{
+		Version:     version,
+		Timestamp:   ts,
+		Description: description,
+		Tables:      registry.Tables(),
+		Edges:       registry.Edges(),
+		Accesses:    []schema.AccessDefinition{},
+	}, nil
+}
+
+// StoreSnapshot writes a snapshot to a JSON file at path.
+//
+// If path is a directory, the snapshot is written to
+// "<path>/<version>.snapshot.json". If path already ends with the expected
+// suffix it is used verbatim. The snapshot must have a non-empty Version.
+// Parent directories are created as needed with 0o755 permissions; the file
+// itself is written with 0o644.
+func StoreSnapshot(snapshot SchemaSnapshot, path string) error {
+	if snapshot.Version == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"cannot store snapshot with empty version")
+	}
+	if path == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"snapshot path cannot be empty")
+	}
+
+	target, err := resolveSnapshotPath(path, snapshot.Version)
+	if err != nil {
+		return err
+	}
+
+	if dir := filepath.Dir(target); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return surqlerrors.Wrapf(surqlerrors.ErrSerialization, err,
+				"failed to create snapshot directory %q", dir)
+		}
+	}
+
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return surqlerrors.Wrapf(surqlerrors.ErrSerialization, err,
+			"failed to marshal snapshot %q", snapshot.Version)
+	}
+
+	if err := os.WriteFile(target, data, 0o644); err != nil {
+		return surqlerrors.Wrapf(surqlerrors.ErrSerialization, err,
+			"failed to write snapshot file %q", target)
+	}
+	return nil
+}
+
+// LoadSnapshot reads a snapshot JSON file from path and returns the decoded
+// SchemaSnapshot.
+//
+// A missing file returns ErrMigrationLoad; a malformed file returns
+// ErrSerialization. The returned snapshot is validated for a non-empty
+// Version field — legacy snapshots without versioning metadata are rejected
+// so that callers can rely on Version being present.
+func LoadSnapshot(path string) (SchemaSnapshot, error) {
+	if path == "" {
+		return SchemaSnapshot{}, surqlerrors.New(surqlerrors.ErrValidation,
+			"snapshot path cannot be empty")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return SchemaSnapshot{}, surqlerrors.Wrapf(surqlerrors.ErrMigrationLoad, err,
+			"failed to read snapshot file %q", path)
+	}
+
+	var snapshot SchemaSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return SchemaSnapshot{}, surqlerrors.Wrapf(surqlerrors.ErrSerialization, err,
+			"failed to decode snapshot file %q", path)
+	}
+
+	if snapshot.Version == "" {
+		return SchemaSnapshot{}, surqlerrors.Newf(surqlerrors.ErrSerialization,
+			"snapshot file %q has empty version", path)
+	}
+	return snapshot, nil
+}
+
+// ListSnapshots scans dir for snapshot files and returns the decoded
+// snapshots in ascending Version order.
+//
+// Files that do not match the snapshot suffix are skipped. Individual decode
+// failures are surfaced as errors (rather than silently dropped) so callers
+// can detect corruption. A non-existent directory returns
+// ErrMigrationDiscovery.
+func ListSnapshots(dir string) ([]SchemaSnapshot, error) {
+	if dir == "" {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation,
+			"snapshot directory cannot be empty")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, surqlerrors.Wrapf(surqlerrors.ErrMigrationDiscovery, err,
+			"failed to read snapshot directory %q", dir)
+	}
+
+	snapshots := make([]SchemaSnapshot, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, snapshotFileSuffix) {
+			continue
+		}
+		snap, err := LoadSnapshot(filepath.Join(dir, name))
+		if err != nil {
+			return nil, err
+		}
+		snapshots = append(snapshots, snap)
+	}
+
+	sort.Slice(snapshots, func(i, j int) bool {
+		return snapshots[i].Version < snapshots[j].Version
+	})
+	return snapshots, nil
+}
+
+// CompareSnapshots computes the set of SchemaDiff operations needed to evolve
+// the "from" snapshot into the "to" snapshot.
+//
+// Internally this is DiffSchemas(to, from) — DiffSchemas treats the first
+// argument as the desired (code) state and the second as the current (db)
+// state, so passing to/from in that order yields ADD diffs for entries
+// present in "to" but missing in "from", DROP diffs for the reverse.
+//
+// Accesses are not yet part of DiffSchemas; CompareSnapshots reports only
+// table and edge differences. Future work can extend the diff engine to
+// cover DEFINE ACCESS statements.
+func CompareSnapshots(from, to SchemaSnapshot) ([]SchemaDiff, error) {
+	return DiffSchemas(to, from)
+}
+
+// VersionNode is a node in the VersionGraph, tying a snapshot to its parent
+// (previous schema version) and child (subsequent) versions.
+//
+// Parent is the empty string for root nodes. Children is maintained by the
+// owning VersionGraph and is always kept in sorted order for deterministic
+// traversal.
+type VersionNode struct {
+	Version  string         `json:"version"`
+	Parent   string         `json:"parent,omitempty"`
+	Snapshot SchemaSnapshot `json:"snapshot"`
+	Children []string       `json:"children,omitempty"`
+}
+
+// VersionGraph is a thread-safe DAG of schema snapshots keyed by Version.
+//
+// It mirrors surql-py's VersionGraph: snapshots are inserted with an optional
+// parent, and the graph exposes path-finding (BFS), ancestor, descendant, and
+// bulk version listing helpers used by rollback and version comparison
+// tooling.
+type VersionGraph struct {
+	mu    sync.RWMutex
+	nodes map[string]*VersionNode
+	root  string
+}
+
+// NewVersionGraph returns an empty VersionGraph.
+func NewVersionGraph() *VersionGraph {
+	return &VersionGraph{nodes: make(map[string]*VersionNode)}
+}
+
+// Add inserts a snapshot into the graph under the given parent.
+//
+// Parent may be the empty string to register a root node; the first
+// parentless node becomes the graph's root. A duplicate Version returns
+// ErrValidation. A non-empty parent that does not yet exist in the graph
+// also returns ErrValidation. The snapshot must have a non-empty Version.
+func (g *VersionGraph) Add(snapshot SchemaSnapshot, parent string) error {
+	if snapshot.Version == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"cannot add snapshot with empty version to graph")
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if _, exists := g.nodes[snapshot.Version]; exists {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"version %q already exists in graph", snapshot.Version)
+	}
+	if parent != "" {
+		if _, ok := g.nodes[parent]; !ok {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"parent version %q not found in graph", parent)
+		}
+	}
+
+	node := &VersionNode{
+		Version:  snapshot.Version,
+		Parent:   parent,
+		Snapshot: snapshot,
+	}
+	g.nodes[snapshot.Version] = node
+
+	if parent != "" {
+		parentNode := g.nodes[parent]
+		parentNode.Children = insertSorted(parentNode.Children, snapshot.Version)
+	} else if g.root == "" {
+		g.root = snapshot.Version
+	}
+	return nil
+}
+
+// Remove deletes a node from the graph.
+//
+// Removal rewires the graph: each child of the removed node is re-parented
+// to the removed node's parent (or becomes a root if no parent exists). A
+// missing version returns ErrValidation.
+func (g *VersionGraph) Remove(version string) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	node, ok := g.nodes[version]
+	if !ok {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"version %q not found in graph", version)
+	}
+
+	// Detach from parent's children list.
+	if node.Parent != "" {
+		if parentNode, ok := g.nodes[node.Parent]; ok {
+			parentNode.Children = removeFromSlice(parentNode.Children, version)
+		}
+	}
+
+	// Re-parent children onto the removed node's parent (or promote to root).
+	for _, childVersion := range node.Children {
+		child, ok := g.nodes[childVersion]
+		if !ok {
+			continue
+		}
+		child.Parent = node.Parent
+		if node.Parent != "" {
+			if parentNode, ok := g.nodes[node.Parent]; ok {
+				parentNode.Children = insertSorted(parentNode.Children, childVersion)
+			}
+		}
+	}
+
+	delete(g.nodes, version)
+
+	// Reset root if we just removed it; promote an arbitrary remaining root.
+	if g.root == version {
+		g.root = ""
+		for v, n := range g.nodes {
+			if n.Parent == "" {
+				g.root = v
+				break
+			}
+		}
+	}
+	return nil
+}
+
+// Get returns the VersionNode for the given version (and whether it exists).
+// The returned node is a shallow copy; mutating its Children slice is safe
+// and will not affect graph state.
+func (g *VersionGraph) Get(version string) (VersionNode, bool) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	node, ok := g.nodes[version]
+	if !ok {
+		return VersionNode{}, false
+	}
+	cp := *node
+	cp.Children = append([]string(nil), node.Children...)
+	return cp, true
+}
+
+// Has reports whether the given version exists in the graph.
+func (g *VersionGraph) Has(version string) bool {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	_, ok := g.nodes[version]
+	return ok
+}
+
+// Root returns the root version (empty string when the graph is empty).
+func (g *VersionGraph) Root() string {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.root
+}
+
+// Len returns the number of versions in the graph.
+func (g *VersionGraph) Len() int {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return len(g.nodes)
+}
+
+// Versions returns every version in the graph sorted alphabetically.
+func (g *VersionGraph) Versions() []string {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	out := make([]string, 0, len(g.nodes))
+	for v := range g.nodes {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Path returns the shortest path from one version to another, traversing
+// both parent and child edges (BFS). An empty slice is returned when either
+// endpoint is missing; a nil slice is returned when no path exists between
+// existing nodes.
+func (g *VersionGraph) Path(from, to string) []string {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	if _, ok := g.nodes[from]; !ok {
+		return nil
+	}
+	if _, ok := g.nodes[to]; !ok {
+		return nil
+	}
+	if from == to {
+		return []string{from}
+	}
+
+	type state struct {
+		version string
+		path    []string
+	}
+	queue := []state{{version: from, path: []string{from}}}
+	visited := map[string]struct{}{from: {}}
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+
+		node := g.nodes[cur.version]
+		neighbours := make([]string, 0, len(node.Children)+1)
+		neighbours = append(neighbours, node.Children...)
+		if node.Parent != "" {
+			neighbours = append(neighbours, node.Parent)
+		}
+
+		for _, n := range neighbours {
+			if _, seen := visited[n]; seen {
+				continue
+			}
+			visited[n] = struct{}{}
+			newPath := make([]string, len(cur.path)+1)
+			copy(newPath, cur.path)
+			newPath[len(cur.path)] = n
+			if n == to {
+				return newPath
+			}
+			queue = append(queue, state{version: n, path: newPath})
+		}
+	}
+	return nil
+}
+
+// Ancestors returns every ancestor of the given version, ordered from root
+// down to the immediate parent. An unknown version returns nil.
+func (g *VersionGraph) Ancestors(version string) []string {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	if _, ok := g.nodes[version]; !ok {
+		return nil
+	}
+
+	var ancestors []string
+	current := version
+	for {
+		node := g.nodes[current]
+		if node == nil || node.Parent == "" {
+			break
+		}
+		ancestors = append([]string{node.Parent}, ancestors...)
+		current = node.Parent
+	}
+	return ancestors
+}
+
+// Descendants returns every descendant of the given version in BFS order.
+// An unknown version returns nil.
+func (g *VersionGraph) Descendants(version string) []string {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	node, ok := g.nodes[version]
+	if !ok {
+		return nil
+	}
+
+	descendants := make([]string, 0)
+	queue := append([]string(nil), node.Children...)
+	visited := make(map[string]struct{}, len(node.Children))
+	for _, c := range node.Children {
+		visited[c] = struct{}{}
+	}
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		descendants = append(descendants, cur)
+
+		childNode, ok := g.nodes[cur]
+		if !ok {
+			continue
+		}
+		for _, c := range childNode.Children {
+			if _, seen := visited[c]; seen {
+				continue
+			}
+			visited[c] = struct{}{}
+			queue = append(queue, c)
+		}
+	}
+	return descendants
+}
+
+// resolveSnapshotPath normalises a caller-supplied path + version into the
+// absolute snapshot filename. When path names an existing directory the
+// snapshot is placed under "<path>/<version>.snapshot.json"; when path ends
+// with the snapshot suffix it is used verbatim; otherwise the path is
+// treated as the destination file name (directory created on write).
+func resolveSnapshotPath(path, version string) (string, error) {
+	if strings.HasSuffix(path, snapshotFileSuffix) {
+		return path, nil
+	}
+
+	info, err := os.Stat(path)
+	switch {
+	case err == nil && info.IsDir():
+		return filepath.Join(path, fmt.Sprintf("%s%s", version, snapshotFileSuffix)), nil
+	case err == nil:
+		return "", surqlerrors.Newf(surqlerrors.ErrValidation,
+			"snapshot path %q exists and is neither a directory nor a %s file",
+			path, snapshotFileSuffix)
+	case os.IsNotExist(err):
+		// Non-existent paths without the snapshot suffix are treated as a
+		// directory that should be created lazily on write.
+		return filepath.Join(path, fmt.Sprintf("%s%s", version, snapshotFileSuffix)), nil
+	default:
+		return "", surqlerrors.Wrapf(surqlerrors.ErrValidation, err,
+			"failed to stat snapshot path %q", path)
+	}
+}
+
+// insertSorted returns a copy of slice with value inserted in sorted order,
+// preserving uniqueness.
+func insertSorted(slice []string, value string) []string {
+	idx := sort.SearchStrings(slice, value)
+	if idx < len(slice) && slice[idx] == value {
+		return slice
+	}
+	out := make([]string, len(slice)+1)
+	copy(out, slice[:idx])
+	out[idx] = value
+	copy(out[idx+1:], slice[idx:])
+	return out
+}
+
+// removeFromSlice returns a copy of slice with the first occurrence of value
+// removed.
+func removeFromSlice(slice []string, value string) []string {
+	for i, v := range slice {
+		if v == value {
+			out := make([]string, 0, len(slice)-1)
+			out = append(out, slice[:i]...)
+			out = append(out, slice[i+1:]...)
+			return out
+		}
+	}
+	return append([]string(nil), slice...)
+}

--- a/pkg/surql/migration/versioning_test.go
+++ b/pkg/surql/migration/versioning_test.go
@@ -1,0 +1,778 @@
+package migration
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/schema"
+)
+
+// withSnapshotClock overrides snapshotClock for the duration of the test.
+func withSnapshotClock(t *testing.T, fixed time.Time) {
+	t.Helper()
+	previous := snapshotClock
+	snapshotClock = func() time.Time { return fixed }
+	t.Cleanup(func() { snapshotClock = previous })
+}
+
+// fixedTime is a deterministic timestamp used across tests.
+func fixedTime() time.Time {
+	return time.Date(2026, 4, 18, 12, 30, 45, 0, time.UTC)
+}
+
+// populatedRegistry returns a registry containing one table + one edge.
+func populatedRegistry(t *testing.T) *schema.SchemaRegistry {
+	t.Helper()
+	reg := schema.NewSchemaRegistry()
+	if err := reg.RegisterTable(schema.NewTable("user",
+		schema.WithFields(schema.StringField("email"), schema.StringField("name")),
+	)); err != nil {
+		t.Fatalf("failed to register table: %v", err)
+	}
+	if err := reg.RegisterEdge(schema.TypedEdge("likes", "user", "post")); err != nil {
+		t.Fatalf("failed to register edge: %v", err)
+	}
+	return reg
+}
+
+func TestCreateSnapshotPopulatesVersionAndTimestamp(t *testing.T) {
+	withSnapshotClock(t, fixedTime())
+	reg := populatedRegistry(t)
+
+	snap, err := CreateSnapshot(reg, "initial")
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+	if snap.Version != "20260418_123045" {
+		t.Errorf("Version = %q, want 20260418_123045", snap.Version)
+	}
+	if !snap.Timestamp.Equal(fixedTime()) {
+		t.Errorf("Timestamp = %v, want %v", snap.Timestamp, fixedTime())
+	}
+	if snap.Description != "initial" {
+		t.Errorf("Description = %q, want %q", snap.Description, "initial")
+	}
+}
+
+func TestCreateSnapshotCopiesRegistryContents(t *testing.T) {
+	withSnapshotClock(t, fixedTime())
+	reg := populatedRegistry(t)
+
+	snap, err := CreateSnapshot(reg, "")
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+	if len(snap.Tables) != 1 || snap.Tables[0].Name != "user" {
+		t.Errorf("Tables = %v, want [user]", snap.Tables)
+	}
+	if len(snap.Edges) != 1 || snap.Edges[0].Name != "likes" {
+		t.Errorf("Edges = %v, want [likes]", snap.Edges)
+	}
+}
+
+func TestCreateSnapshotAllowsEmptyDescription(t *testing.T) {
+	withSnapshotClock(t, fixedTime())
+	snap, err := CreateSnapshot(schema.NewSchemaRegistry(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap.Description != "" {
+		t.Errorf("Description = %q, want empty", snap.Description)
+	}
+}
+
+func TestCreateSnapshotRejectsNilRegistry(t *testing.T) {
+	_, err := CreateSnapshot(nil, "nope")
+	if err == nil {
+		t.Fatal("expected error for nil registry")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestCreateSnapshotIsIndependentOfLaterRegistryMutation(t *testing.T) {
+	withSnapshotClock(t, fixedTime())
+	reg := populatedRegistry(t)
+	snap, err := CreateSnapshot(reg, "")
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+
+	// Mutating the registry after snapshot must not alter the snapshot.
+	if err := reg.RegisterTable(schema.NewTable("added_after")); err != nil {
+		t.Fatalf("failed to register later table: %v", err)
+	}
+	if len(snap.Tables) != 1 {
+		t.Errorf("snapshot Tables len = %d, want 1 after registry mutation",
+			len(snap.Tables))
+	}
+}
+
+func TestStoreAndLoadSnapshotRoundTrip(t *testing.T) {
+	withSnapshotClock(t, fixedTime())
+	reg := populatedRegistry(t)
+	snap, err := CreateSnapshot(reg, "initial schema")
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := StoreSnapshot(snap, dir); err != nil {
+		t.Fatalf("StoreSnapshot returned error: %v", err)
+	}
+
+	expectedPath := filepath.Join(dir, snap.Version+snapshotFileSuffix)
+	loaded, err := LoadSnapshot(expectedPath)
+	if err != nil {
+		t.Fatalf("LoadSnapshot returned error: %v", err)
+	}
+
+	if loaded.Version != snap.Version {
+		t.Errorf("Version mismatch: got %q, want %q", loaded.Version, snap.Version)
+	}
+	if loaded.Description != snap.Description {
+		t.Errorf("Description mismatch: got %q, want %q",
+			loaded.Description, snap.Description)
+	}
+	if len(loaded.Tables) != len(snap.Tables) {
+		t.Errorf("Tables len: got %d, want %d",
+			len(loaded.Tables), len(snap.Tables))
+	}
+	if len(loaded.Edges) != len(snap.Edges) {
+		t.Errorf("Edges len: got %d, want %d",
+			len(loaded.Edges), len(snap.Edges))
+	}
+	if !loaded.Timestamp.Equal(snap.Timestamp) {
+		t.Errorf("Timestamp mismatch: got %v, want %v",
+			loaded.Timestamp, snap.Timestamp)
+	}
+}
+
+func TestStoreSnapshotCreatesParentDirectory(t *testing.T) {
+	withSnapshotClock(t, fixedTime())
+	snap, err := CreateSnapshot(schema.NewSchemaRegistry(), "x")
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+
+	base := t.TempDir()
+	nested := filepath.Join(base, "sub", "dir")
+	if err := StoreSnapshot(snap, nested); err != nil {
+		t.Fatalf("StoreSnapshot returned error: %v", err)
+	}
+	// Directory should exist now.
+	info, err := os.Stat(nested)
+	if err != nil {
+		t.Fatalf("expected nested dir to exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected nested path to be a directory")
+	}
+}
+
+func TestStoreSnapshotAcceptsExplicitFilePath(t *testing.T) {
+	withSnapshotClock(t, fixedTime())
+	snap, err := CreateSnapshot(schema.NewSchemaRegistry(), "x")
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), "explicit"+snapshotFileSuffix)
+	if err := StoreSnapshot(snap, target); err != nil {
+		t.Fatalf("StoreSnapshot returned error: %v", err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("expected file at %q: %v", target, err)
+	}
+}
+
+func TestStoreSnapshotRejectsEmptyVersion(t *testing.T) {
+	err := StoreSnapshot(SchemaSnapshot{}, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for empty version")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestStoreSnapshotRejectsEmptyPath(t *testing.T) {
+	err := StoreSnapshot(SchemaSnapshot{Version: "v1"}, "")
+	if err == nil {
+		t.Fatal("expected error for empty path")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestLoadSnapshotMissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist"+snapshotFileSuffix)
+	_, err := LoadSnapshot(missing)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !errors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("expected ErrMigrationLoad, got %v", err)
+	}
+}
+
+func TestLoadSnapshotMalformedJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad"+snapshotFileSuffix)
+	if err := os.WriteFile(path, []byte("not json"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	_, err := LoadSnapshot(path)
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+	if !errors.Is(err, surqlerrors.ErrSerialization) {
+		t.Errorf("expected ErrSerialization, got %v", err)
+	}
+}
+
+func TestLoadSnapshotRejectsEmptyVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "noversion"+snapshotFileSuffix)
+	payload, _ := json.Marshal(map[string]any{"tables": []any{}})
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	_, err := LoadSnapshot(path)
+	if err == nil {
+		t.Fatal("expected error for empty version")
+	}
+	if !errors.Is(err, surqlerrors.ErrSerialization) {
+		t.Errorf("expected ErrSerialization, got %v", err)
+	}
+}
+
+func TestLoadSnapshotRejectsEmptyPath(t *testing.T) {
+	_, err := LoadSnapshot("")
+	if err == nil {
+		t.Fatal("expected error for empty path")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestListSnapshotsReturnsSortedByVersion(t *testing.T) {
+	dir := t.TempDir()
+
+	versions := []string{"20260103_000000", "20260101_000000", "20260102_000000"}
+	for _, v := range versions {
+		snap := SchemaSnapshot{Version: v, Timestamp: time.Now().UTC()}
+		if err := StoreSnapshot(snap, dir); err != nil {
+			t.Fatalf("StoreSnapshot failed for %s: %v", v, err)
+		}
+	}
+
+	got, err := ListSnapshots(dir)
+	if err != nil {
+		t.Fatalf("ListSnapshots returned error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 snapshots, got %d", len(got))
+	}
+	sorted := sort.SliceIsSorted(got, func(i, j int) bool {
+		return got[i].Version < got[j].Version
+	})
+	if !sorted {
+		t.Errorf("expected sorted by version, got %v",
+			versionsOf(got))
+	}
+	want := []string{"20260101_000000", "20260102_000000", "20260103_000000"}
+	for i, v := range want {
+		if got[i].Version != v {
+			t.Errorf("index %d: got %q, want %q", i, got[i].Version, v)
+		}
+	}
+}
+
+func TestListSnapshotsIgnoresNonSnapshotFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create one real snapshot and two decoys.
+	snap := SchemaSnapshot{Version: "v1", Timestamp: time.Now().UTC()}
+	if err := StoreSnapshot(snap, dir); err != nil {
+		t.Fatalf("StoreSnapshot failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "readme.md"),
+		[]byte("nope"), 0o644); err != nil {
+		t.Fatalf("write decoy failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "data.json"),
+		[]byte("{}"), 0o644); err != nil {
+		t.Fatalf("write decoy failed: %v", err)
+	}
+
+	got, err := ListSnapshots(dir)
+	if err != nil {
+		t.Fatalf("ListSnapshots returned error: %v", err)
+	}
+	if len(got) != 1 || got[0].Version != "v1" {
+		t.Errorf("expected only the single snapshot v1, got %v",
+			versionsOf(got))
+	}
+}
+
+func TestListSnapshotsEmptyDir(t *testing.T) {
+	got, err := ListSnapshots(t.TempDir())
+	if err != nil {
+		t.Fatalf("ListSnapshots returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 snapshots, got %d", len(got))
+	}
+}
+
+func TestListSnapshotsMissingDir(t *testing.T) {
+	_, err := ListSnapshots(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err == nil {
+		t.Fatal("expected error for missing directory")
+	}
+	if !errors.Is(err, surqlerrors.ErrMigrationDiscovery) {
+		t.Errorf("expected ErrMigrationDiscovery, got %v", err)
+	}
+}
+
+func TestListSnapshotsEmptyDirPath(t *testing.T) {
+	_, err := ListSnapshots("")
+	if err == nil {
+		t.Fatal("expected error for empty dir")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestListSnapshotsPropagatesCorruption(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "bad"+snapshotFileSuffix),
+		[]byte("totally invalid"), 0o644); err != nil {
+		t.Fatalf("write corrupt snapshot: %v", err)
+	}
+	_, err := ListSnapshots(dir)
+	if err == nil {
+		t.Fatal("expected corruption to be surfaced")
+	}
+	if !errors.Is(err, surqlerrors.ErrSerialization) {
+		t.Errorf("expected ErrSerialization, got %v", err)
+	}
+}
+
+func TestCompareSnapshotsIdentity(t *testing.T) {
+	reg := populatedRegistry(t)
+	withSnapshotClock(t, fixedTime())
+	snap, err := CreateSnapshot(reg, "")
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+
+	diffs, err := CompareSnapshots(snap, snap)
+	if err != nil {
+		t.Fatalf("CompareSnapshots returned error: %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs for identical snapshots, got %v", diffs)
+	}
+}
+
+func TestCompareSnapshotsAddTable(t *testing.T) {
+	from := SchemaSnapshot{Version: "v0"}
+	to := SchemaSnapshot{
+		Version: "v1",
+		Tables:  []schema.TableDefinition{schema.NewTable("user")},
+	}
+
+	diffs, err := CompareSnapshots(from, to)
+	if err != nil {
+		t.Fatalf("CompareSnapshots returned error: %v", err)
+	}
+	if len(diffs) == 0 {
+		t.Fatal("expected at least one diff")
+	}
+	if diffs[0].Operation != DiffOperationAddTable ||
+		diffs[0].Table != "user" {
+		t.Errorf("first diff = %+v, want add_table on user", diffs[0])
+	}
+}
+
+func TestCompareSnapshotsDropTable(t *testing.T) {
+	from := SchemaSnapshot{
+		Version: "v0",
+		Tables:  []schema.TableDefinition{schema.NewTable("legacy")},
+	}
+	to := SchemaSnapshot{Version: "v1"}
+
+	diffs, err := CompareSnapshots(from, to)
+	if err != nil {
+		t.Fatalf("CompareSnapshots returned error: %v", err)
+	}
+	found := false
+	for _, d := range diffs {
+		if d.Operation == DiffOperationDropTable && d.Table == "legacy" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected drop_table diff for legacy, got %v", diffs)
+	}
+}
+
+func TestCompareSnapshotsEndToEnd(t *testing.T) {
+	// Round-trip via disk, then compare.
+	dir := t.TempDir()
+
+	reg1 := schema.NewSchemaRegistry()
+	_ = reg1.RegisterTable(schema.NewTable("user",
+		schema.WithFields(schema.StringField("email"))))
+	withSnapshotClock(t, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	snap1, err := CreateSnapshot(reg1, "v1")
+	if err != nil {
+		t.Fatalf("CreateSnapshot v1: %v", err)
+	}
+	if err := StoreSnapshot(snap1, dir); err != nil {
+		t.Fatalf("StoreSnapshot v1: %v", err)
+	}
+
+	reg2 := schema.NewSchemaRegistry()
+	_ = reg2.RegisterTable(schema.NewTable("user",
+		schema.WithFields(schema.StringField("email"), schema.StringField("name"))))
+	_ = reg2.RegisterTable(schema.NewTable("post"))
+	withSnapshotClock(t, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
+	snap2, err := CreateSnapshot(reg2, "v2")
+	if err != nil {
+		t.Fatalf("CreateSnapshot v2: %v", err)
+	}
+	if err := StoreSnapshot(snap2, dir); err != nil {
+		t.Fatalf("StoreSnapshot v2: %v", err)
+	}
+
+	snapshots, err := ListSnapshots(dir)
+	if err != nil {
+		t.Fatalf("ListSnapshots: %v", err)
+	}
+	if len(snapshots) != 2 {
+		t.Fatalf("expected 2 snapshots, got %d", len(snapshots))
+	}
+
+	diffs, err := CompareSnapshots(snapshots[0], snapshots[1])
+	if err != nil {
+		t.Fatalf("CompareSnapshots: %v", err)
+	}
+
+	ops := map[DiffOperation]int{}
+	for _, d := range diffs {
+		ops[d.Operation]++
+	}
+	if ops[DiffOperationAddTable] != 1 {
+		t.Errorf("expected 1 add_table (post), got %d", ops[DiffOperationAddTable])
+	}
+	if ops[DiffOperationAddField] != 1 {
+		t.Errorf("expected 1 add_field (user.name), got %d", ops[DiffOperationAddField])
+	}
+}
+
+// --- VersionGraph tests ---
+
+func TestVersionGraphAddRoot(t *testing.T) {
+	g := NewVersionGraph()
+	if err := g.Add(SchemaSnapshot{Version: "v1"}, ""); err != nil {
+		t.Fatalf("Add root: %v", err)
+	}
+	if g.Root() != "v1" {
+		t.Errorf("Root = %q, want v1", g.Root())
+	}
+	if g.Len() != 1 {
+		t.Errorf("Len = %d, want 1", g.Len())
+	}
+}
+
+func TestVersionGraphAddWithParent(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	if err := g.Add(SchemaSnapshot{Version: "v2"}, "v1"); err != nil {
+		t.Fatalf("Add child: %v", err)
+	}
+	node, ok := g.Get("v1")
+	if !ok {
+		t.Fatal("v1 missing")
+	}
+	if len(node.Children) != 1 || node.Children[0] != "v2" {
+		t.Errorf("v1 children = %v, want [v2]", node.Children)
+	}
+	child, ok := g.Get("v2")
+	if !ok || child.Parent != "v1" {
+		t.Errorf("v2 parent = %q, want v1", child.Parent)
+	}
+}
+
+func TestVersionGraphAddDuplicateVersion(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	err := g.Add(SchemaSnapshot{Version: "v1"}, "")
+	if err == nil {
+		t.Fatal("expected duplicate error")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestVersionGraphAddUnknownParent(t *testing.T) {
+	g := NewVersionGraph()
+	err := g.Add(SchemaSnapshot{Version: "v2"}, "nonexistent")
+	if err == nil {
+		t.Fatal("expected unknown-parent error")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestVersionGraphAddEmptyVersion(t *testing.T) {
+	g := NewVersionGraph()
+	err := g.Add(SchemaSnapshot{}, "")
+	if err == nil {
+		t.Fatal("expected empty-version error")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestVersionGraphLookup(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+
+	if !g.Has("v1") {
+		t.Error("Has(v1) = false")
+	}
+	if g.Has("missing") {
+		t.Error("Has(missing) = true")
+	}
+	if _, ok := g.Get("missing"); ok {
+		t.Error("Get(missing) returned ok")
+	}
+}
+
+func TestVersionGraphVersionsSorted(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v3"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "v3")
+	_ = g.Add(SchemaSnapshot{Version: "v2"}, "v3")
+
+	got := g.Versions()
+	want := []string{"v1", "v2", "v3"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("Versions = %v, want %v", got, want)
+	}
+}
+
+func TestVersionGraphPathLinear(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v2"}, "v1")
+	_ = g.Add(SchemaSnapshot{Version: "v3"}, "v2")
+
+	path := g.Path("v1", "v3")
+	want := []string{"v1", "v2", "v3"}
+	if strings.Join(path, ",") != strings.Join(want, ",") {
+		t.Errorf("Path(v1, v3) = %v, want %v", path, want)
+	}
+}
+
+func TestVersionGraphPathReverse(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v2"}, "v1")
+
+	path := g.Path("v2", "v1")
+	want := []string{"v2", "v1"}
+	if strings.Join(path, ",") != strings.Join(want, ",") {
+		t.Errorf("Path(v2, v1) = %v, want %v", path, want)
+	}
+}
+
+func TestVersionGraphPathSameNode(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+
+	path := g.Path("v1", "v1")
+	if len(path) != 1 || path[0] != "v1" {
+		t.Errorf("Path(v1, v1) = %v, want [v1]", path)
+	}
+}
+
+func TestVersionGraphPathUnknown(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	if path := g.Path("v1", "unknown"); path != nil {
+		t.Errorf("expected nil path for unknown endpoint, got %v", path)
+	}
+}
+
+func TestVersionGraphAncestors(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v2"}, "v1")
+	_ = g.Add(SchemaSnapshot{Version: "v3"}, "v2")
+
+	got := g.Ancestors("v3")
+	want := []string{"v1", "v2"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("Ancestors(v3) = %v, want %v", got, want)
+	}
+}
+
+func TestVersionGraphAncestorsRootHasNone(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	if got := g.Ancestors("v1"); len(got) != 0 {
+		t.Errorf("Ancestors(root) = %v, want empty", got)
+	}
+}
+
+func TestVersionGraphAncestorsUnknown(t *testing.T) {
+	g := NewVersionGraph()
+	if got := g.Ancestors("nope"); got != nil {
+		t.Errorf("Ancestors(unknown) = %v, want nil", got)
+	}
+}
+
+func TestVersionGraphDescendants(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v2a"}, "v1")
+	_ = g.Add(SchemaSnapshot{Version: "v2b"}, "v1")
+	_ = g.Add(SchemaSnapshot{Version: "v3"}, "v2a")
+
+	got := g.Descendants("v1")
+	sort.Strings(got)
+	want := []string{"v2a", "v2b", "v3"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("Descendants(v1) = %v, want %v", got, want)
+	}
+}
+
+func TestVersionGraphDescendantsLeaf(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	if got := g.Descendants("v1"); len(got) != 0 {
+		t.Errorf("Descendants(leaf) = %v, want empty", got)
+	}
+}
+
+func TestVersionGraphDescendantsUnknown(t *testing.T) {
+	g := NewVersionGraph()
+	if got := g.Descendants("nope"); got != nil {
+		t.Errorf("Descendants(unknown) = %v, want nil", got)
+	}
+}
+
+func TestVersionGraphRemoveLeaf(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v2"}, "v1")
+
+	if err := g.Remove("v2"); err != nil {
+		t.Fatalf("Remove leaf: %v", err)
+	}
+	if g.Has("v2") {
+		t.Error("v2 should be removed")
+	}
+	parent, _ := g.Get("v1")
+	if len(parent.Children) != 0 {
+		t.Errorf("v1 Children = %v, want []", parent.Children)
+	}
+}
+
+func TestVersionGraphRemoveMiddleRewiresChildren(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v2"}, "v1")
+	_ = g.Add(SchemaSnapshot{Version: "v3"}, "v2")
+
+	if err := g.Remove("v2"); err != nil {
+		t.Fatalf("Remove middle: %v", err)
+	}
+	child, _ := g.Get("v3")
+	if child.Parent != "v1" {
+		t.Errorf("v3 parent after remove = %q, want v1", child.Parent)
+	}
+	parent, _ := g.Get("v1")
+	if len(parent.Children) != 1 || parent.Children[0] != "v3" {
+		t.Errorf("v1 Children = %v, want [v3]", parent.Children)
+	}
+}
+
+func TestVersionGraphRemoveRootPromotesChild(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v2"}, "v1")
+
+	if err := g.Remove("v1"); err != nil {
+		t.Fatalf("Remove root: %v", err)
+	}
+	child, _ := g.Get("v2")
+	if child.Parent != "" {
+		t.Errorf("v2 parent after root removal = %q, want empty", child.Parent)
+	}
+	if g.Root() != "v2" {
+		t.Errorf("Root after removal = %q, want v2", g.Root())
+	}
+}
+
+func TestVersionGraphRemoveUnknown(t *testing.T) {
+	g := NewVersionGraph()
+	err := g.Remove("nope")
+	if err == nil {
+		t.Fatal("expected error for unknown version")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestVersionGraphRootEmpty(t *testing.T) {
+	g := NewVersionGraph()
+	if g.Root() != "" {
+		t.Errorf("empty graph Root = %q, want empty", g.Root())
+	}
+	if g.Len() != 0 {
+		t.Errorf("empty Len = %d, want 0", g.Len())
+	}
+}
+
+func TestVersionGraphGetReturnsCopy(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v2"}, "v1")
+
+	node, _ := g.Get("v1")
+	node.Children[0] = "mutated"
+
+	original, _ := g.Get("v1")
+	if original.Children[0] != "v2" {
+		t.Errorf("graph was mutated via returned node: Children[0] = %q",
+			original.Children[0])
+	}
+}
+
+// versionsOf is a small debug helper pulling the version strings from a list
+// of snapshots.
+func versionsOf(snaps []SchemaSnapshot) []string {
+	out := make([]string, 0, len(snaps))
+	for _, s := range snaps {
+		out = append(out, s.Version)
+	}
+	return out
+}


### PR DESCRIPTION
Closes #27.

## Summary
Port surql-py/src/surql/migration/versioning.py.

- **\`migration/versioning.go\`**: \`CreateSnapshot\` / \`StoreSnapshot\` / \`LoadSnapshot\` / \`ListSnapshots\` / \`CompareSnapshots\` + \`VersionGraph\` (thread-safe DAG): \`NewVersionGraph\`, \`Add\`, \`Remove\` (rewires children), \`Get\` / \`Has\` / \`Root\` / \`Len\` / \`Versions\`, \`Path\` (BFS parent+children), \`Ancestors\`, \`Descendants\`.
- Extended existing \`SchemaSnapshot\` with \`Version\`, \`Timestamp\`, \`Description\`, \`Accesses\` — \`omitempty\` so existing \`DiffSchemas\` callers stay intact.
- JSON-file-based storage (Python's async DB-backed store adapts to stdlib).
- Deterministic clock via \`snapshotClock\` var (test-overridable).

## Test plan
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./... -race\` — **47 new tests green**
- [ ] CI green