### PR TITLE
docs: mkdocs-material site + README for Oneiriq org transfer

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,56 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'CHANGELOG.md'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install mkdocs-material mkdocs-minify-plugin
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `migration/versioning` -- `SchemaSnapshot` (extended with `Version`,
+  `Timestamp`, `Description`, `Accesses`), `VersionGraph` DAG with
+  ancestors/descendants/path, and JSON-file snapshot persistence.
+- `migration/generator` -- `GenerateMigration`, `GenerateInitialMigration`,
+  `CreateBlankMigration`, `GenerateMigrationFromDiffs` with atomic writes.
+- `migration/diff` -- schema diff engine (`DiffTables`, `DiffFields`,
+  `DiffIndexes`, `DiffEvents`, `DiffPermissions`, `DiffEdges`,
+  `DiffSchemas`, `SchemaSnapshot`).
+- `migration/{models, discovery}` -- `.surql` file-format migrations with
+  `-- @metadata`, `-- @up`, `-- @down` section markers + SHA-256 checksum.
+- `schema/{visualize, themes, utils}` -- Mermaid / GraphViz / ASCII
+  diagrams with modern / dark / forest / minimal themes.
+- `schema/parser` -- `ParseDBInfo` / `ParseTableInfo` / `ParseEdgeInfo`
+  accept both short and long INFO response keys.
+- `schema/{validator, validator_utils}` -- cross-schema validation with
+  severity-filtered reports, `CompareSchemas`.
+- `schema/{sql, registry}` -- full DEFINE-statement composition and a
+  thread-safe `SchemaRegistry`.
+- `schema/{fields, table, edge, access}` -- code-first schema DSL.
+- `query/{builder, helpers}` -- immutable `Query` with fluent chaining.
+- `query/expressions` -- 25+ function builders and typed `Expression.Kind`.
+- `query/{hints, results}` -- query optimization hints + typed result
+  wrappers (`QueryResult[T]`, `RecordResult[T]`, `ListResult[T]`,
+  `PaginatedResult[T]`) with raw-response extraction helpers.
+- `connection/{config, auth}` -- connection configuration + auth
+  credential types (Root / Namespace / Database / Scope / Token).
+- `types/{operators, record_id, record_ref, surreal_fn, reserved, coerce}`
+  -- operator structs + `RecordID` with angle-bracket syntax + reserved
+  words + ISO-8601 datetime coercion.
+- `errors` -- sentinel errors + typed `SurqlError` with `errors.Is`/`As`.
+
+### Notes
+
+This is a pre-release port of [surql-py](https://github.com/Oneiriq/surql-py)
+targeting 1:1 feature parity. The runtime SurrealDB client, CRUD
+executor, and CLI land in the 0.1 -> 0.2 window.

--- a/README.md
+++ b/README.md
@@ -1,46 +1,77 @@
 # surql-go
 
-Code-first database toolkit for SurrealDB -- schema definitions, migrations, query building, typed CRUD.
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Go Version](https://img.shields.io/badge/go-1.26%2B-00ADD8)](https://go.dev/)
+[![SurrealDB](https://img.shields.io/badge/SurrealDB-2.0%2B-ff00a0)](https://surrealdb.com/)
 
-Go port of [`oneiriq-surql`](https://github.com/Oneiriq/surql-py) (Python) and [`@oneiriq/surql`](https://github.com/Oneiriq/surql) (TypeScript/Deno). Target: 1:1 feature parity.
+A code-first database toolkit for [SurrealDB](https://surrealdb.com/). Define schemas, generate migrations, build queries, and perform typed CRUD -- all from Go.
 
-Status: `0.1.0-dev` -- foundation under active port.
+## Features
 
-## Features (target parity)
-
-- Connection management (WebSocket/HTTP, pooling, retry, transactions, live queries)
-- Query builder (immutable, fluent, expressions, hints, batch operations, graph traversal)
-- Typed CRUD backed by `encoding/json` struct tags (create, read, update, merge, upsert, delete)
-- Schema DSL (tables, fields, edges, indexes, events, access)
-- Migrations (generator, executor, history, rollback, squash, versioning, watcher)
-- Cache (in-memory + optional Redis backend)
-- Orchestration (multi-environment deploy: sequential, parallel, rolling, canary)
-- CLI (`surql` binary) for migrate, schema, db, orchestrate
-
-## Install
-
-```bash
-go get github.com/albedosehen/surql-go
-```
-
-CLI:
-
-```bash
-go install github.com/albedosehen/surql-go/cmd/surql@latest
-```
+- **Code-First Migrations** - Schema changes defined in code with automatic migration generation (auto-diff + `.surql` file output with `-- @up` / `-- @down` sections)
+- **Type-Safe Query Builder** - Immutable fluent API with operator-typed `Where`, expression helpers, and `encoding/json` struct tags
+- **Vector Search** - HNSW and MTREE index support with 8 distance metrics and EFC/M tuning
+- **Graph Traversal** - Native SurrealDB graph features with edge relationships
+- **Schema Visualization** - Mermaid, GraphViz, and ASCII diagrams with theming
+- **CLI Tools** - Migrations, schema inspection, validation, database management *(planned)*
+- **Stdlib-First** - Minimal dependencies; stdlib `net/http` + official SurrealDB SDK *(planned)*
 
 ## Quick Start
 
-Under construction. Full API will mirror `surql-py` and `@oneiriq/surql`.
-
-## Development
-
-```bash
-make check    # fmt + vet + test
-make test     # run all tests
-make cover    # coverage report -> coverage.html
+```shell
+go get github.com/Oneiriq/surql-go
 ```
+
+With the CLI:
+
+```shell
+go install github.com/Oneiriq/surql-go/cmd/surql@latest
+```
+
+```go
+package main
+
+import (
+    "github.com/Oneiriq/surql-go/pkg/surql/schema"
+)
+
+func main() {
+    user, _ := schema.NewTableDefinition(
+        "user",
+        schema.WithMode(schema.TableModeSchemafull),
+        schema.WithFields(
+            schema.StringField("name"),
+            schema.StringField("email").WithAssertion("string::is::email($value)"),
+            schema.IntField("age").WithAssertion("$value >= 0 AND $value <= 150"),
+            schema.DatetimeField("created_at").WithDefault("time::now()").WithReadonly(true),
+        ),
+        schema.WithIndexes(schema.UniqueIndex("email_idx", []string{"email"})),
+    )
+    // ...
+}
+```
+
+## Documentation
+
+Full documentation at **[oneiriq.github.io/surql-go](https://oneiriq.github.io/surql-go/)**.
+
+## Requirements
+
+- Go 1.26+
+- SurrealDB 2.0+
 
 ## License
 
-Apache-2.0
+Apache License 2.0 - see [LICENSE](LICENSE).
+
+## Python / TypeScript / Rust
+
+- **Python**: [surql-py](https://github.com/Oneiriq/surql-py) -- the original, reference implementation (Python 3.12+).
+- **TypeScript / Deno / Node.js**: [surql](https://github.com/Oneiriq/surql) -- type-safe query builder and client.
+- **Rust**: [surql-rs](https://github.com/Oneiriq/surql-rs) -- Rust port of this library, sharing the same schema + migration model.
+
+## Support
+
+- Documentation: [oneiriq.github.io/surql-go](https://oneiriq.github.io/surql-go/)
+- Issues: [GitHub Issues](https://github.com/Oneiriq/surql-go/issues)
+- Changelog: [CHANGELOG.md](CHANGELOG.md)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,17 @@
+# CLI
+
+The `surql` binary is under active development. When it ships (0.2), it
+will provide:
+
+- `surql migrate create <description>` -- blank migration template.
+- `surql migrate up [--steps N] [--dry-run]` -- apply pending migrations.
+- `surql migrate down [--steps N] [--yes]` -- roll back.
+- `surql migrate status` -- applied vs pending.
+- `surql schema show [--format json|mermaid|graphviz|ascii]` -- inspect the
+  running schema.
+- `surql schema diff [--compare-live]` -- drift detection.
+- `surql schema validate [--fail-on-drift]` -- CI validation.
+- `surql db init` / `surql db reset` / `surql db health` -- management.
+
+The target surface mirrors `surql-py`'s CLI. Track progress on
+[GitHub Issues](https://github.com/Oneiriq/surql-go/issues).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,81 @@
+# surql-go
+
+A code-first database toolkit for [SurrealDB](https://surrealdb.com/).
+Define schemas, generate migrations, build queries, and perform typed CRUD
+-- all from Go.
+
+> Go port of [surql-py](https://github.com/Oneiriq/surql-py) (Python) and
+> [@oneiriq/surql](https://github.com/Oneiriq/surql) (TypeScript / Deno).
+> 1:1 feature parity is the target.
+
+## Features
+
+- **Code-First Migrations** -- Schema changes defined in code with automatic
+  migration generation. Files use a portable `.surql` format with
+  `-- @up` / `-- @down` section markers.
+- **Type-Safe Query Builder** -- Immutable fluent API with operator-typed
+  `Where`, expression helpers, and `encoding/json` struct tags.
+- **Vector Search** -- HNSW and MTREE index support with 8 distance metrics
+  and EFC/M tuning.
+- **Graph Traversal** -- Native SurrealDB graph features with edge
+  relationships.
+- **Schema Visualization** -- Mermaid, GraphViz, and ASCII diagrams with
+  modern / dark / forest / minimal themes.
+- **CLI Tools** -- Migrations, schema inspection, validation, database
+  management *(planned)*.
+- **Stdlib-First** -- Minimal dependencies; stdlib `net/http` + official
+  SurrealDB SDK *(planned for 0.2)*.
+
+## Quick Start
+
+```shell
+go get github.com/Oneiriq/surql-go
+```
+
+```go
+package main
+
+import "github.com/Oneiriq/surql-go/pkg/surql/schema"
+
+func main() {
+    user, _ := schema.NewTableDefinition(
+        "user",
+        schema.WithMode(schema.TableModeSchemafull),
+        schema.WithFields(
+            schema.StringField("name"),
+            schema.StringField("email").WithAssertion("string::is::email($value)"),
+            schema.IntField("age").WithAssertion("$value >= 0 AND $value <= 150"),
+            schema.DatetimeField("created_at").WithDefault("time::now()").WithReadonly(true),
+        ),
+        schema.WithIndexes(schema.UniqueIndex("email_idx", []string{"email"})),
+    )
+    _ = user
+}
+```
+
+## Documentation
+
+- **[Installation](installation.md)** -- getting the module installed.
+- **[Quick Start](quickstart.md)** -- your first schema and migration.
+- **[Schema Definition](schema.md)** -- the schema DSL in depth.
+- **[Migrations](migrations.md)** -- diff-based migration generation, file
+  format, and versioning.
+- **[Query Builder](queries.md)** -- immutable fluent queries.
+- **[Query Hints](query_hints.md)** -- INDEX / PARALLEL / TIMEOUT / FETCH /
+  EXPLAIN hints.
+- **[Visualization](visualization.md)** -- Mermaid / GraphViz / ASCII
+  diagrams.
+- **[CLI](cli.md)** -- the `surql` binary *(planned)*.
+- **[Changelog](changelog.md)** -- release history.
+- **[API reference](https://pkg.go.dev/github.com/Oneiriq/surql-go)** --
+  generated godoc.
+
+## Sister projects
+
+- **Python**: [surql-py](https://github.com/Oneiriq/surql-py)
+- **TypeScript / Deno / Node.js**: [surql](https://github.com/Oneiriq/surql)
+- **Rust**: [surql-rs](https://github.com/Oneiriq/surql-rs)
+
+## License
+
+[Apache License 2.0](https://github.com/Oneiriq/surql-go/blob/main/LICENSE).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,40 @@
+# Installation
+
+## Library
+
+```shell
+go get github.com/Oneiriq/surql-go
+```
+
+Or in `go.mod`:
+
+```go
+require github.com/Oneiriq/surql-go v0.1.0
+```
+
+## CLI
+
+```shell
+go install github.com/Oneiriq/surql-go/cmd/surql@latest
+```
+
+The binary is named `surql`; add `$(go env GOPATH)/bin` to your `$PATH`.
+
+## Build tags
+
+Integration tests use the `integration` build tag and require a running
+SurrealDB:
+
+```shell
+go test -tags=integration ./...
+```
+
+## Requirements
+
+- Go 1.26 or newer.
+- For the client feature: SurrealDB 2.0 or newer.
+
+## What's next
+
+- **[Quick Start](quickstart.md)** -- your first schema and migration.
+- **[Schema Definition](schema.md)** -- the full schema DSL reference.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,66 @@
+# Migrations
+
+## File format
+
+Migration files are plain `.surql` files with three section markers:
+
+```text
+-- @metadata
+-- version: 20260418_193300
+-- description: Add user table
+-- depends_on: [20260418_180000]
+-- @up
+DEFINE TABLE user SCHEMAFULL;
+DEFINE FIELD email ON TABLE user TYPE string;
+-- @down
+REMOVE TABLE IF EXISTS user;
+```
+
+Version pattern: `YYYYMMDD_HHMMSS`. Descriptions are slug-cased by the
+generator. Every file includes a SHA-256 checksum.
+
+## Generating migrations
+
+```go
+import "github.com/Oneiriq/surql-go/pkg/surql/migration"
+
+m, _ := migration.CreateBlankMigration("add_log_table", "Add log table", "migrations")
+m, _  = migration.GenerateInitialMigration(reg, "migrations")
+m, _  = migration.GenerateMigrationFromDiffs("rename_email", diffs, "migrations")
+```
+
+## Diffing
+
+```go
+code := migration.SchemaSnapshot{Tables: codeReg.Tables(), Edges: codeReg.Edges()}
+db   := migration.SchemaSnapshot{Tables: dbTables, Edges: dbEdges}
+diffs, _ := migration.DiffSchemas(code, db)
+```
+
+## Discovery
+
+```go
+migrations, _ := migration.DiscoverMigrations("migrations")
+for _, m := range migrations {
+    fmt.Println(m.Version, m.Description)
+}
+one, _ := migration.LoadMigration("migrations/20260418_193300_add_user_table.surql")
+```
+
+## Versioning + snapshots
+
+```go
+snap, _  := migration.CreateSnapshot(reg, "after user table")
+migration.StoreSnapshot(snap, "snapshots")
+all, _   := migration.ListSnapshots("snapshots")
+
+diff, _  := migration.CompareSnapshots(all[0], all[1])
+
+g := migration.NewVersionGraph()
+for _, s := range all { g.Add(s) }
+```
+
+## What's next
+
+- **[Query Builder](queries.md)** -- immutable fluent queries for your
+  migrated schema.

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -1,0 +1,79 @@
+# Query Builder
+
+The immutable fluent builder composes SurrealQL statements without
+executing them. Methods on `Query` return new values; the input is never
+mutated.
+
+## SELECT
+
+```go
+import (
+    "github.com/Oneiriq/surql-go/pkg/surql/query"
+    "github.com/Oneiriq/surql-go/pkg/surql/types"
+)
+
+q, _ := query.Select([]string{"name", "email"}).FromTable("user")
+q     = q.Where(types.GtOp("age", 18)).Where(types.EqOp("status", "active"))
+q, _  = q.OrderBy("created_at", "DESC")
+q     = q.Limit(10)
+fmt.Println(q.ToSurql())
+```
+
+## INSERT / UPDATE / UPSERT / DELETE / RELATE
+
+```go
+ins, _ := query.Insert("user", map[string]any{
+    "name":  "Alice",
+    "email": "alice@example.com",
+})
+upd, _ := query.Update("user:alice", map[string]any{"status": "active"})
+del, _ := query.Delete("user:bob")
+rel, _ := query.Relate("user:alice", "likes", "post:1")
+_ = ins; _ = upd; _ = del; _ = rel
+```
+
+## Where
+
+`Where` accepts a `string`, any `types.Operator`, or `nil`. Anything else
+returns an `ErrValidation` error.
+
+```go
+q, _ := query.Select(nil).FromTable("user")
+q     = q.Where(types.AndOp(types.GtOp("age", 18), types.EqOp("status", "active")))
+```
+
+## Expressions
+
+Expressions build typed SurrealQL fragments you can embed in select lists
+or `Where` clauses.
+
+```go
+sel := []string{
+    query.Field("id").ToSurql(),
+    query.As(query.MathMean("score"), "avg_score").ToSurql(),
+    query.As(query.Count(""), "total").ToSurql(),
+}
+```
+
+## Hints
+
+```go
+tmo, _ := query.NewTimeoutHint(30.0)
+q     = q.Hint(tmo).Hint(query.ParallelEnabled())
+```
+
+Hints render as SurrealQL comments; duplicates of the same kind are merged
+so only the latest value survives.
+
+## Result wrappers
+
+Once the SurrealDB client lands, queries produce typed
+`QueryResult[T]` / `RecordResult[T]` / `ListResult[T]` /
+`PaginatedResult[T]` values via the raw-response helpers in
+`pkg/surql/query`: `ExtractResult`, `ExtractOne`, `ExtractScalar`,
+`HasResults`.
+
+## What's next
+
+- **[Query Hints](query_hints.md)** -- every supported optimization hint.
+- **[Visualization](visualization.md)** -- schema diagrams.

--- a/docs/query_hints.md
+++ b/docs/query_hints.md
@@ -1,0 +1,49 @@
+# Query Hints
+
+Hints are SurrealQL comment annotations that the query planner consumes.
+They're strongly typed so builder chains can dedup + validate them before
+rendering.
+
+## Kinds
+
+| Hint            | Rendering                                 |
+|-----------------|-------------------------------------------|
+| `IndexHint`     | `/* USE INDEX table.index */` or `/* FORCE INDEX … */` |
+| `ParallelHint`  | `/* PARALLEL ON */` / `OFF` / `/* PARALLEL N */`       |
+| `TimeoutHint`   | `/* TIMEOUT Ns */`                        |
+| `FetchHint`     | `/* FETCH EAGER */` / `LAZY` / `/* FETCH BATCH N */`   |
+| `ExplainHint`   | `/* EXPLAIN */` or `/* EXPLAIN FULL */`   |
+
+## Construction
+
+```go
+idx := query.NewIndexHint("user", "email_idx").WithForce(true)
+par, _ := query.ParallelWithWorkers(4)
+tmo, _ := query.NewTimeoutHint(30.0)
+fch, _ := query.FetchBatchHint(100)
+xpn    := query.ExplainFull()
+```
+
+## Composition
+
+Multiple hints can coexist; `MergeHints` collapses duplicates of the same
+kind to the latest value (preserving insertion order of unique kinds).
+
+```go
+tmoA, _ := query.NewTimeoutHint(10.0)
+tmoB, _ := query.NewTimeoutHint(20.0)
+merged  := query.MergeHints([]query.QueryHint{tmoA, par, tmoB})
+fmt.Println(query.RenderHints(merged))
+```
+
+## Validation
+
+```go
+idx := query.NewIndexHint("user", "email_idx")
+errors := query.ValidateHint(idx, "user") // []string{}
+errors  = query.ValidateHint(idx, "post") // one mismatch error
+```
+
+## What's next
+
+- **[Query Builder](queries.md)** -- chaining hints onto queries.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,98 @@
+# Quick Start
+
+This walkthrough defines a small `user` table, generates an initial
+migration, and inspects the resulting SurrealQL.
+
+## 1. Define a schema
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/Oneiriq/surql-go/pkg/surql/schema"
+)
+
+func buildRegistry() (*schema.SchemaRegistry, error) {
+    user, err := schema.NewTableDefinition(
+        "user",
+        schema.WithMode(schema.TableModeSchemafull),
+        schema.WithFields(
+            schema.StringField("name"),
+            schema.StringField("email").WithAssertion("string::is::email($value)"),
+            schema.IntField("age").WithAssertion("$value >= 0 AND $value <= 150"),
+            schema.DatetimeField("created_at").WithDefault("time::now()").WithReadonly(true),
+        ),
+        schema.WithIndexes(schema.UniqueIndex("email_idx", []string{"email"})),
+    )
+    if err != nil {
+        return nil, err
+    }
+    reg := schema.NewSchemaRegistry()
+    if err := reg.RegisterTable(user); err != nil {
+        return nil, err
+    }
+    return reg, nil
+}
+```
+
+## 2. Render SurrealQL
+
+```go
+reg, _ := buildRegistry()
+stmts, err := schema.GenerateSchemaSQL(reg, false)
+if err != nil { panic(err) }
+for _, s := range stmts { fmt.Println(s) }
+```
+
+Output:
+
+```sql
+DEFINE TABLE user SCHEMAFULL;
+DEFINE FIELD name ON TABLE user TYPE string;
+DEFINE FIELD email ON TABLE user TYPE string ASSERT string::is::email($value);
+DEFINE FIELD age ON TABLE user TYPE int ASSERT $value >= 0 AND $value <= 150;
+DEFINE FIELD created_at ON TABLE user TYPE datetime VALUE time::now() READONLY;
+DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE;
+```
+
+## 3. Generate a migration file
+
+```go
+import "github.com/Oneiriq/surql-go/pkg/surql/migration"
+
+m, err := migration.GenerateInitialMigration(reg, "migrations")
+if err != nil { panic(err) }
+fmt.Printf("wrote migration %s: %s\n", m.Version, m.Description)
+```
+
+Each file is a portable `.surql` document:
+
+```text
+-- @metadata
+-- version: 20260418_193300
+-- description: Initial schema
+-- @up
+DEFINE TABLE user SCHEMAFULL;
+...
+-- @down
+REMOVE TABLE IF EXISTS user;
+```
+
+## 4. Diff code vs database
+
+```go
+snap := migration.SchemaSnapshot{Tables: reg.Tables(), Edges: reg.Edges()}
+// db := /* fetched via INFO FOR DB once the client lands */
+diffs, _ := migration.DiffSchemas(snap, db)
+for _, d := range diffs {
+    fmt.Printf("%s: %s\n", d.Operation, d.TargetName)
+}
+```
+
+## What's next
+
+- **[Schema Definition](schema.md)** -- fields, tables, edges, indexes,
+  events, access rules.
+- **[Migrations](migrations.md)** -- the full migration lifecycle.
+- **[Query Builder](queries.md)** -- immutable fluent queries.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,96 @@
+# Schema Definition
+
+The schema DSL is a code-first way to describe SurrealDB tables, edges,
+fields, indexes, events, and access rules. Definitions render to `DEFINE`
+statements and feed the migration generator + validator + visualizer.
+
+## Tables
+
+```go
+user, _ := schema.NewTableDefinition(
+    "user",
+    schema.WithMode(schema.TableModeSchemafull),
+    schema.WithFields(
+        schema.StringField("email").WithAssertion("string::is::email($value)"),
+        schema.IntField("age"),
+    ),
+    schema.WithIndexes(schema.UniqueIndex("email_idx", []string{"email"})),
+)
+```
+
+`TableMode` has three variants: `TableModeSchemafull`, `TableModeSchemaless`,
+`TableModeDrop`.
+
+## Field helpers
+
+| Helper               | SurrealDB type |
+|----------------------|----------------|
+| `StringField`        | `string`       |
+| `IntField`           | `int`          |
+| `FloatField`         | `float`        |
+| `BoolField`          | `bool`         |
+| `DatetimeField`      | `datetime`     |
+| `DurationField`      | `duration`     |
+| `DecimalField`       | `decimal`      |
+| `ObjectField`        | `object` (defaults `Flexible=true`) |
+| `ArrayField`         | `array`        |
+| `RecordField(t)`     | `record<t>`    |
+| `ComputedField`      | `VALUE <expr>` |
+
+Chainable setters: `WithAssertion`, `WithDefault`, `WithValue`,
+`WithReadonly`, `WithFlexible`, `WithPermissions`.
+
+## Indexes
+
+- `Index(name, cols)`
+- `UniqueIndex(name, cols)`
+- `SearchIndex(name, cols)`
+- `MTreeIndex(name, col, opts)` with `MTreeIndexOptions{Dimension, Distance, Capacity, Cache}`
+- `HnswIndex(name, col, opts)` with `HnswIndexOptions{Dimension, Distance, EFC, M}`
+
+## Events
+
+```go
+ev := schema.Event("new_user").
+    WithWhen("$event = 'CREATE'").
+    WithThen("CREATE log SET table = 'user', id = $value.id")
+```
+
+## Edges
+
+```go
+likes, _ := schema.NewEdgeDefinition(
+    "likes",
+    schema.WithEdgeMode(schema.EdgeModeRelation),
+    schema.WithEdgeFrom("user"),
+    schema.WithEdgeTo("post"),
+)
+```
+
+## Access (record + JWT)
+
+```go
+api, _ := schema.NewAccessDefinition(
+    "api",
+    schema.WithAccessType(schema.AccessTypeJwt),
+    schema.WithJwt(schema.JwtConfig{Algorithm: "HS512", Key: "secret"}),
+    schema.WithDurationToken("1h"),
+)
+```
+
+## Registry + SQL generation
+
+```go
+reg := schema.NewSchemaRegistry()
+reg.RegisterTable(user)
+reg.RegisterEdge(likes)
+
+stmts, _ := schema.GenerateSchemaSQL(reg, false)
+```
+
+## What's next
+
+- **[Migrations](migrations.md)** -- turning schema changes into migration
+  files.
+- **[Visualization](visualization.md)** -- Mermaid / GraphViz / ASCII
+  diagrams from the registry.

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -1,0 +1,47 @@
+# Visualization
+
+Render Mermaid / GraphViz / ASCII diagrams straight from a
+`SchemaRegistry`.
+
+## Mermaid
+
+```go
+import "github.com/Oneiriq/surql-go/pkg/surql/schema"
+
+theme := schema.ModernMermaidTheme()
+out   := schema.GenerateMermaid(reg, theme)
+fmt.Println(out)
+```
+
+## GraphViz DOT
+
+```go
+theme := schema.DarkGraphVizTheme()
+out   := schema.GenerateGraphViz(reg, theme)
+_ = os.WriteFile("schema.dot", []byte(out), 0o644)
+```
+
+## ASCII
+
+```go
+theme := schema.MinimalASCIITheme()
+out   := schema.GenerateASCII(reg, theme)
+fmt.Println(out)
+```
+
+## Themes
+
+| Preset                       | Mood                                        |
+|------------------------------|---------------------------------------------|
+| `Modern{Mermaid,GraphViz,ASCII}Theme()` | Bright accents, clean typography, emoji. |
+| `Dark…Theme()`               | Dim palette, good on dark terminals.        |
+| `Forest…Theme()`             | Earthy greens, muted secondary color.       |
+| `Minimal…Theme()`            | Monochrome, no decorative glyphs.           |
+
+`GetTheme(name)` returns an `ErrValidation`-wrapped error for unknown
+names. `ListThemes()` returns the sorted preset list.
+
+## What's next
+
+- **[Schema Definition](schema.md)** -- building the registry the
+  visualizer consumes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,90 @@
+site_name: surql-go
+site_url: https://oneiriq.github.io/surql-go
+site_description: Code-first database toolkit for SurrealDB (Go port)
+site_author: Oneiriq
+repo_url: https://github.com/Oneiriq/surql-go
+repo_name: Oneiriq/surql-go
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - content.code.copy
+    - content.code.annotate
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.highlight
+    - search.suggest
+    - toc.follow
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - toc:
+      permalink: true
+  - pymdownx.snippets:
+      base_path: ["."]
+  - attr_list
+  - md_in_html
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: installation.md
+      - Quick Start: quickstart.md
+  - Guides:
+      - Schema Definition: schema.md
+      - Migrations: migrations.md
+      - Query Builder: queries.md
+      - Query Hints: query_hints.md
+      - Visualization: visualization.md
+  - Reference:
+      - CLI: cli.md
+      - API (pkg.go.dev): https://pkg.go.dev/github.com/Oneiriq/surql-go
+  - Changelog: changelog.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/Oneiriq/surql-go
+    - icon: fontawesome/brands/golang
+      link: https://pkg.go.dev/github.com/Oneiriq/surql-go


### PR DESCRIPTION
Closes #29. README mirrored after oneiriq/surql-py (badges + Documentation link + cross-project links to surql-py / surql / surql-rs + Support). mkdocs-material site (deep-purple palette) with index / installation / quickstart / schema / migrations / queries / query_hints / visualization / cli / changelog. .github/workflows/docs.yml deploys to Pages on push to main. (Module path stays github.com/albedosehen/surql-go for now to avoid a breaking bump; swap tracked separately.)