### PR TITLE
release: 0.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+  push:
+    branches:
+      - main
+      - 'release/**'
+
+jobs:
+  quality:
+    name: Lint and Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache-dependency-path: go.sum
+
+      - name: Format check
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "These files need gofmt:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./... -race -v
+
+  integration:
+    name: Integration
+    runs-on: ubuntu-latest
+    services:
+      surrealdb:
+        image: surrealdb/surrealdb:latest
+        ports:
+          - 8000:8000
+        options: >-
+          --health-cmd "curl -f http://localhost:8000/health || exit 1"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+        env:
+          SURREAL_USER: root
+          SURREAL_PASS: root
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache-dependency-path: go.sum
+
+      - name: Integration tests
+        run: go test -tags=integration ./... -race -v
+        env:
+          SURREAL_URL: ws://localhost:8000
+          SURREAL_USER: root
+          SURREAL_PASS: root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,21 +44,24 @@ jobs:
   integration:
     name: Integration
     runs-on: ubuntu-latest
-    services:
-      surrealdb:
-        image: surrealdb/surrealdb:latest
-        ports:
-          - 8000:8000
-        options: >-
-          --health-cmd "curl -f http://localhost:8000/health || exit 1"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
-        env:
-          SURREAL_USER: root
-          SURREAL_PASS: root
     steps:
       - uses: actions/checkout@v4
+
+      - name: Start SurrealDB
+        run: |
+          docker run -d \
+            --name surrealdb \
+            -p 8000:8000 \
+            surrealdb/surrealdb:v2.2 \
+            start --user root --pass root memory
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:8000/health; then
+              echo "SurrealDB ready"
+              break
+            fi
+            echo "Waiting for SurrealDB... attempt $i"
+            sleep 2
+          done
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -72,3 +75,7 @@ jobs:
           SURREAL_URL: ws://localhost:8000
           SURREAL_USER: root
           SURREAL_PASS: root
+
+      - name: Stop SurrealDB
+        if: always()
+        run: docker stop surrealdb || true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,56 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'CHANGELOG.md'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install mkdocs-material mkdocs-minify-plugin
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Run goreleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+bin/
+dist/
+coverage.out
+coverage.html
+*.test
+*.out
+*.prof
+.idea/
+.vscode/
+.DS_Store
+*.log

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,38 @@
+run:
+  timeout: 5m
+  go: "1.26"
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
+    - ineffassign
+    - unused
+    - gofmt
+    - goimports
+    - misspell
+    - revive
+    - unconvert
+    - gocritic
+    - gosec
+
+linters-settings:
+  revive:
+    rules:
+      - name: exported
+      - name: package-comments
+      - name: var-naming
+  gosec:
+    excludes:
+      - G104 # errcheck handles
+  goimports:
+    local-prefixes: github.com/albedosehen/surql-go
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gosec
+        - errcheck

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,34 @@
+version: 2
+
+project_name: surql
+
+builds:
+  - main: ./cmd/surql
+    binary: surql
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X main.version={{ .Version }} -X main.commit={{ .Commit }} -X main.date={{ .Date }}
+
+archives:
+  - formats: ['tar.gz']
+    format_overrides:
+      - goos: windows
+        formats: ['zip']
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+
+checksum:
+  name_template: checksums.txt
+
+release:
+  github:
+    owner: albedosehen
+    name: surql-go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `migration/versioning` -- `SchemaSnapshot` (extended with `Version`,
+  `Timestamp`, `Description`, `Accesses`), `VersionGraph` DAG with
+  ancestors/descendants/path, and JSON-file snapshot persistence.
+- `migration/generator` -- `GenerateMigration`, `GenerateInitialMigration`,
+  `CreateBlankMigration`, `GenerateMigrationFromDiffs` with atomic writes.
+- `migration/diff` -- schema diff engine (`DiffTables`, `DiffFields`,
+  `DiffIndexes`, `DiffEvents`, `DiffPermissions`, `DiffEdges`,
+  `DiffSchemas`, `SchemaSnapshot`).
+- `migration/{models, discovery}` -- `.surql` file-format migrations with
+  `-- @metadata`, `-- @up`, `-- @down` section markers + SHA-256 checksum.
+- `schema/{visualize, themes, utils}` -- Mermaid / GraphViz / ASCII
+  diagrams with modern / dark / forest / minimal themes.
+- `schema/parser` -- `ParseDBInfo` / `ParseTableInfo` / `ParseEdgeInfo`
+  accept both short and long INFO response keys.
+- `schema/{validator, validator_utils}` -- cross-schema validation with
+  severity-filtered reports, `CompareSchemas`.
+- `schema/{sql, registry}` -- full DEFINE-statement composition and a
+  thread-safe `SchemaRegistry`.
+- `schema/{fields, table, edge, access}` -- code-first schema DSL.
+- `query/{builder, helpers}` -- immutable `Query` with fluent chaining.
+- `query/expressions` -- 25+ function builders and typed `Expression.Kind`.
+- `query/{hints, results}` -- query optimization hints + typed result
+  wrappers (`QueryResult[T]`, `RecordResult[T]`, `ListResult[T]`,
+  `PaginatedResult[T]`) with raw-response extraction helpers.
+- `connection/{config, auth}` -- connection configuration + auth
+  credential types (Root / Namespace / Database / Scope / Token).
+- `types/{operators, record_id, record_ref, surreal_fn, reserved, coerce}`
+  -- operator structs + `RecordID` with angle-bracket syntax + reserved
+  words + ISO-8601 datetime coercion.
+- `errors` -- sentinel errors + typed `SurqlError` with `errors.Is`/`As`.
+
+### Notes
+
+This is a pre-release port of [surql-py](https://github.com/Oneiriq/surql-py)
+targeting 1:1 feature parity. The runtime SurrealDB client, CRUD
+executor, and CLI land in the 0.1 -> 0.2 window.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Shon Thomas
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+.PHONY: build run test test-short vet fmt fmt-check lint check clean cover tidy
+
+BIN_DIR := bin
+BIN     := $(BIN_DIR)/surql
+PKG     := ./...
+
+build:
+	go build -o $(BIN) ./cmd/surql
+
+run:
+	go run ./cmd/surql
+
+test:
+	go test $(PKG) -race -v
+
+test-short:
+	go test $(PKG) -short
+
+vet:
+	go vet $(PKG)
+
+fmt:
+	gofmt -w .
+
+fmt-check:
+	@diff -u /dev/null <(gofmt -l .)
+
+lint:
+	golangci-lint run $(PKG)
+
+check: fmt-check vet test
+	@echo "All checks passed."
+
+tidy:
+	go mod tidy
+
+cover:
+	go test $(PKG) -race -coverprofile=coverage.out -covermode=atomic
+	go tool cover -html=coverage.out -o coverage.html
+	@echo "Coverage report: coverage.html"
+
+clean:
+	rm -rf $(BIN_DIR) coverage.out coverage.html

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# surql-go
+
+Code-first database toolkit for SurrealDB -- schema definitions, migrations, query building, typed CRUD.
+
+Go port of [`oneiriq-surql`](https://github.com/Oneiriq/surql-py) (Python) and [`@oneiriq/surql`](https://github.com/Oneiriq/surql) (TypeScript/Deno). Target: 1:1 feature parity.
+
+Status: `0.1.0-dev` -- foundation under active port.
+
+## Features (target parity)
+
+- Connection management (WebSocket/HTTP, pooling, retry, transactions, live queries)
+- Query builder (immutable, fluent, expressions, hints, batch operations, graph traversal)
+- Typed CRUD backed by `encoding/json` struct tags (create, read, update, merge, upsert, delete)
+- Schema DSL (tables, fields, edges, indexes, events, access)
+- Migrations (generator, executor, history, rollback, squash, versioning, watcher)
+- Cache (in-memory + optional Redis backend)
+- Orchestration (multi-environment deploy: sequential, parallel, rolling, canary)
+- CLI (`surql` binary) for migrate, schema, db, orchestrate
+
+## Install
+
+```bash
+go get github.com/albedosehen/surql-go
+```
+
+CLI:
+
+```bash
+go install github.com/albedosehen/surql-go/cmd/surql@latest
+```
+
+## Quick Start
+
+Under construction. Full API will mirror `surql-py` and `@oneiriq/surql`.
+
+## Development
+
+```bash
+make check    # fmt + vet + test
+make test     # run all tests
+make cover    # coverage report -> coverage.html
+```
+
+## License
+
+Apache-2.0

--- a/README.md
+++ b/README.md
@@ -1,46 +1,77 @@
 # surql-go
 
-Code-first database toolkit for SurrealDB -- schema definitions, migrations, query building, typed CRUD.
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Go Version](https://img.shields.io/badge/go-1.26%2B-00ADD8)](https://go.dev/)
+[![SurrealDB](https://img.shields.io/badge/SurrealDB-2.0%2B-ff00a0)](https://surrealdb.com/)
 
-Go port of [`oneiriq-surql`](https://github.com/Oneiriq/surql-py) (Python) and [`@oneiriq/surql`](https://github.com/Oneiriq/surql) (TypeScript/Deno). Target: 1:1 feature parity.
+A code-first database toolkit for [SurrealDB](https://surrealdb.com/). Define schemas, generate migrations, build queries, and perform typed CRUD -- all from Go.
 
-Status: `0.1.0-dev` -- foundation under active port.
+## Features
 
-## Features (target parity)
-
-- Connection management (WebSocket/HTTP, pooling, retry, transactions, live queries)
-- Query builder (immutable, fluent, expressions, hints, batch operations, graph traversal)
-- Typed CRUD backed by `encoding/json` struct tags (create, read, update, merge, upsert, delete)
-- Schema DSL (tables, fields, edges, indexes, events, access)
-- Migrations (generator, executor, history, rollback, squash, versioning, watcher)
-- Cache (in-memory + optional Redis backend)
-- Orchestration (multi-environment deploy: sequential, parallel, rolling, canary)
-- CLI (`surql` binary) for migrate, schema, db, orchestrate
-
-## Install
-
-```bash
-go get github.com/albedosehen/surql-go
-```
-
-CLI:
-
-```bash
-go install github.com/albedosehen/surql-go/cmd/surql@latest
-```
+- **Code-First Migrations** - Schema changes defined in code with automatic migration generation (auto-diff + `.surql` file output with `-- @up` / `-- @down` sections)
+- **Type-Safe Query Builder** - Immutable fluent API with operator-typed `Where`, expression helpers, and `encoding/json` struct tags
+- **Vector Search** - HNSW and MTREE index support with 8 distance metrics and EFC/M tuning
+- **Graph Traversal** - Native SurrealDB graph features with edge relationships
+- **Schema Visualization** - Mermaid, GraphViz, and ASCII diagrams with theming
+- **CLI Tools** - Migrations, schema inspection, validation, database management *(planned)*
+- **Stdlib-First** - Minimal dependencies; stdlib `net/http` + official SurrealDB SDK *(planned)*
 
 ## Quick Start
 
-Under construction. Full API will mirror `surql-py` and `@oneiriq/surql`.
-
-## Development
-
-```bash
-make check    # fmt + vet + test
-make test     # run all tests
-make cover    # coverage report -> coverage.html
+```shell
+go get github.com/Oneiriq/surql-go
 ```
+
+With the CLI:
+
+```shell
+go install github.com/Oneiriq/surql-go/cmd/surql@latest
+```
+
+```go
+package main
+
+import (
+    "github.com/Oneiriq/surql-go/pkg/surql/schema"
+)
+
+func main() {
+    user, _ := schema.NewTableDefinition(
+        "user",
+        schema.WithMode(schema.TableModeSchemafull),
+        schema.WithFields(
+            schema.StringField("name"),
+            schema.StringField("email").WithAssertion("string::is::email($value)"),
+            schema.IntField("age").WithAssertion("$value >= 0 AND $value <= 150"),
+            schema.DatetimeField("created_at").WithDefault("time::now()").WithReadonly(true),
+        ),
+        schema.WithIndexes(schema.UniqueIndex("email_idx", []string{"email"})),
+    )
+    // ...
+}
+```
+
+## Documentation
+
+Full documentation at **[oneiriq.github.io/surql-go](https://oneiriq.github.io/surql-go/)**.
+
+## Requirements
+
+- Go 1.26+
+- SurrealDB 2.0+
 
 ## License
 
-Apache-2.0
+Apache License 2.0 - see [LICENSE](LICENSE).
+
+## Python / TypeScript / Rust
+
+- **Python**: [surql-py](https://github.com/Oneiriq/surql-py) -- the original, reference implementation (Python 3.12+).
+- **TypeScript / Deno / Node.js**: [surql](https://github.com/Oneiriq/surql) -- type-safe query builder and client.
+- **Rust**: [surql-rs](https://github.com/Oneiriq/surql-rs) -- Rust port of this library, sharing the same schema + migration model.
+
+## Support
+
+- Documentation: [oneiriq.github.io/surql-go](https://oneiriq.github.io/surql-go/)
+- Issues: [GitHub Issues](https://github.com/Oneiriq/surql-go/issues)
+- Changelog: [CHANGELOG.md](CHANGELOG.md)

--- a/cmd/surql/main.go
+++ b/cmd/surql/main.go
@@ -1,0 +1,37 @@
+// Command surql is the CLI entry point for the surql-go toolkit.
+//
+// Subcommands (migrate, schema, db, orchestrate) are added incrementally
+// as the library port progresses. See README.md for the target surface.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/albedosehen/surql-go/pkg/surql"
+)
+
+// build-time populated by goreleaser via -ldflags.
+var (
+	version = surql.Version
+	commit  = ""
+	date    = ""
+)
+
+func main() {
+	if len(os.Args) >= 2 && (os.Args[1] == "-v" || os.Args[1] == "--version" || os.Args[1] == "version") {
+		fmt.Printf("surql %s", version)
+		if commit != "" {
+			fmt.Printf(" (commit %s)", commit)
+		}
+		if date != "" {
+			fmt.Printf(" built %s", date)
+		}
+		fmt.Println()
+		return
+	}
+
+	fmt.Fprintln(os.Stderr, "surql-go CLI is under construction; subcommands will land with each release.")
+	fmt.Fprintln(os.Stderr, "Use `surql --version` to inspect the current build.")
+	os.Exit(0)
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,17 @@
+# CLI
+
+The `surql` binary is under active development. When it ships (0.2), it
+will provide:
+
+- `surql migrate create <description>` -- blank migration template.
+- `surql migrate up [--steps N] [--dry-run]` -- apply pending migrations.
+- `surql migrate down [--steps N] [--yes]` -- roll back.
+- `surql migrate status` -- applied vs pending.
+- `surql schema show [--format json|mermaid|graphviz|ascii]` -- inspect the
+  running schema.
+- `surql schema diff [--compare-live]` -- drift detection.
+- `surql schema validate [--fail-on-drift]` -- CI validation.
+- `surql db init` / `surql db reset` / `surql db health` -- management.
+
+The target surface mirrors `surql-py`'s CLI. Track progress on
+[GitHub Issues](https://github.com/Oneiriq/surql-go/issues).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,81 @@
+# surql-go
+
+A code-first database toolkit for [SurrealDB](https://surrealdb.com/).
+Define schemas, generate migrations, build queries, and perform typed CRUD
+-- all from Go.
+
+> Go port of [surql-py](https://github.com/Oneiriq/surql-py) (Python) and
+> [@oneiriq/surql](https://github.com/Oneiriq/surql) (TypeScript / Deno).
+> 1:1 feature parity is the target.
+
+## Features
+
+- **Code-First Migrations** -- Schema changes defined in code with automatic
+  migration generation. Files use a portable `.surql` format with
+  `-- @up` / `-- @down` section markers.
+- **Type-Safe Query Builder** -- Immutable fluent API with operator-typed
+  `Where`, expression helpers, and `encoding/json` struct tags.
+- **Vector Search** -- HNSW and MTREE index support with 8 distance metrics
+  and EFC/M tuning.
+- **Graph Traversal** -- Native SurrealDB graph features with edge
+  relationships.
+- **Schema Visualization** -- Mermaid, GraphViz, and ASCII diagrams with
+  modern / dark / forest / minimal themes.
+- **CLI Tools** -- Migrations, schema inspection, validation, database
+  management *(planned)*.
+- **Stdlib-First** -- Minimal dependencies; stdlib `net/http` + official
+  SurrealDB SDK *(planned for 0.2)*.
+
+## Quick Start
+
+```shell
+go get github.com/Oneiriq/surql-go
+```
+
+```go
+package main
+
+import "github.com/Oneiriq/surql-go/pkg/surql/schema"
+
+func main() {
+    user, _ := schema.NewTableDefinition(
+        "user",
+        schema.WithMode(schema.TableModeSchemafull),
+        schema.WithFields(
+            schema.StringField("name"),
+            schema.StringField("email").WithAssertion("string::is::email($value)"),
+            schema.IntField("age").WithAssertion("$value >= 0 AND $value <= 150"),
+            schema.DatetimeField("created_at").WithDefault("time::now()").WithReadonly(true),
+        ),
+        schema.WithIndexes(schema.UniqueIndex("email_idx", []string{"email"})),
+    )
+    _ = user
+}
+```
+
+## Documentation
+
+- **[Installation](installation.md)** -- getting the module installed.
+- **[Quick Start](quickstart.md)** -- your first schema and migration.
+- **[Schema Definition](schema.md)** -- the schema DSL in depth.
+- **[Migrations](migrations.md)** -- diff-based migration generation, file
+  format, and versioning.
+- **[Query Builder](queries.md)** -- immutable fluent queries.
+- **[Query Hints](query_hints.md)** -- INDEX / PARALLEL / TIMEOUT / FETCH /
+  EXPLAIN hints.
+- **[Visualization](visualization.md)** -- Mermaid / GraphViz / ASCII
+  diagrams.
+- **[CLI](cli.md)** -- the `surql` binary *(planned)*.
+- **[Changelog](changelog.md)** -- release history.
+- **[API reference](https://pkg.go.dev/github.com/Oneiriq/surql-go)** --
+  generated godoc.
+
+## Sister projects
+
+- **Python**: [surql-py](https://github.com/Oneiriq/surql-py)
+- **TypeScript / Deno / Node.js**: [surql](https://github.com/Oneiriq/surql)
+- **Rust**: [surql-rs](https://github.com/Oneiriq/surql-rs)
+
+## License
+
+[Apache License 2.0](https://github.com/Oneiriq/surql-go/blob/main/LICENSE).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,40 @@
+# Installation
+
+## Library
+
+```shell
+go get github.com/Oneiriq/surql-go
+```
+
+Or in `go.mod`:
+
+```go
+require github.com/Oneiriq/surql-go v0.1.0
+```
+
+## CLI
+
+```shell
+go install github.com/Oneiriq/surql-go/cmd/surql@latest
+```
+
+The binary is named `surql`; add `$(go env GOPATH)/bin` to your `$PATH`.
+
+## Build tags
+
+Integration tests use the `integration` build tag and require a running
+SurrealDB:
+
+```shell
+go test -tags=integration ./...
+```
+
+## Requirements
+
+- Go 1.26 or newer.
+- For the client feature: SurrealDB 2.0 or newer.
+
+## What's next
+
+- **[Quick Start](quickstart.md)** -- your first schema and migration.
+- **[Schema Definition](schema.md)** -- the full schema DSL reference.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,66 @@
+# Migrations
+
+## File format
+
+Migration files are plain `.surql` files with three section markers:
+
+```text
+-- @metadata
+-- version: 20260418_193300
+-- description: Add user table
+-- depends_on: [20260418_180000]
+-- @up
+DEFINE TABLE user SCHEMAFULL;
+DEFINE FIELD email ON TABLE user TYPE string;
+-- @down
+REMOVE TABLE IF EXISTS user;
+```
+
+Version pattern: `YYYYMMDD_HHMMSS`. Descriptions are slug-cased by the
+generator. Every file includes a SHA-256 checksum.
+
+## Generating migrations
+
+```go
+import "github.com/Oneiriq/surql-go/pkg/surql/migration"
+
+m, _ := migration.CreateBlankMigration("add_log_table", "Add log table", "migrations")
+m, _  = migration.GenerateInitialMigration(reg, "migrations")
+m, _  = migration.GenerateMigrationFromDiffs("rename_email", diffs, "migrations")
+```
+
+## Diffing
+
+```go
+code := migration.SchemaSnapshot{Tables: codeReg.Tables(), Edges: codeReg.Edges()}
+db   := migration.SchemaSnapshot{Tables: dbTables, Edges: dbEdges}
+diffs, _ := migration.DiffSchemas(code, db)
+```
+
+## Discovery
+
+```go
+migrations, _ := migration.DiscoverMigrations("migrations")
+for _, m := range migrations {
+    fmt.Println(m.Version, m.Description)
+}
+one, _ := migration.LoadMigration("migrations/20260418_193300_add_user_table.surql")
+```
+
+## Versioning + snapshots
+
+```go
+snap, _  := migration.CreateSnapshot(reg, "after user table")
+migration.StoreSnapshot(snap, "snapshots")
+all, _   := migration.ListSnapshots("snapshots")
+
+diff, _  := migration.CompareSnapshots(all[0], all[1])
+
+g := migration.NewVersionGraph()
+for _, s := range all { g.Add(s) }
+```
+
+## What's next
+
+- **[Query Builder](queries.md)** -- immutable fluent queries for your
+  migrated schema.

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -1,0 +1,79 @@
+# Query Builder
+
+The immutable fluent builder composes SurrealQL statements without
+executing them. Methods on `Query` return new values; the input is never
+mutated.
+
+## SELECT
+
+```go
+import (
+    "github.com/Oneiriq/surql-go/pkg/surql/query"
+    "github.com/Oneiriq/surql-go/pkg/surql/types"
+)
+
+q, _ := query.Select([]string{"name", "email"}).FromTable("user")
+q     = q.Where(types.GtOp("age", 18)).Where(types.EqOp("status", "active"))
+q, _  = q.OrderBy("created_at", "DESC")
+q     = q.Limit(10)
+fmt.Println(q.ToSurql())
+```
+
+## INSERT / UPDATE / UPSERT / DELETE / RELATE
+
+```go
+ins, _ := query.Insert("user", map[string]any{
+    "name":  "Alice",
+    "email": "alice@example.com",
+})
+upd, _ := query.Update("user:alice", map[string]any{"status": "active"})
+del, _ := query.Delete("user:bob")
+rel, _ := query.Relate("user:alice", "likes", "post:1")
+_ = ins; _ = upd; _ = del; _ = rel
+```
+
+## Where
+
+`Where` accepts a `string`, any `types.Operator`, or `nil`. Anything else
+returns an `ErrValidation` error.
+
+```go
+q, _ := query.Select(nil).FromTable("user")
+q     = q.Where(types.AndOp(types.GtOp("age", 18), types.EqOp("status", "active")))
+```
+
+## Expressions
+
+Expressions build typed SurrealQL fragments you can embed in select lists
+or `Where` clauses.
+
+```go
+sel := []string{
+    query.Field("id").ToSurql(),
+    query.As(query.MathMean("score"), "avg_score").ToSurql(),
+    query.As(query.Count(""), "total").ToSurql(),
+}
+```
+
+## Hints
+
+```go
+tmo, _ := query.NewTimeoutHint(30.0)
+q     = q.Hint(tmo).Hint(query.ParallelEnabled())
+```
+
+Hints render as SurrealQL comments; duplicates of the same kind are merged
+so only the latest value survives.
+
+## Result wrappers
+
+Once the SurrealDB client lands, queries produce typed
+`QueryResult[T]` / `RecordResult[T]` / `ListResult[T]` /
+`PaginatedResult[T]` values via the raw-response helpers in
+`pkg/surql/query`: `ExtractResult`, `ExtractOne`, `ExtractScalar`,
+`HasResults`.
+
+## What's next
+
+- **[Query Hints](query_hints.md)** -- every supported optimization hint.
+- **[Visualization](visualization.md)** -- schema diagrams.

--- a/docs/query_hints.md
+++ b/docs/query_hints.md
@@ -1,0 +1,49 @@
+# Query Hints
+
+Hints are SurrealQL comment annotations that the query planner consumes.
+They're strongly typed so builder chains can dedup + validate them before
+rendering.
+
+## Kinds
+
+| Hint            | Rendering                                 |
+|-----------------|-------------------------------------------|
+| `IndexHint`     | `/* USE INDEX table.index */` or `/* FORCE INDEX … */` |
+| `ParallelHint`  | `/* PARALLEL ON */` / `OFF` / `/* PARALLEL N */`       |
+| `TimeoutHint`   | `/* TIMEOUT Ns */`                        |
+| `FetchHint`     | `/* FETCH EAGER */` / `LAZY` / `/* FETCH BATCH N */`   |
+| `ExplainHint`   | `/* EXPLAIN */` or `/* EXPLAIN FULL */`   |
+
+## Construction
+
+```go
+idx := query.NewIndexHint("user", "email_idx").WithForce(true)
+par, _ := query.ParallelWithWorkers(4)
+tmo, _ := query.NewTimeoutHint(30.0)
+fch, _ := query.FetchBatchHint(100)
+xpn    := query.ExplainFull()
+```
+
+## Composition
+
+Multiple hints can coexist; `MergeHints` collapses duplicates of the same
+kind to the latest value (preserving insertion order of unique kinds).
+
+```go
+tmoA, _ := query.NewTimeoutHint(10.0)
+tmoB, _ := query.NewTimeoutHint(20.0)
+merged  := query.MergeHints([]query.QueryHint{tmoA, par, tmoB})
+fmt.Println(query.RenderHints(merged))
+```
+
+## Validation
+
+```go
+idx := query.NewIndexHint("user", "email_idx")
+errors := query.ValidateHint(idx, "user") // []string{}
+errors  = query.ValidateHint(idx, "post") // one mismatch error
+```
+
+## What's next
+
+- **[Query Builder](queries.md)** -- chaining hints onto queries.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,98 @@
+# Quick Start
+
+This walkthrough defines a small `user` table, generates an initial
+migration, and inspects the resulting SurrealQL.
+
+## 1. Define a schema
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/Oneiriq/surql-go/pkg/surql/schema"
+)
+
+func buildRegistry() (*schema.SchemaRegistry, error) {
+    user, err := schema.NewTableDefinition(
+        "user",
+        schema.WithMode(schema.TableModeSchemafull),
+        schema.WithFields(
+            schema.StringField("name"),
+            schema.StringField("email").WithAssertion("string::is::email($value)"),
+            schema.IntField("age").WithAssertion("$value >= 0 AND $value <= 150"),
+            schema.DatetimeField("created_at").WithDefault("time::now()").WithReadonly(true),
+        ),
+        schema.WithIndexes(schema.UniqueIndex("email_idx", []string{"email"})),
+    )
+    if err != nil {
+        return nil, err
+    }
+    reg := schema.NewSchemaRegistry()
+    if err := reg.RegisterTable(user); err != nil {
+        return nil, err
+    }
+    return reg, nil
+}
+```
+
+## 2. Render SurrealQL
+
+```go
+reg, _ := buildRegistry()
+stmts, err := schema.GenerateSchemaSQL(reg, false)
+if err != nil { panic(err) }
+for _, s := range stmts { fmt.Println(s) }
+```
+
+Output:
+
+```sql
+DEFINE TABLE user SCHEMAFULL;
+DEFINE FIELD name ON TABLE user TYPE string;
+DEFINE FIELD email ON TABLE user TYPE string ASSERT string::is::email($value);
+DEFINE FIELD age ON TABLE user TYPE int ASSERT $value >= 0 AND $value <= 150;
+DEFINE FIELD created_at ON TABLE user TYPE datetime VALUE time::now() READONLY;
+DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE;
+```
+
+## 3. Generate a migration file
+
+```go
+import "github.com/Oneiriq/surql-go/pkg/surql/migration"
+
+m, err := migration.GenerateInitialMigration(reg, "migrations")
+if err != nil { panic(err) }
+fmt.Printf("wrote migration %s: %s\n", m.Version, m.Description)
+```
+
+Each file is a portable `.surql` document:
+
+```text
+-- @metadata
+-- version: 20260418_193300
+-- description: Initial schema
+-- @up
+DEFINE TABLE user SCHEMAFULL;
+...
+-- @down
+REMOVE TABLE IF EXISTS user;
+```
+
+## 4. Diff code vs database
+
+```go
+snap := migration.SchemaSnapshot{Tables: reg.Tables(), Edges: reg.Edges()}
+// db := /* fetched via INFO FOR DB once the client lands */
+diffs, _ := migration.DiffSchemas(snap, db)
+for _, d := range diffs {
+    fmt.Printf("%s: %s\n", d.Operation, d.TargetName)
+}
+```
+
+## What's next
+
+- **[Schema Definition](schema.md)** -- fields, tables, edges, indexes,
+  events, access rules.
+- **[Migrations](migrations.md)** -- the full migration lifecycle.
+- **[Query Builder](queries.md)** -- immutable fluent queries.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,96 @@
+# Schema Definition
+
+The schema DSL is a code-first way to describe SurrealDB tables, edges,
+fields, indexes, events, and access rules. Definitions render to `DEFINE`
+statements and feed the migration generator + validator + visualizer.
+
+## Tables
+
+```go
+user, _ := schema.NewTableDefinition(
+    "user",
+    schema.WithMode(schema.TableModeSchemafull),
+    schema.WithFields(
+        schema.StringField("email").WithAssertion("string::is::email($value)"),
+        schema.IntField("age"),
+    ),
+    schema.WithIndexes(schema.UniqueIndex("email_idx", []string{"email"})),
+)
+```
+
+`TableMode` has three variants: `TableModeSchemafull`, `TableModeSchemaless`,
+`TableModeDrop`.
+
+## Field helpers
+
+| Helper               | SurrealDB type |
+|----------------------|----------------|
+| `StringField`        | `string`       |
+| `IntField`           | `int`          |
+| `FloatField`         | `float`        |
+| `BoolField`          | `bool`         |
+| `DatetimeField`      | `datetime`     |
+| `DurationField`      | `duration`     |
+| `DecimalField`       | `decimal`      |
+| `ObjectField`        | `object` (defaults `Flexible=true`) |
+| `ArrayField`         | `array`        |
+| `RecordField(t)`     | `record<t>`    |
+| `ComputedField`      | `VALUE <expr>` |
+
+Chainable setters: `WithAssertion`, `WithDefault`, `WithValue`,
+`WithReadonly`, `WithFlexible`, `WithPermissions`.
+
+## Indexes
+
+- `Index(name, cols)`
+- `UniqueIndex(name, cols)`
+- `SearchIndex(name, cols)`
+- `MTreeIndex(name, col, opts)` with `MTreeIndexOptions{Dimension, Distance, Capacity, Cache}`
+- `HnswIndex(name, col, opts)` with `HnswIndexOptions{Dimension, Distance, EFC, M}`
+
+## Events
+
+```go
+ev := schema.Event("new_user").
+    WithWhen("$event = 'CREATE'").
+    WithThen("CREATE log SET table = 'user', id = $value.id")
+```
+
+## Edges
+
+```go
+likes, _ := schema.NewEdgeDefinition(
+    "likes",
+    schema.WithEdgeMode(schema.EdgeModeRelation),
+    schema.WithEdgeFrom("user"),
+    schema.WithEdgeTo("post"),
+)
+```
+
+## Access (record + JWT)
+
+```go
+api, _ := schema.NewAccessDefinition(
+    "api",
+    schema.WithAccessType(schema.AccessTypeJwt),
+    schema.WithJwt(schema.JwtConfig{Algorithm: "HS512", Key: "secret"}),
+    schema.WithDurationToken("1h"),
+)
+```
+
+## Registry + SQL generation
+
+```go
+reg := schema.NewSchemaRegistry()
+reg.RegisterTable(user)
+reg.RegisterEdge(likes)
+
+stmts, _ := schema.GenerateSchemaSQL(reg, false)
+```
+
+## What's next
+
+- **[Migrations](migrations.md)** -- turning schema changes into migration
+  files.
+- **[Visualization](visualization.md)** -- Mermaid / GraphViz / ASCII
+  diagrams from the registry.

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -1,0 +1,47 @@
+# Visualization
+
+Render Mermaid / GraphViz / ASCII diagrams straight from a
+`SchemaRegistry`.
+
+## Mermaid
+
+```go
+import "github.com/Oneiriq/surql-go/pkg/surql/schema"
+
+theme := schema.ModernMermaidTheme()
+out   := schema.GenerateMermaid(reg, theme)
+fmt.Println(out)
+```
+
+## GraphViz DOT
+
+```go
+theme := schema.DarkGraphVizTheme()
+out   := schema.GenerateGraphViz(reg, theme)
+_ = os.WriteFile("schema.dot", []byte(out), 0o644)
+```
+
+## ASCII
+
+```go
+theme := schema.MinimalASCIITheme()
+out   := schema.GenerateASCII(reg, theme)
+fmt.Println(out)
+```
+
+## Themes
+
+| Preset                       | Mood                                        |
+|------------------------------|---------------------------------------------|
+| `Modern{Mermaid,GraphViz,ASCII}Theme()` | Bright accents, clean typography, emoji. |
+| `Dark…Theme()`               | Dim palette, good on dark terminals.        |
+| `Forest…Theme()`             | Earthy greens, muted secondary color.       |
+| `Minimal…Theme()`            | Monochrome, no decorative glyphs.           |
+
+`GetTheme(name)` returns an `ErrValidation`-wrapped error for unknown
+names. `ListThemes()` returns the sorted preset list.
+
+## What's next
+
+- **[Schema Definition](schema.md)** -- building the registry the
+  visualizer consumes.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/albedosehen/surql-go
+
+go 1.26.1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,90 @@
+site_name: surql-go
+site_url: https://oneiriq.github.io/surql-go
+site_description: Code-first database toolkit for SurrealDB (Go port)
+site_author: Oneiriq
+repo_url: https://github.com/Oneiriq/surql-go
+repo_name: Oneiriq/surql-go
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - content.code.copy
+    - content.code.annotate
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.highlight
+    - search.suggest
+    - toc.follow
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - toc:
+      permalink: true
+  - pymdownx.snippets:
+      base_path: ["."]
+  - attr_list
+  - md_in_html
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: installation.md
+      - Quick Start: quickstart.md
+  - Guides:
+      - Schema Definition: schema.md
+      - Migrations: migrations.md
+      - Query Builder: queries.md
+      - Query Hints: query_hints.md
+      - Visualization: visualization.md
+  - Reference:
+      - CLI: cli.md
+      - API (pkg.go.dev): https://pkg.go.dev/github.com/Oneiriq/surql-go
+  - Changelog: changelog.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/Oneiriq/surql-go
+    - icon: fontawesome/brands/golang
+      link: https://pkg.go.dev/github.com/Oneiriq/surql-go

--- a/pkg/surql/connection/auth.go
+++ b/pkg/surql/connection/auth.go
@@ -1,0 +1,166 @@
+package connection
+
+// AuthType is the SurrealDB authentication level.
+type AuthType string
+
+const (
+	// AuthRoot == server root user.
+	AuthRoot AuthType = "root"
+	// AuthNamespace == namespace user.
+	AuthNamespace AuthType = "namespace"
+	// AuthDatabase == database user.
+	AuthDatabase AuthType = "database"
+	// AuthScope == record/scope-level user.
+	AuthScope AuthType = "scope"
+)
+
+// Credentials is implemented by every credential type so the runtime
+// client can serialise them to the SurrealDB SDK signin/signup payload.
+type Credentials interface {
+	AuthType() AuthType
+	ToSigninPayload() map[string]any
+}
+
+// RootCredentials carry server root-level username + password.
+type RootCredentials struct {
+	Username string `json:"username"`
+	Password string `json:"password,omitempty"`
+}
+
+// AuthType implements Credentials.
+func (RootCredentials) AuthType() AuthType { return AuthRoot }
+
+// ToSigninPayload implements Credentials.
+func (c RootCredentials) ToSigninPayload() map[string]any {
+	out := map[string]any{"username": c.Username}
+	if c.Password != "" {
+		out["password"] = c.Password
+	}
+	return out
+}
+
+// NewRootCredentials constructs a RootCredentials.
+func NewRootCredentials(username, password string) RootCredentials {
+	return RootCredentials{Username: username, Password: password}
+}
+
+// NamespaceCredentials carry namespace-scoped signin material.
+type NamespaceCredentials struct {
+	Namespace string `json:"namespace"`
+	Username  string `json:"username"`
+	Password  string `json:"password,omitempty"`
+}
+
+// AuthType implements Credentials.
+func (NamespaceCredentials) AuthType() AuthType { return AuthNamespace }
+
+// ToSigninPayload implements Credentials.
+func (c NamespaceCredentials) ToSigninPayload() map[string]any {
+	out := map[string]any{
+		"namespace": c.Namespace,
+		"username":  c.Username,
+	}
+	if c.Password != "" {
+		out["password"] = c.Password
+	}
+	return out
+}
+
+// NewNamespaceCredentials constructs a NamespaceCredentials.
+func NewNamespaceCredentials(namespace, username, password string) NamespaceCredentials {
+	return NamespaceCredentials{Namespace: namespace, Username: username, Password: password}
+}
+
+// DatabaseCredentials carry database-scoped signin material.
+type DatabaseCredentials struct {
+	Namespace string `json:"namespace"`
+	Database  string `json:"database"`
+	Username  string `json:"username"`
+	Password  string `json:"password,omitempty"`
+}
+
+// AuthType implements Credentials.
+func (DatabaseCredentials) AuthType() AuthType { return AuthDatabase }
+
+// ToSigninPayload implements Credentials.
+func (c DatabaseCredentials) ToSigninPayload() map[string]any {
+	out := map[string]any{
+		"namespace": c.Namespace,
+		"database":  c.Database,
+		"username":  c.Username,
+	}
+	if c.Password != "" {
+		out["password"] = c.Password
+	}
+	return out
+}
+
+// NewDatabaseCredentials constructs a DatabaseCredentials.
+func NewDatabaseCredentials(namespace, database, username, password string) DatabaseCredentials {
+	return DatabaseCredentials{
+		Namespace: namespace, Database: database, Username: username, Password: password,
+	}
+}
+
+// ScopeCredentials carry record/scope-level signin material. Variables are
+// flattened into the top-level signin payload (e.g. email, password).
+type ScopeCredentials struct {
+	Namespace string         `json:"namespace"`
+	Database  string         `json:"database"`
+	Access    string         `json:"access"`
+	Variables map[string]any `json:"variables,omitempty"`
+}
+
+// AuthType implements Credentials.
+func (ScopeCredentials) AuthType() AuthType { return AuthScope }
+
+// ToSigninPayload implements Credentials.
+func (c ScopeCredentials) ToSigninPayload() map[string]any {
+	out := map[string]any{
+		"namespace": c.Namespace,
+		"database":  c.Database,
+		"access":    c.Access,
+	}
+	for k, v := range c.Variables {
+		out[k] = v
+	}
+	return out
+}
+
+// NewScopeCredentials constructs ScopeCredentials with an empty variable set.
+func NewScopeCredentials(namespace, database, access string) ScopeCredentials {
+	return ScopeCredentials{
+		Namespace: namespace, Database: database, Access: access,
+		Variables: map[string]any{},
+	}
+}
+
+// With attaches a scope variable (e.g. "email", "password") and returns a
+// copy.
+func (c ScopeCredentials) With(key string, value any) ScopeCredentials {
+	vars := make(map[string]any, len(c.Variables)+1)
+	for k, v := range c.Variables {
+		vars[k] = v
+	}
+	vars[key] = value
+	c.Variables = vars
+	return c
+}
+
+// TokenAuth carries an existing JWT.
+type TokenAuth struct {
+	Token string `json:"token"`
+}
+
+// NewTokenAuth constructs a TokenAuth.
+func NewTokenAuth(token string) TokenAuth {
+	return TokenAuth{Token: token}
+}
+
+// Compile-time interface checks.
+var (
+	_ Credentials = RootCredentials{}
+	_ Credentials = NamespaceCredentials{}
+	_ Credentials = DatabaseCredentials{}
+	_ Credentials = ScopeCredentials{}
+)

--- a/pkg/surql/connection/auth_test.go
+++ b/pkg/surql/connection/auth_test.go
@@ -1,0 +1,117 @@
+package connection
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAuthType_Values(t *testing.T) {
+	cases := map[AuthType]string{
+		AuthRoot:      "root",
+		AuthNamespace: "namespace",
+		AuthDatabase:  "database",
+		AuthScope:     "scope",
+	}
+	for at, want := range cases {
+		if string(at) != want {
+			t.Errorf("%v: got %q, want %q", at, string(at), want)
+		}
+	}
+}
+
+func TestRootCredentials_Payload(t *testing.T) {
+	c := NewRootCredentials("root", "secret")
+	p := c.ToSigninPayload()
+	if p["username"] != "root" || p["password"] != "secret" {
+		t.Errorf("payload: %+v", p)
+	}
+	if c.AuthType() != AuthRoot {
+		t.Errorf("authtype: %v", c.AuthType())
+	}
+}
+
+func TestNamespaceCredentials_Payload(t *testing.T) {
+	c := NewNamespaceCredentials("prod", "u", "p")
+	p := c.ToSigninPayload()
+	if p["namespace"] != "prod" || p["username"] != "u" || p["password"] != "p" {
+		t.Errorf("payload: %+v", p)
+	}
+	if c.AuthType() != AuthNamespace {
+		t.Error("authtype mismatch")
+	}
+}
+
+func TestDatabaseCredentials_Payload(t *testing.T) {
+	c := NewDatabaseCredentials("prod", "app", "u", "p")
+	p := c.ToSigninPayload()
+	if p["namespace"] != "prod" || p["database"] != "app" {
+		t.Errorf("ns/db: %+v", p)
+	}
+	if p["username"] != "u" || p["password"] != "p" {
+		t.Errorf("user/pass: %+v", p)
+	}
+	if c.AuthType() != AuthDatabase {
+		t.Error("authtype mismatch")
+	}
+}
+
+func TestScopeCredentials_PayloadFlattensVariables(t *testing.T) {
+	c := NewScopeCredentials("prod", "app", "user").
+		With("email", "a@example.com").
+		With("password", "secret")
+	p := c.ToSigninPayload()
+	if p["namespace"] != "prod" || p["database"] != "app" || p["access"] != "user" {
+		t.Errorf("base: %+v", p)
+	}
+	if p["email"] != "a@example.com" || p["password"] != "secret" {
+		t.Errorf("vars: %+v", p)
+	}
+	if c.AuthType() != AuthScope {
+		t.Error("authtype mismatch")
+	}
+}
+
+func TestScopeCredentials_WithDoesNotMutate(t *testing.T) {
+	a := NewScopeCredentials("prod", "app", "user")
+	b := a.With("email", "a@example.com")
+	if len(a.Variables) != 0 {
+		t.Errorf("original should be untouched, got %+v", a.Variables)
+	}
+	if b.Variables["email"] != "a@example.com" {
+		t.Errorf("derived missing email: %+v", b.Variables)
+	}
+}
+
+func TestRootCredentials_OmitsEmptyPassword(t *testing.T) {
+	c := RootCredentials{Username: "root"}
+	data, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if containsString(string(data), "password") {
+		t.Errorf("should omit empty password: %s", data)
+	}
+}
+
+func TestCredentialsInterface(t *testing.T) {
+	var _ Credentials = NewRootCredentials("r", "p")
+	var _ Credentials = NewNamespaceCredentials("n", "u", "p")
+	var _ Credentials = NewDatabaseCredentials("n", "d", "u", "p")
+	var _ Credentials = NewScopeCredentials("n", "d", "a")
+}
+
+func TestTokenAuth(t *testing.T) {
+	t1 := NewTokenAuth("abc")
+	if t1.Token != "abc" {
+		t.Errorf("token: %q", t1.Token)
+	}
+}
+
+func containsString(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/surql/connection/config.go
+++ b/pkg/surql/connection/config.go
@@ -1,0 +1,408 @@
+package connection
+
+import (
+	"math"
+	"os"
+	"strconv"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// EnvPrefix is the environment variable prefix used by LoadConfigFromEnv.
+const EnvPrefix = "SURQL_"
+
+// Protocol is the connection protocol implied by the configured URL.
+type Protocol int
+
+const (
+	// ProtocolWebSocket == ws://
+	ProtocolWebSocket Protocol = iota
+	// ProtocolWebSocketSecure == wss://
+	ProtocolWebSocketSecure
+	// ProtocolHTTP == http://
+	ProtocolHTTP
+	// ProtocolHTTPS == https://
+	ProtocolHTTPS
+	// ProtocolMemory == mem:// or memory://
+	ProtocolMemory
+	// ProtocolFile == file://
+	ProtocolFile
+	// ProtocolSurrealKV == surrealkv://
+	ProtocolSurrealKV
+)
+
+// String returns the canonical scheme name.
+func (p Protocol) String() string {
+	switch p {
+	case ProtocolWebSocket:
+		return "ws"
+	case ProtocolWebSocketSecure:
+		return "wss"
+	case ProtocolHTTP:
+		return "http"
+	case ProtocolHTTPS:
+		return "https"
+	case ProtocolMemory:
+		return "memory"
+	case ProtocolFile:
+		return "file"
+	case ProtocolSurrealKV:
+		return "surrealkv"
+	default:
+		return "unknown"
+	}
+}
+
+// SupportsLiveQueries reports whether the protocol supports LIVE SELECT.
+func (p Protocol) SupportsLiveQueries() bool {
+	return p != ProtocolHTTP && p != ProtocolHTTPS
+}
+
+// IsEmbedded reports whether the protocol runs in-process (no server).
+func (p Protocol) IsEmbedded() bool {
+	return p == ProtocolMemory || p == ProtocolFile || p == ProtocolSurrealKV
+}
+
+// ConnectionConfig is the SurrealDB connection configuration.
+//
+// Field names follow the Python port (DBURL, DBNS, DB, ...) for
+// wire-compatibility with env loading; convenient accessors (URL,
+// Namespace, Database, ...) are provided for the shorter aliases.
+//
+//nolint:revive // Allow exported field name repetition with package name
+type ConnectionConfig struct {
+	DBURL              string  `json:"db_url"`
+	DBNS               string  `json:"db_ns"`
+	DB                 string  `json:"db"`
+	DBUser             *string `json:"db_user,omitempty"`
+	DBPass             *string `json:"db_pass,omitempty"`
+	DBTimeout          float64 `json:"db_timeout"`
+	DBMaxConnections   uint32  `json:"db_max_connections"`
+	DBRetryMaxAttempts uint32  `json:"db_retry_max_attempts"`
+	DBRetryMinWait     float64 `json:"db_retry_min_wait"`
+	DBRetryMaxWait     float64 `json:"db_retry_max_wait"`
+	DBRetryMultiplier  float64 `json:"db_retry_multiplier"`
+	EnableLiveQueries  bool    `json:"enable_live_queries"`
+}
+
+// DefaultConfig returns the library defaults (same as the Python port).
+func DefaultConfig() ConnectionConfig {
+	return ConnectionConfig{
+		DBURL:              "ws://localhost:8000/rpc",
+		DBNS:               "development",
+		DB:                 "main",
+		DBUser:             nil,
+		DBPass:             nil,
+		DBTimeout:          30.0,
+		DBMaxConnections:   10,
+		DBRetryMaxAttempts: 3,
+		DBRetryMinWait:     1.0,
+		DBRetryMaxWait:     10.0,
+		DBRetryMultiplier:  2.0,
+		EnableLiveQueries:  true,
+	}
+}
+
+// URL returns DBURL (alias).
+func (c ConnectionConfig) URL() string { return c.DBURL }
+
+// Namespace returns DBNS (alias).
+func (c ConnectionConfig) Namespace() string { return c.DBNS }
+
+// Database returns DB (alias).
+func (c ConnectionConfig) Database() string { return c.DB }
+
+// Username returns DBUser (alias).
+func (c ConnectionConfig) Username() *string { return c.DBUser }
+
+// Password returns DBPass (alias).
+func (c ConnectionConfig) Password() *string { return c.DBPass }
+
+// Timeout returns DBTimeout (alias).
+func (c ConnectionConfig) Timeout() float64 { return c.DBTimeout }
+
+// MaxConnections returns DBMaxConnections (alias).
+func (c ConnectionConfig) MaxConnections() uint32 { return c.DBMaxConnections }
+
+// RetryMaxAttempts returns DBRetryMaxAttempts (alias).
+func (c ConnectionConfig) RetryMaxAttempts() uint32 { return c.DBRetryMaxAttempts }
+
+// RetryMinWait returns DBRetryMinWait (alias).
+func (c ConnectionConfig) RetryMinWait() float64 { return c.DBRetryMinWait }
+
+// RetryMaxWait returns DBRetryMaxWait (alias).
+func (c ConnectionConfig) RetryMaxWait() float64 { return c.DBRetryMaxWait }
+
+// RetryMultiplier returns DBRetryMultiplier (alias).
+func (c ConnectionConfig) RetryMultiplier() float64 { return c.DBRetryMultiplier }
+
+// Protocol infers the protocol from DBURL (validates as a side effect).
+func (c ConnectionConfig) Protocol() (Protocol, error) {
+	return detectProtocol(c.DBURL)
+}
+
+// Validate applies all the rules from the Python port.
+func (c ConnectionConfig) Validate() error {
+	if err := validateURL(c.DBURL); err != nil {
+		return err
+	}
+	if err := validateIdentifier(c.DBNS, "namespace"); err != nil {
+		return err
+	}
+	if err := validateIdentifier(c.DB, "database"); err != nil {
+		return err
+	}
+	if err := validateNumericRange("timeout", c.DBTimeout, 1.0, math.Inf(1)); err != nil {
+		return err
+	}
+	if err := validateNumericRange("max_connections", float64(c.DBMaxConnections), 1.0, 100.0); err != nil {
+		return err
+	}
+	if err := validateNumericRange("retry_max_attempts", float64(c.DBRetryMaxAttempts), 1.0, 10.0); err != nil {
+		return err
+	}
+	if err := validateNumericRange("retry_min_wait", c.DBRetryMinWait, 0.1, math.Inf(1)); err != nil {
+		return err
+	}
+	if err := validateNumericRange("retry_max_wait", c.DBRetryMaxWait, 1.0, math.Inf(1)); err != nil {
+		return err
+	}
+	if err := validateNumericRange("retry_multiplier", c.DBRetryMultiplier, 1.0, math.Inf(1)); err != nil {
+		return err
+	}
+	if c.DBRetryMaxWait <= c.DBRetryMinWait {
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"db_retry_max_wait must be greater than db_retry_min_wait")
+	}
+	proto, err := detectProtocol(c.DBURL)
+	if err != nil {
+		return err
+	}
+	if c.EnableLiveQueries && !proto.SupportsLiveQueries() {
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"Live queries require WebSocket (ws://, wss://) or embedded (mem://, memory://, file://, surrealkv://) connection")
+	}
+	return nil
+}
+
+// LoadConfigFromEnv loads SurrealDB configuration from process env vars
+// prefixed with EnvPrefix (SURQL_). Missing values fall back to defaults.
+//
+// Recognised names: SURQL_URL, SURQL_NAMESPACE, SURQL_DATABASE,
+// SURQL_USERNAME, SURQL_PASSWORD, SURQL_TIMEOUT, SURQL_MAX_CONNECTIONS,
+// SURQL_RETRY_MAX_ATTEMPTS, SURQL_RETRY_MIN_WAIT, SURQL_RETRY_MAX_WAIT,
+// SURQL_RETRY_MULTIPLIER, SURQL_ENABLE_LIVE_QUERIES. Python-port legacy
+// aliases (DB_URL, DB_NS, DB, DB_USER, DB_PASS, ...) are also accepted.
+func LoadConfigFromEnv() (ConnectionConfig, error) {
+	return LoadConfigFromEnvWithPrefix(EnvPrefix)
+}
+
+// LoadConfigFromEnvWithPrefix is LoadConfigFromEnv with a custom prefix
+// (e.g. "SURQL_PRIMARY_" for named connections).
+func LoadConfigFromEnvWithPrefix(prefix string) (ConnectionConfig, error) {
+	return LoadConfigFromSource(prefix, func(key string) (string, bool) {
+		return os.LookupEnv(key)
+	})
+}
+
+// LoadConfigFromSource builds a config from an arbitrary key lookup.
+// Tests pass a map-backed lookup to avoid mutating process env.
+func LoadConfigFromSource(prefix string, lookup func(string) (string, bool)) (ConnectionConfig, error) {
+	cfg := DefaultConfig()
+	if v, ok := getWithAliases(lookup, prefix, "URL", "DB_URL"); ok {
+		cfg.DBURL = v
+	}
+	if v, ok := getWithAliases(lookup, prefix, "NAMESPACE", "DB_NS"); ok {
+		cfg.DBNS = v
+	}
+	if v, ok := getWithAliases(lookup, prefix, "DATABASE", "DB"); ok {
+		cfg.DB = v
+	}
+	if v, ok := getWithAliases(lookup, prefix, "USERNAME", "DB_USER"); ok {
+		u := v
+		cfg.DBUser = &u
+	}
+	if v, ok := getWithAliases(lookup, prefix, "PASSWORD", "DB_PASS"); ok {
+		p := v
+		cfg.DBPass = &p
+	}
+	if v, ok := getWithAliases(lookup, prefix, "TIMEOUT", "DB_TIMEOUT"); ok {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return ConnectionConfig{}, surqlerrors.Wrapf(surqlerrors.ErrValidation, err, "invalid timeout=%q", v)
+		}
+		cfg.DBTimeout = f
+	}
+	if v, ok := getWithAliases(lookup, prefix, "MAX_CONNECTIONS", "DB_MAX_CONNECTIONS"); ok {
+		n, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			return ConnectionConfig{}, surqlerrors.Wrapf(surqlerrors.ErrValidation, err, "invalid max_connections=%q", v)
+		}
+		cfg.DBMaxConnections = uint32(n)
+	}
+	if v, ok := getWithAliases(lookup, prefix, "RETRY_MAX_ATTEMPTS", "DB_RETRY_MAX_ATTEMPTS"); ok {
+		n, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			return ConnectionConfig{}, surqlerrors.Wrapf(surqlerrors.ErrValidation, err, "invalid retry_max_attempts=%q", v)
+		}
+		cfg.DBRetryMaxAttempts = uint32(n)
+	}
+	if v, ok := getWithAliases(lookup, prefix, "RETRY_MIN_WAIT", "DB_RETRY_MIN_WAIT"); ok {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return ConnectionConfig{}, surqlerrors.Wrapf(surqlerrors.ErrValidation, err, "invalid retry_min_wait=%q", v)
+		}
+		cfg.DBRetryMinWait = f
+	}
+	if v, ok := getWithAliases(lookup, prefix, "RETRY_MAX_WAIT", "DB_RETRY_MAX_WAIT"); ok {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return ConnectionConfig{}, surqlerrors.Wrapf(surqlerrors.ErrValidation, err, "invalid retry_max_wait=%q", v)
+		}
+		cfg.DBRetryMaxWait = f
+	}
+	if v, ok := getWithAliases(lookup, prefix, "RETRY_MULTIPLIER", "DB_RETRY_MULTIPLIER"); ok {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return ConnectionConfig{}, surqlerrors.Wrapf(surqlerrors.ErrValidation, err, "invalid retry_multiplier=%q", v)
+		}
+		cfg.DBRetryMultiplier = f
+	}
+	if v, ok := getWithAliases(lookup, prefix, "ENABLE_LIVE_QUERIES"); ok {
+		b, err := parseBool(v)
+		if err != nil {
+			return ConnectionConfig{}, err
+		}
+		cfg.EnableLiveQueries = b
+	}
+	if err := cfg.Validate(); err != nil {
+		return ConnectionConfig{}, err
+	}
+	return cfg, nil
+}
+
+// LoadConfigFromMap is a test-friendly alternative to LoadConfigFromEnv.
+func LoadConfigFromMap(prefix string, m map[string]string) (ConnectionConfig, error) {
+	return LoadConfigFromSource(prefix, func(k string) (string, bool) {
+		v, ok := m[k]
+		return v, ok
+	})
+}
+
+// NamedConnectionConfig is a named ConnectionConfig for multi-DB setups.
+//
+//nolint:revive // Package/field name repetition is intentional for clarity
+type NamedConnectionConfig struct {
+	Name   string           `json:"name"`
+	Config ConnectionConfig `json:"config"`
+}
+
+// LoadNamedConfigFromEnv loads a named connection using prefix SURQL_<NAME>_.
+func LoadNamedConfigFromEnv(name string) (NamedConnectionConfig, error) {
+	prefix := EnvPrefix + strings.ToUpper(name) + "_"
+	cfg, err := LoadConfigFromEnvWithPrefix(prefix)
+	if err != nil {
+		return NamedConnectionConfig{}, err
+	}
+	return NamedConnectionConfig{Name: strings.ToLower(name), Config: cfg}, nil
+}
+
+// LoadNamedConfigFromSource is the test-friendly variant of LoadNamedConfigFromEnv.
+func LoadNamedConfigFromSource(name string, lookup func(string) (string, bool)) (NamedConnectionConfig, error) {
+	prefix := EnvPrefix + strings.ToUpper(name) + "_"
+	cfg, err := LoadConfigFromSource(prefix, lookup)
+	if err != nil {
+		return NamedConnectionConfig{}, err
+	}
+	return NamedConnectionConfig{Name: strings.ToLower(name), Config: cfg}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+func validateURL(url string) error {
+	if url == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "URL cannot be empty")
+	}
+	_, err := detectProtocol(url)
+	return err
+}
+
+func validateIdentifier(value, context string) error {
+	if value == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "Identifier cannot be empty")
+	}
+	for _, r := range value {
+		ok := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-'
+		if !ok {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"Identifier (%s) must be alphanumeric with optional underscores/hyphens", context)
+		}
+	}
+	return nil
+}
+
+func validateNumericRange(name string, value, minVal, maxVal float64) error {
+	if math.IsNaN(value) {
+		return surqlerrors.Newf(surqlerrors.ErrValidation, "%s must be a finite number", name)
+	}
+	if value < minVal {
+		return surqlerrors.Newf(surqlerrors.ErrValidation, "%s must be >= %v", name, minVal)
+	}
+	if value > maxVal {
+		return surqlerrors.Newf(surqlerrors.ErrValidation, "%s must be <= %v", name, maxVal)
+	}
+	return nil
+}
+
+func detectProtocol(url string) (Protocol, error) {
+	trimmed := strings.TrimSpace(url)
+	switch {
+	case strings.HasPrefix(trimmed, "ws://"):
+		if trimmed == "ws://" {
+			return 0, surqlerrors.New(surqlerrors.ErrValidation, "URL host must not be empty")
+		}
+		return ProtocolWebSocket, nil
+	case strings.HasPrefix(trimmed, "wss://"):
+		return ProtocolWebSocketSecure, nil
+	case strings.HasPrefix(trimmed, "http://"):
+		return ProtocolHTTP, nil
+	case strings.HasPrefix(trimmed, "https://"):
+		return ProtocolHTTPS, nil
+	case strings.HasPrefix(trimmed, "mem://"), strings.HasPrefix(trimmed, "memory://"):
+		return ProtocolMemory, nil
+	case strings.HasPrefix(trimmed, "file://"):
+		return ProtocolFile, nil
+	case strings.HasPrefix(trimmed, "surrealkv://"):
+		return ProtocolSurrealKV, nil
+	default:
+		return 0, surqlerrors.New(surqlerrors.ErrValidation,
+			"URL must use one of: ws://, wss://, http://, https://, mem://, memory://, file://, surrealkv://")
+	}
+}
+
+func getWithAliases(lookup func(string) (string, bool), prefix string, keys ...string) (string, bool) {
+	for _, k := range keys {
+		name := prefix + k
+		if v, ok := lookup(name); ok {
+			return v, true
+		}
+		if v, ok := lookup(strings.ToLower(name)); ok {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+func parseBool(s string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "1", "true", "yes", "on":
+		return true, nil
+	case "0", "false", "no", "off":
+		return false, nil
+	default:
+		return false, surqlerrors.Newf(surqlerrors.ErrValidation, "invalid boolean value %q", s)
+	}
+}

--- a/pkg/surql/connection/config_test.go
+++ b/pkg/surql/connection/config_test.go
@@ -1,0 +1,220 @@
+package connection
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestDefaultsAreValid(t *testing.T) {
+	cfg := DefaultConfig()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if cfg.URL() != "ws://localhost:8000/rpc" {
+		t.Errorf("url: %q", cfg.URL())
+	}
+	if cfg.Namespace() != "development" || cfg.Database() != "main" {
+		t.Errorf("ns=%q db=%q", cfg.Namespace(), cfg.Database())
+	}
+	if !cfg.EnableLiveQueries {
+		t.Error("live queries should default to enabled")
+	}
+}
+
+func TestValidateRejectsEmptyURL(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.DBURL = ""
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error")
+	} else if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestValidateRejectsUnsupportedProtocol(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.DBURL = "ftp://localhost"
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestValidateAcceptsEmbeddedProtocols(t *testing.T) {
+	for _, url := range []string{
+		"mem://",
+		"memory://",
+		"file:///tmp/db.sdb",
+		"surrealkv:///tmp/db.skv",
+	} {
+		cfg := DefaultConfig()
+		cfg.DBURL = url
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("%s: %v", url, err)
+		}
+	}
+}
+
+func TestLiveQueriesRejectedOverHTTP(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.DBURL = "https://db.example.com/rpc"
+	cfg.EnableLiveQueries = true
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error")
+	}
+	cfg.EnableLiveQueries = false
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("https with live queries off should be valid: %v", err)
+	}
+}
+
+func TestInvalidIdentifiers(t *testing.T) {
+	for _, bad := range []string{"", "has space", "has/slash", "has!bang"} {
+		cfg := DefaultConfig()
+		cfg.DBNS = bad
+		if err := cfg.Validate(); err == nil {
+			t.Errorf("ns %q should be invalid", bad)
+		}
+	}
+}
+
+func TestRetryMaxMustExceedMin(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.DBRetryMinWait = 5.0
+	cfg.DBRetryMaxWait = 3.0
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestProtocolDetection(t *testing.T) {
+	cases := []struct {
+		url      string
+		protocol Protocol
+	}{
+		{"ws://localhost:8000", ProtocolWebSocket},
+		{"wss://host/rpc", ProtocolWebSocketSecure},
+		{"http://host", ProtocolHTTP},
+		{"https://host", ProtocolHTTPS},
+		{"mem://", ProtocolMemory},
+		{"memory://", ProtocolMemory},
+		{"file:///tmp/db", ProtocolFile},
+		{"surrealkv:///tmp/db", ProtocolSurrealKV},
+	}
+	for _, tc := range cases {
+		cfg := DefaultConfig()
+		cfg.DBURL = tc.url
+		cfg.EnableLiveQueries = tc.protocol.SupportsLiveQueries()
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("%s: validate: %v", tc.url, err)
+		}
+		p, err := cfg.Protocol()
+		if err != nil {
+			t.Fatalf("%s: protocol: %v", tc.url, err)
+		}
+		if p != tc.protocol {
+			t.Errorf("%s: got %v, want %v", tc.url, p, tc.protocol)
+		}
+	}
+}
+
+func TestProtocolHelpers(t *testing.T) {
+	if !ProtocolWebSocket.SupportsLiveQueries() || !ProtocolMemory.SupportsLiveQueries() {
+		t.Error("ws/memory should support live queries")
+	}
+	if ProtocolHTTP.SupportsLiveQueries() || ProtocolHTTPS.SupportsLiveQueries() {
+		t.Error("http(s) should not support live queries")
+	}
+	if !ProtocolMemory.IsEmbedded() {
+		t.Error("memory should be embedded")
+	}
+	if ProtocolWebSocket.IsEmbedded() {
+		t.Error("ws should not be embedded")
+	}
+}
+
+func TestLoadConfigFromMap(t *testing.T) {
+	prefix := "SURQL_TEST_CFG_"
+	env := map[string]string{
+		prefix + "URL":                 "wss://env.example/rpc",
+		prefix + "NAMESPACE":           "envns",
+		prefix + "DATABASE":            "envdb",
+		prefix + "USERNAME":            "envuser",
+		prefix + "TIMEOUT":             "45.5",
+		prefix + "ENABLE_LIVE_QUERIES": "false",
+	}
+	cfg, err := LoadConfigFromMap(prefix, env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.URL() != "wss://env.example/rpc" {
+		t.Errorf("url: %q", cfg.URL())
+	}
+	if cfg.Namespace() != "envns" || cfg.Database() != "envdb" {
+		t.Errorf("ns/db: %q/%q", cfg.Namespace(), cfg.Database())
+	}
+	if cfg.Username() == nil || *cfg.Username() != "envuser" {
+		t.Errorf("username: %v", cfg.Username())
+	}
+	if math.Abs(cfg.Timeout()-45.5) > 1e-9 {
+		t.Errorf("timeout: %v", cfg.Timeout())
+	}
+	if cfg.EnableLiveQueries {
+		t.Error("enable_live_queries should be false")
+	}
+}
+
+func TestLoadConfigAcceptsLegacyAliases(t *testing.T) {
+	prefix := "SURQL_LEGACY_"
+	env := map[string]string{
+		prefix + "DB_URL":  "ws://legacy.example/rpc",
+		prefix + "DB_NS":   "legns",
+		prefix + "DB":      "legdb",
+		prefix + "DB_USER": "leguser",
+		prefix + "DB_PASS": "legpass",
+	}
+	cfg, err := LoadConfigFromMap(prefix, env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.URL() != "ws://legacy.example/rpc" {
+		t.Errorf("url: %q", cfg.URL())
+	}
+	if cfg.Namespace() != "legns" || cfg.Database() != "legdb" {
+		t.Errorf("ns/db: %q/%q", cfg.Namespace(), cfg.Database())
+	}
+	if cfg.Password() == nil || *cfg.Password() != "legpass" {
+		t.Errorf("password: %v", cfg.Password())
+	}
+}
+
+func TestLoadNamedConfigFromSource(t *testing.T) {
+	prefix := "SURQL_PRIMARY_"
+	env := map[string]string{
+		prefix + "URL":       "ws://primary.example/rpc",
+		prefix + "NAMESPACE": "pns",
+		prefix + "DATABASE":  "pdb",
+	}
+	named, err := LoadNamedConfigFromSource("primary", func(k string) (string, bool) {
+		v, ok := env[k]
+		return v, ok
+	})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if named.Name != "primary" {
+		t.Errorf("name: %q", named.Name)
+	}
+	if named.Config.URL() != "ws://primary.example/rpc" {
+		t.Errorf("url: %q", named.Config.URL())
+	}
+}
+
+func TestLoadConfigInvalidTimeout(t *testing.T) {
+	_, err := LoadConfigFromMap("X_", map[string]string{"X_TIMEOUT": "not-a-float"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/pkg/surql/connection/doc.go
+++ b/pkg/surql/connection/doc.go
@@ -1,0 +1,10 @@
+// Package connection exposes pure-data types describing how to connect
+// and authenticate to SurrealDB: ConnectionConfig (URL / namespace /
+// database / timeouts / retries / live-queries flag), NamedConnectionConfig,
+// and the four credential kinds (Root / Namespace / Database / Scope)
+// plus JWT TokenAuth.
+//
+// It is a 1:1 port of surql-py/src/surql/connection/{config,auth}.py. The
+// runtime DatabaseClient and AuthManager (which wrap the SurrealDB SDK
+// and handle signin / signup / live queries) land in a follow-up PR.
+package connection

--- a/pkg/surql/doc.go
+++ b/pkg/surql/doc.go
@@ -1,0 +1,9 @@
+// Package surql is the Go port of oneiriq-surql (Python) and @oneiriq/surql
+// (TypeScript/Deno): a code-first database toolkit for SurrealDB covering
+// schema definitions, migrations, query building, and typed CRUD.
+//
+// This root package is an umbrella for the library's public subpackages
+// (types, errors, and -- as the port progresses -- connection, query,
+// schema, migration, cache, and orchestration). The goal is 1:1 feature
+// parity with the Python and TypeScript implementations.
+package surql

--- a/pkg/surql/errors/errors.go
+++ b/pkg/surql/errors/errors.go
@@ -1,0 +1,132 @@
+// Package errors defines the unified error hierarchy for the surql library.
+//
+// It follows idiomatic Go error handling: sentinel errors for the high-level
+// categories (used with errors.Is) plus typed error structs carrying
+// structured context (used with errors.As). Every fallible operation in
+// surql returns an error built on one of these roots.
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors. Use errors.Is to test membership.
+var (
+	// ErrDatabase is the root for all database-level failures.
+	ErrDatabase = errors.New("database error")
+	// ErrConnection indicates a connection failed, timed out, or closed.
+	ErrConnection = errors.New("connection error")
+	// ErrQuery indicates a query failed at the database or during decoding.
+	ErrQuery = errors.New("query error")
+	// ErrTransaction indicates a transaction lifecycle failure.
+	ErrTransaction = errors.New("transaction error")
+	// ErrContext indicates a missing or misconfigured ambient connection context.
+	ErrContext = errors.New("context error")
+	// ErrRegistry indicates a named-connection registry failure.
+	ErrRegistry = errors.New("registry error")
+	// ErrStreaming indicates a live/streaming query failure.
+	ErrStreaming = errors.New("streaming error")
+	// ErrValidation indicates invalid input or malformed identifier.
+	ErrValidation = errors.New("validation error")
+	// ErrSchemaParse indicates the schema parser could not interpret input.
+	ErrSchemaParse = errors.New("schema parse error")
+	// ErrMigrationDiscovery indicates a migration file discovery failure.
+	ErrMigrationDiscovery = errors.New("migration discovery error")
+	// ErrMigrationLoad indicates loading an individual migration failed.
+	ErrMigrationLoad = errors.New("migration load error")
+	// ErrMigrationGeneration indicates migration generation failed.
+	ErrMigrationGeneration = errors.New("migration generation error")
+	// ErrMigrationExecution indicates executing a migration failed.
+	ErrMigrationExecution = errors.New("migration execution error")
+	// ErrMigrationHistory indicates a migration history failure.
+	ErrMigrationHistory = errors.New("migration history error")
+	// ErrMigrationSquash indicates migration squashing failed.
+	ErrMigrationSquash = errors.New("migration squash error")
+	// ErrOrchestration indicates a multi-environment orchestration failure.
+	ErrOrchestration = errors.New("orchestration error")
+	// ErrSerialization indicates JSON encode/decode failure.
+	ErrSerialization = errors.New("serialization error")
+)
+
+// SurqlError is the typed error returned by surql operations. It wraps
+// one of the sentinels (available via Unwrap / errors.Is) with a
+// human-readable reason and an optional inner error.
+type SurqlError struct {
+	Kind    error
+	Reason  string
+	Wrapped error
+}
+
+// Error returns a formatted error string.
+func (e *SurqlError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Reason == "" && e.Wrapped == nil {
+		if e.Kind != nil {
+			return e.Kind.Error()
+		}
+		return "surql: unknown error"
+	}
+	kind := "surql error"
+	if e.Kind != nil {
+		kind = e.Kind.Error()
+	}
+	switch {
+	case e.Reason != "" && e.Wrapped != nil:
+		return fmt.Sprintf("%s: %s: %v", kind, e.Reason, e.Wrapped)
+	case e.Reason != "":
+		return fmt.Sprintf("%s: %s", kind, e.Reason)
+	default:
+		return fmt.Sprintf("%s: %v", kind, e.Wrapped)
+	}
+}
+
+// Unwrap returns the next error in the chain. If a wrapped error exists
+// it is preferred (preserving cause chains); otherwise the sentinel kind
+// is returned so that errors.Is works.
+func (e *SurqlError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	if e.Wrapped != nil {
+		return e.Wrapped
+	}
+	return e.Kind
+}
+
+// Is reports whether target matches this error's kind or wrapped chain.
+func (e *SurqlError) Is(target error) bool {
+	if e == nil {
+		return target == nil
+	}
+	if e.Kind != nil && errors.Is(e.Kind, target) {
+		return true
+	}
+	if e.Wrapped != nil && errors.Is(e.Wrapped, target) {
+		return true
+	}
+	return false
+}
+
+// New constructs a SurqlError with the given sentinel kind and reason.
+func New(kind error, reason string) *SurqlError {
+	return &SurqlError{Kind: kind, Reason: reason}
+}
+
+// Wrap constructs a SurqlError that wraps an existing error with an added
+// sentinel kind and contextual reason.
+func Wrap(kind error, reason string, err error) *SurqlError {
+	return &SurqlError{Kind: kind, Reason: reason, Wrapped: err}
+}
+
+// Newf constructs a SurqlError with fmt.Sprintf-style formatting.
+func Newf(kind error, format string, args ...any) *SurqlError {
+	return &SurqlError{Kind: kind, Reason: fmt.Sprintf(format, args...)}
+}
+
+// Wrapf constructs a SurqlError that wraps err with fmt.Sprintf-style context.
+func Wrapf(kind error, err error, format string, args ...any) *SurqlError {
+	return &SurqlError{Kind: kind, Reason: fmt.Sprintf(format, args...), Wrapped: err}
+}

--- a/pkg/surql/errors/errors_test.go
+++ b/pkg/surql/errors/errors_test.go
@@ -1,0 +1,102 @@
+package errors
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+func TestNew_IncludesReason(t *testing.T) {
+	err := New(ErrQuery, "missing table")
+	if err.Error() != "query error: missing table" {
+		t.Errorf("got %q", err.Error())
+	}
+}
+
+func TestWrap_FormatsChain(t *testing.T) {
+	err := Wrap(ErrConnection, "dialing", io.EOF)
+	want := "connection error: dialing: EOF"
+	if err.Error() != want {
+		t.Errorf("got %q, want %q", err.Error(), want)
+	}
+}
+
+func TestIs_MatchesSentinel(t *testing.T) {
+	err := New(ErrValidation, "bad input")
+	if !errors.Is(err, ErrValidation) {
+		t.Error("expected errors.Is(err, ErrValidation) to be true")
+	}
+	if errors.Is(err, ErrQuery) {
+		t.Error("unexpected match on unrelated sentinel")
+	}
+}
+
+func TestIs_MatchesWrappedChain(t *testing.T) {
+	inner := errors.New("inner")
+	err := Wrap(ErrQuery, "outer", inner)
+	if !errors.Is(err, inner) {
+		t.Error("expected errors.Is to see inner in chain")
+	}
+	if !errors.Is(err, ErrQuery) {
+		t.Error("expected errors.Is to see sentinel kind")
+	}
+}
+
+func TestAs_ReturnsTypedError(t *testing.T) {
+	err := error(Wrap(ErrQuery, "outer", io.EOF))
+	var se *SurqlError
+	if !errors.As(err, &se) {
+		t.Fatal("expected errors.As to extract SurqlError")
+	}
+	if se.Kind != ErrQuery {
+		t.Errorf("expected Kind ErrQuery, got %v", se.Kind)
+	}
+}
+
+func TestUnwrap_PrefersWrapped(t *testing.T) {
+	err := Wrap(ErrQuery, "ctx", io.EOF)
+	if errors.Unwrap(err) != io.EOF {
+		t.Errorf("expected Unwrap to return io.EOF, got %v", errors.Unwrap(err))
+	}
+}
+
+func TestUnwrap_FallsBackToKind(t *testing.T) {
+	err := New(ErrQuery, "ctx")
+	if errors.Unwrap(err) != ErrQuery {
+		t.Errorf("expected Unwrap to return ErrQuery, got %v", errors.Unwrap(err))
+	}
+}
+
+func TestNewf_Formats(t *testing.T) {
+	err := Newf(ErrValidation, "bad %s (%d)", "field", 42)
+	if err.Error() != "validation error: bad field (42)" {
+		t.Errorf("got %q", err.Error())
+	}
+}
+
+func TestWrapf_Formats(t *testing.T) {
+	err := Wrapf(ErrQuery, io.EOF, "decoding %s", "row")
+	if err.Error() != "query error: decoding row: EOF" {
+		t.Errorf("got %q", err.Error())
+	}
+}
+
+func TestNilError_HandlesGracefully(t *testing.T) {
+	var e *SurqlError
+	if e.Error() != "<nil>" {
+		t.Errorf("got %q", e.Error())
+	}
+	if e.Unwrap() != nil {
+		t.Error("nil Unwrap should be nil")
+	}
+	if !e.Is(nil) {
+		t.Error("nil should match nil target")
+	}
+}
+
+func TestError_NoReasonOrWrapped_FallsBackToKind(t *testing.T) {
+	e := &SurqlError{Kind: ErrDatabase}
+	if e.Error() != "database error" {
+		t.Errorf("got %q", e.Error())
+	}
+}

--- a/pkg/surql/migration/diff.go
+++ b/pkg/surql/migration/diff.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
 	"github.com/albedosehen/surql-go/pkg/surql/schema"
@@ -32,16 +33,29 @@ var safeDefaultPattern = regexp.MustCompile(
 		`)$`,
 )
 
-// SchemaSnapshot is a whole-schema view consumed by DiffSchemas. It carries
-// the ordered set of tables and edges that make up a schema revision (code
-// side) or the remote database state.
+// SchemaSnapshot is a point-in-time view of a SurrealDB schema.
 //
-// The snapshot deliberately mirrors the shape of surql-py's implicit "list of
-// tables + list of edges" contract rather than introducing a new Python
-// concept; it simply gives the Go port a concrete type to compare against.
+// In its simplest form (empty Version / Timestamp / Description / Accesses)
+// it is the whole-schema comparison input consumed by DiffSchemas; the Tables
+// and Edges slices drive the code-vs-db comparison.
+//
+// When used via the versioning API (CreateSnapshot / StoreSnapshot /
+// LoadSnapshot) the remaining fields record snapshot provenance:
+//
+//   - Version identifies the snapshot (YYYYMMDD_HHMMSS timestamp).
+//   - Timestamp is the UTC creation time.
+//   - Description is a human-readable summary.
+//   - Accesses holds DEFINE ACCESS definitions present at this point.
+//
+// The type is JSON-serialisable; fields with no semantic content are emitted
+// with `omitempty` so the DiffSchemas contract is preserved.
 type SchemaSnapshot struct {
-	Tables []schema.TableDefinition
-	Edges  []schema.EdgeDefinition
+	Version     string                    `json:"version,omitempty"`
+	Timestamp   time.Time                 `json:"timestamp,omitempty"`
+	Description string                    `json:"description,omitempty"`
+	Tables      []schema.TableDefinition  `json:"tables,omitempty"`
+	Edges       []schema.EdgeDefinition   `json:"edges,omitempty"`
+	Accesses    []schema.AccessDefinition `json:"accesses,omitempty"`
 }
 
 // validateEventExpression rejects event condition or action expressions that

--- a/pkg/surql/migration/diff.go
+++ b/pkg/surql/migration/diff.go
@@ -1,0 +1,898 @@
+package migration
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/schema"
+)
+
+// safeDefaultPattern mirrors the Python _SAFE_DEFAULT_PATTERN. It matches
+// SurrealDB default-value expressions that are safe to interpolate into a
+// DEFINE FIELD statement or a backfill UPDATE:
+//
+//   - function calls (e.g. time::now(), rand::uuid())
+//   - numeric literals (42, 3.14, -1)
+//   - boolean literals (true, false)
+//   - NONE / NULL sentinels
+//   - single-quoted strings
+//   - parameter references ($session_id)
+var safeDefaultPattern = regexp.MustCompile(
+	`^(` +
+		`[a-zA-Z_][a-zA-Z0-9_]*(?:::[a-zA-Z_][a-zA-Z0-9_]*)*\([^;]*\)` + // function calls
+		`|-?\d+(?:\.\d+)?` + // numeric literals
+		`|true|false` + // boolean literals
+		`|NONE|NULL` + // null sentinels
+		`|'(?:[^'\\]|\\.)*'` + // single-quoted strings
+		`|\$[a-zA-Z_][a-zA-Z0-9_]*` + // parameter references
+		`)$`,
+)
+
+// SchemaSnapshot is a whole-schema view consumed by DiffSchemas. It carries
+// the ordered set of tables and edges that make up a schema revision (code
+// side) or the remote database state.
+//
+// The snapshot deliberately mirrors the shape of surql-py's implicit "list of
+// tables + list of edges" contract rather than introducing a new Python
+// concept; it simply gives the Go port a concrete type to compare against.
+type SchemaSnapshot struct {
+	Tables []schema.TableDefinition
+	Edges  []schema.EdgeDefinition
+}
+
+// validateEventExpression rejects event condition or action expressions that
+// smell like SQL injection attempts (statement separators, SQL comments).
+func validateEventExpression(expr, label string) error {
+	stripped := strings.TrimSpace(expr)
+	if strings.Contains(stripped, "; ") ||
+		strings.Contains(stripped, ";--") ||
+		strings.HasSuffix(stripped, ";") {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"unsafe event %s: %q must not contain statement separators", label, expr)
+	}
+	if strings.Contains(stripped, "--") {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"unsafe event %s: %q must not contain SQL comments", label, expr)
+	}
+	return nil
+}
+
+// validateDefaultValue ensures a field default / value expression matches the
+// safe-default allow-list. Returns ErrValidation when the default could be
+// used as an SQL injection vector.
+func validateDefaultValue(expr string) error {
+	if !safeDefaultPattern.MatchString(strings.TrimSpace(expr)) {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"unsafe default value expression: %q; defaults must be function calls, literals, or parameter references",
+			expr)
+	}
+	return nil
+}
+
+// DiffTables compares two TableDefinition snapshots and returns the list of
+// SchemaDiff operations needed to evolve old -> new.
+//
+// Passing nil for old produces ADD diffs (table, fields, indexes, events,
+// permissions) while nil for new yields a single DROP diff. When both are
+// non-nil, field / index / event / permission diffs are produced.
+func DiffTables(oldTable, newTable *schema.TableDefinition) ([]SchemaDiff, error) {
+	switch {
+	case oldTable == nil && newTable != nil:
+		return generateAddTableDiffs(*newTable)
+	case oldTable != nil && newTable == nil:
+		return []SchemaDiff{generateDropTableDiff(*oldTable)}, nil
+	case oldTable != nil && newTable != nil:
+		diffs := make([]SchemaDiff, 0)
+		fieldDiffs, err := DiffFields(*oldTable, *newTable)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, fieldDiffs...)
+
+		idxDiffs, err := DiffIndexes(*oldTable, *newTable)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, idxDiffs...)
+
+		evtDiffs, err := DiffEvents(*oldTable, *newTable)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, evtDiffs...)
+
+		diffs = append(diffs, DiffPermissions(*oldTable, *newTable)...)
+		return diffs, nil
+	}
+	return nil, nil
+}
+
+// DiffFields computes per-field differences between two tables. The diff uses
+// structural field equality (name, type, assertion, default, value, readonly,
+// flexible) and produces ADD / DROP / MODIFY entries in a stable order
+// (additions in new-table order, drops in old-table order, modifications in
+// sorted field-name order).
+func DiffFields(oldTable, newTable schema.TableDefinition) ([]SchemaDiff, error) {
+	oldFields := make(map[string]schema.FieldDefinition, len(oldTable.Fields))
+	for _, f := range oldTable.Fields {
+		oldFields[f.Name] = f
+	}
+	newFields := make(map[string]schema.FieldDefinition, len(newTable.Fields))
+	for _, f := range newTable.Fields {
+		newFields[f.Name] = f
+	}
+
+	diffs := make([]SchemaDiff, 0)
+
+	// Added: iterate in new-table order for determinism.
+	for _, f := range newTable.Fields {
+		if _, ok := oldFields[f.Name]; ok {
+			continue
+		}
+		d, err := generateAddFieldDiff(newTable.Name, f)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+
+	// Dropped: iterate in old-table order.
+	for _, f := range oldTable.Fields {
+		if _, ok := newFields[f.Name]; ok {
+			continue
+		}
+		d, err := generateDropFieldDiff(newTable.Name, f)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+
+	// Modified: intersection in sorted order for deterministic output.
+	intersect := make([]string, 0)
+	for name := range oldFields {
+		if _, ok := newFields[name]; ok {
+			intersect = append(intersect, name)
+		}
+	}
+	sort.Strings(intersect)
+	for _, name := range intersect {
+		oldF := oldFields[name]
+		newF := newFields[name]
+		if fieldsEqual(oldF, newF) {
+			continue
+		}
+		d, err := generateModifyFieldDiff(newTable.Name, oldF, newF)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+
+	return diffs, nil
+}
+
+// DiffIndexes computes per-index differences between two tables. Indexes are
+// keyed by name; MTREE and HNSW flavours produce their specialised DEFINE
+// INDEX statements.
+func DiffIndexes(oldTable, newTable schema.TableDefinition) ([]SchemaDiff, error) {
+	oldIdx := make(map[string]schema.IndexDefinition, len(oldTable.Indexes))
+	for _, i := range oldTable.Indexes {
+		oldIdx[i.Name] = i
+	}
+	newIdx := make(map[string]schema.IndexDefinition, len(newTable.Indexes))
+	for _, i := range newTable.Indexes {
+		newIdx[i.Name] = i
+	}
+
+	diffs := make([]SchemaDiff, 0)
+
+	for _, idx := range newTable.Indexes {
+		if _, ok := oldIdx[idx.Name]; ok {
+			continue
+		}
+		d, err := generateAddIndexDiff(newTable.Name, idx)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+
+	for _, idx := range oldTable.Indexes {
+		if _, ok := newIdx[idx.Name]; ok {
+			continue
+		}
+		d, err := generateDropIndexDiff(newTable.Name, idx)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+
+	return diffs, nil
+}
+
+// DiffEvents computes per-event differences between two tables. Event
+// expressions are validated against the safe-expression allow-list; an unsafe
+// expression returns ErrValidation.
+func DiffEvents(oldTable, newTable schema.TableDefinition) ([]SchemaDiff, error) {
+	oldEv := make(map[string]schema.EventDefinition, len(oldTable.Events))
+	for _, e := range oldTable.Events {
+		oldEv[e.Name] = e
+	}
+	newEv := make(map[string]schema.EventDefinition, len(newTable.Events))
+	for _, e := range newTable.Events {
+		newEv[e.Name] = e
+	}
+
+	diffs := make([]SchemaDiff, 0)
+
+	for _, ev := range newTable.Events {
+		if _, ok := oldEv[ev.Name]; ok {
+			continue
+		}
+		d, err := generateAddEventDiff(newTable.Name, ev)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+
+	for _, ev := range oldTable.Events {
+		if _, ok := newEv[ev.Name]; ok {
+			continue
+		}
+		d, err := generateDropEventDiff(newTable.Name, ev)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+
+	return diffs, nil
+}
+
+// DiffPermissions compares the permission map of two tables and returns a
+// single MODIFY_PERMISSIONS diff when they differ (or an empty slice when
+// they match). Forward SQL reflects the new permissions; backward SQL the
+// old. The empty map and a nil map compare equal.
+func DiffPermissions(oldTable, newTable schema.TableDefinition) []SchemaDiff {
+	if permissionsEqual(oldTable.Permissions, newTable.Permissions) {
+		return nil
+	}
+	return []SchemaDiff{
+		generateModifyPermissionsDiff(newTable.Name, newTable.Permissions, oldTable.Permissions),
+	}
+}
+
+// DiffEdges compares two EdgeDefinition snapshots by delegating the field,
+// index, event, and permission comparisons to the table diff helpers via a
+// TableDefinition adapter. Adding or dropping an edge produces the full
+// suite of child diffs (not just a DROP TABLE).
+func DiffEdges(oldEdge, newEdge *schema.EdgeDefinition) ([]SchemaDiff, error) {
+	switch {
+	case oldEdge == nil && newEdge != nil:
+		return generateAddEdgeDiffs(*newEdge)
+	case oldEdge != nil && newEdge == nil:
+		return []SchemaDiff{generateDropEdgeDiff(*oldEdge)}, nil
+	case oldEdge != nil && newEdge != nil:
+		oldProxy := edgeToTableProxy(*oldEdge)
+		newProxy := edgeToTableProxy(*newEdge)
+
+		diffs := make([]SchemaDiff, 0)
+		fieldDiffs, err := DiffFields(oldProxy, newProxy)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, fieldDiffs...)
+
+		idxDiffs, err := DiffIndexes(oldProxy, newProxy)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, idxDiffs...)
+
+		evtDiffs, err := DiffEvents(oldProxy, newProxy)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, evtDiffs...)
+
+		diffs = append(diffs, DiffPermissions(oldProxy, newProxy)...)
+		return diffs, nil
+	}
+	return nil, nil
+}
+
+// DiffSchemas aggregates DiffTables and DiffEdges across two whole snapshots.
+// Tables and edges are matched by name; the "code" side is treated as the
+// desired state and the "db" side as the current state, so ADD diffs refer
+// to entries present in code but missing in db.
+//
+// The returned slice is ordered: added tables, dropped tables, modified
+// tables (in sorted name order), then the same for edges. Within each entry
+// the child ordering mirrors DiffTables / DiffEdges.
+func DiffSchemas(code, db SchemaSnapshot) ([]SchemaDiff, error) {
+	codeTables := make(map[string]schema.TableDefinition, len(code.Tables))
+	for _, t := range code.Tables {
+		codeTables[t.Name] = t
+	}
+	dbTables := make(map[string]schema.TableDefinition, len(db.Tables))
+	for _, t := range db.Tables {
+		dbTables[t.Name] = t
+	}
+
+	diffs := make([]SchemaDiff, 0)
+
+	// Added tables (code but not db).
+	for _, t := range code.Tables {
+		if _, ok := dbTables[t.Name]; ok {
+			continue
+		}
+		added, err := DiffTables(nil, tablePtr(t))
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, added...)
+	}
+
+	// Dropped tables (db but not code).
+	for _, t := range db.Tables {
+		if _, ok := codeTables[t.Name]; ok {
+			continue
+		}
+		dropped, err := DiffTables(tablePtr(t), nil)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, dropped...)
+	}
+
+	// Modified tables (present on both sides).
+	intersectT := make([]string, 0)
+	for name := range dbTables {
+		if _, ok := codeTables[name]; ok {
+			intersectT = append(intersectT, name)
+		}
+	}
+	sort.Strings(intersectT)
+	for _, name := range intersectT {
+		oldT := dbTables[name]
+		newT := codeTables[name]
+		modified, err := DiffTables(&oldT, &newT)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, modified...)
+	}
+
+	codeEdges := make(map[string]schema.EdgeDefinition, len(code.Edges))
+	for _, e := range code.Edges {
+		codeEdges[e.Name] = e
+	}
+	dbEdges := make(map[string]schema.EdgeDefinition, len(db.Edges))
+	for _, e := range db.Edges {
+		dbEdges[e.Name] = e
+	}
+
+	for _, e := range code.Edges {
+		if _, ok := dbEdges[e.Name]; ok {
+			continue
+		}
+		added, err := DiffEdges(nil, edgePtr(e))
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, added...)
+	}
+
+	for _, e := range db.Edges {
+		if _, ok := codeEdges[e.Name]; ok {
+			continue
+		}
+		dropped, err := DiffEdges(edgePtr(e), nil)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, dropped...)
+	}
+
+	intersectE := make([]string, 0)
+	for name := range dbEdges {
+		if _, ok := codeEdges[name]; ok {
+			intersectE = append(intersectE, name)
+		}
+	}
+	sort.Strings(intersectE)
+	for _, name := range intersectE {
+		oldE := dbEdges[name]
+		newE := codeEdges[name]
+		modified, err := DiffEdges(&oldE, &newE)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, modified...)
+	}
+
+	return diffs, nil
+}
+
+// --- internal helpers ---
+
+func tablePtr(t schema.TableDefinition) *schema.TableDefinition { return &t }
+func edgePtr(e schema.EdgeDefinition) *schema.EdgeDefinition    { return &e }
+
+func edgeToTableProxy(e schema.EdgeDefinition) schema.TableDefinition {
+	return schema.TableDefinition{
+		Name:        e.Name,
+		Fields:      append([]schema.FieldDefinition(nil), e.Fields...),
+		Indexes:     append([]schema.IndexDefinition(nil), e.Indexes...),
+		Events:      append([]schema.EventDefinition(nil), e.Events...),
+		Permissions: copyPermissions(e.Permissions),
+	}
+}
+
+func copyPermissions(p map[string]string) map[string]string {
+	if p == nil {
+		return nil
+	}
+	out := make(map[string]string, len(p))
+	for k, v := range p {
+		out[k] = v
+	}
+	return out
+}
+
+func permissionsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || bv != v {
+			return false
+		}
+	}
+	return true
+}
+
+func fieldsEqual(a, b schema.FieldDefinition) bool {
+	return a.Name == b.Name &&
+		a.Type == b.Type &&
+		a.Assertion == b.Assertion &&
+		a.Default == b.Default &&
+		a.Value == b.Value &&
+		a.ReadOnly == b.ReadOnly &&
+		a.Flexible == b.Flexible
+}
+
+func generateAddTableDiffs(t schema.TableDefinition) ([]SchemaDiff, error) {
+	mode := string(t.Mode)
+	if mode == "" {
+		mode = string(schema.TableModeSchemafull)
+	}
+	diffs := make([]SchemaDiff, 0, 1+len(t.Fields)+len(t.Indexes)+len(t.Events)+1)
+	diffs = append(diffs, SchemaDiff{
+		Operation:   DiffOperationAddTable,
+		Table:       t.Name,
+		Description: fmt.Sprintf("Add table %s", t.Name),
+		ForwardSQL:  fmt.Sprintf("DEFINE TABLE %s %s;", t.Name, mode),
+		BackwardSQL: fmt.Sprintf("REMOVE TABLE %s;", t.Name),
+	})
+
+	for _, f := range t.Fields {
+		d, err := generateAddFieldDiff(t.Name, f)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+	for _, i := range t.Indexes {
+		d, err := generateAddIndexDiff(t.Name, i)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+	for _, e := range t.Events {
+		d, err := generateAddEventDiff(t.Name, e)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+	if len(t.Permissions) > 0 {
+		diffs = append(diffs, generateModifyPermissionsDiff(t.Name, t.Permissions, nil))
+	}
+	return diffs, nil
+}
+
+func generateDropTableDiff(t schema.TableDefinition) SchemaDiff {
+	mode := string(t.Mode)
+	if mode == "" {
+		mode = string(schema.TableModeSchemafull)
+	}
+	return SchemaDiff{
+		Operation:   DiffOperationDropTable,
+		Table:       t.Name,
+		Description: fmt.Sprintf("Drop table %s", t.Name),
+		ForwardSQL:  fmt.Sprintf("REMOVE TABLE %s;", t.Name),
+		BackwardSQL: fmt.Sprintf("DEFINE TABLE %s %s;", t.Name, mode),
+	}
+}
+
+func generateAddFieldDiff(tableName string, f schema.FieldDefinition) (SchemaDiff, error) {
+	forwardSQL, err := fieldToSQL(tableName, f)
+	if err != nil {
+		return SchemaDiff{}, err
+	}
+	if f.Default != "" {
+		if err := validateDefaultValue(f.Default); err != nil {
+			return SchemaDiff{}, err
+		}
+		forwardSQL = fmt.Sprintf(
+			"%s\nUPDATE %s SET %s = %s WHERE %s IS NONE;",
+			forwardSQL, tableName, f.Name, f.Default, f.Name,
+		)
+	}
+	return SchemaDiff{
+		Operation:   DiffOperationAddField,
+		Table:       tableName,
+		Field:       f.Name,
+		Description: fmt.Sprintf("Add field %s to %s", f.Name, tableName),
+		ForwardSQL:  forwardSQL,
+		BackwardSQL: fmt.Sprintf("REMOVE FIELD %s ON TABLE %s;", f.Name, tableName),
+		Details:     map[string]any{"type": string(f.Type)},
+	}, nil
+}
+
+func generateDropFieldDiff(tableName string, f schema.FieldDefinition) (SchemaDiff, error) {
+	backwardSQL, err := fieldToSQL(tableName, f)
+	if err != nil {
+		return SchemaDiff{}, err
+	}
+	return SchemaDiff{
+		Operation:   DiffOperationDropField,
+		Table:       tableName,
+		Field:       f.Name,
+		Description: fmt.Sprintf("Drop field %s from %s", f.Name, tableName),
+		ForwardSQL:  fmt.Sprintf("REMOVE FIELD %s ON TABLE %s;", f.Name, tableName),
+		BackwardSQL: backwardSQL,
+	}, nil
+}
+
+func generateModifyFieldDiff(tableName string, oldF, newF schema.FieldDefinition) (SchemaDiff, error) {
+	forwardSQL, err := fieldToSQL(tableName, newF)
+	if err != nil {
+		return SchemaDiff{}, err
+	}
+	backwardSQL, err := fieldToSQL(tableName, oldF)
+	if err != nil {
+		return SchemaDiff{}, err
+	}
+	return SchemaDiff{
+		Operation:   DiffOperationModifyField,
+		Table:       tableName,
+		Field:       newF.Name,
+		Description: fmt.Sprintf("Modify field %s in %s", newF.Name, tableName),
+		ForwardSQL:  forwardSQL,
+		BackwardSQL: backwardSQL,
+		Details: map[string]any{
+			"old_type": string(oldF.Type),
+			"new_type": string(newF.Type),
+		},
+	}, nil
+}
+
+func generateAddIndexDiff(tableName string, idx schema.IndexDefinition) (SchemaDiff, error) {
+	forwardSQL, err := indexToSQL(tableName, idx)
+	if err != nil {
+		return SchemaDiff{}, err
+	}
+	return SchemaDiff{
+		Operation:   DiffOperationAddIndex,
+		Table:       tableName,
+		Index:       idx.Name,
+		Description: fmt.Sprintf("Add index %s to %s", idx.Name, tableName),
+		ForwardSQL:  forwardSQL,
+		BackwardSQL: fmt.Sprintf("REMOVE INDEX %s ON TABLE %s;", idx.Name, tableName),
+	}, nil
+}
+
+func generateDropIndexDiff(tableName string, idx schema.IndexDefinition) (SchemaDiff, error) {
+	backwardSQL, err := indexToSQL(tableName, idx)
+	if err != nil {
+		return SchemaDiff{}, err
+	}
+	return SchemaDiff{
+		Operation:   DiffOperationDropIndex,
+		Table:       tableName,
+		Index:       idx.Name,
+		Description: fmt.Sprintf("Drop index %s from %s", idx.Name, tableName),
+		ForwardSQL:  fmt.Sprintf("REMOVE INDEX %s ON TABLE %s;", idx.Name, tableName),
+		BackwardSQL: backwardSQL,
+	}, nil
+}
+
+func generateAddEventDiff(tableName string, ev schema.EventDefinition) (SchemaDiff, error) {
+	if err := validateEventExpression(ev.Condition, "condition"); err != nil {
+		return SchemaDiff{}, err
+	}
+	if err := validateEventExpression(ev.Action, "action"); err != nil {
+		return SchemaDiff{}, err
+	}
+	return SchemaDiff{
+		Operation: DiffOperationAddEvent,
+		Table:     tableName,
+		Event:     ev.Name,
+		Description: fmt.Sprintf(
+			"Add event %s to %s", ev.Name, tableName,
+		),
+		ForwardSQL: fmt.Sprintf(
+			"DEFINE EVENT %s ON TABLE %s WHEN %s THEN { %s };",
+			ev.Name, tableName, ev.Condition, ev.Action,
+		),
+		BackwardSQL: fmt.Sprintf("REMOVE EVENT %s ON TABLE %s;", ev.Name, tableName),
+	}, nil
+}
+
+func generateDropEventDiff(tableName string, ev schema.EventDefinition) (SchemaDiff, error) {
+	if err := validateEventExpression(ev.Condition, "condition"); err != nil {
+		return SchemaDiff{}, err
+	}
+	if err := validateEventExpression(ev.Action, "action"); err != nil {
+		return SchemaDiff{}, err
+	}
+	return SchemaDiff{
+		Operation:   DiffOperationDropEvent,
+		Table:       tableName,
+		Event:       ev.Name,
+		Description: fmt.Sprintf("Drop event %s from %s", ev.Name, tableName),
+		ForwardSQL:  fmt.Sprintf("REMOVE EVENT %s ON TABLE %s;", ev.Name, tableName),
+		BackwardSQL: fmt.Sprintf(
+			"DEFINE EVENT %s ON TABLE %s WHEN %s THEN { %s };",
+			ev.Name, tableName, ev.Condition, ev.Action,
+		),
+	}, nil
+}
+
+// generateModifyPermissionsDiff renders a single MODIFY_PERMISSIONS diff.
+// Forward SQL is the concatenation of DEFINE FIELD PERMISSIONS statements for
+// permissions (the desired state); backward SQL reproduces old_permissions.
+// Keys are emitted in sorted order for stable output.
+func generateModifyPermissionsDiff(tableName string, permissions, oldPermissions map[string]string) SchemaDiff {
+	return SchemaDiff{
+		Operation:   DiffOperationModifyPermissions,
+		Table:       tableName,
+		Description: fmt.Sprintf("Modify permissions for %s", tableName),
+		ForwardSQL:  permissionsToSQL(tableName, permissions),
+		BackwardSQL: permissionsToSQL(tableName, oldPermissions),
+	}
+}
+
+func permissionsToSQL(tableName string, permissions map[string]string) string {
+	if len(permissions) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(permissions))
+	for k := range permissions {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, op := range keys {
+		parts = append(parts, fmt.Sprintf(
+			"DEFINE FIELD PERMISSIONS FOR %s ON TABLE %s WHERE %s;",
+			strings.ToUpper(op), tableName, permissions[op],
+		))
+	}
+	return strings.Join(parts, " ")
+}
+
+func generateAddEdgeDiffs(e schema.EdgeDefinition) ([]SchemaDiff, error) {
+	diffs := make([]SchemaDiff, 0, 1+len(e.Fields)+len(e.Indexes)+len(e.Events))
+
+	var forwardSQL string
+	switch e.Mode {
+	case schema.EdgeModeRelation:
+		forwardSQL = fmt.Sprintf("DEFINE TABLE %s TYPE RELATION", e.Name)
+		if e.FromTable != "" {
+			forwardSQL += " FROM " + e.FromTable
+		}
+		if e.ToTable != "" {
+			forwardSQL += " TO " + e.ToTable
+		}
+		forwardSQL += ";"
+	case schema.EdgeModeSchemafull:
+		forwardSQL = fmt.Sprintf("DEFINE TABLE %s SCHEMAFULL;", e.Name)
+	case schema.EdgeModeSchemaless:
+		forwardSQL = fmt.Sprintf("DEFINE TABLE %s SCHEMALESS;", e.Name)
+	default:
+		// Unrecognised modes default to RELATION to mirror NewEdge's default.
+		forwardSQL = fmt.Sprintf("DEFINE TABLE %s TYPE RELATION;", e.Name)
+	}
+
+	diffs = append(diffs, SchemaDiff{
+		Operation:   DiffOperationAddTable,
+		Table:       e.Name,
+		Description: fmt.Sprintf("Add edge %s", e.Name),
+		ForwardSQL:  forwardSQL,
+		BackwardSQL: fmt.Sprintf("REMOVE TABLE %s;", e.Name),
+	})
+
+	for _, f := range e.Fields {
+		d, err := generateAddFieldDiff(e.Name, f)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+	for _, i := range e.Indexes {
+		d, err := generateAddIndexDiff(e.Name, i)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+	for _, ev := range e.Events {
+		d, err := generateAddEventDiff(e.Name, ev)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d)
+	}
+	return diffs, nil
+}
+
+func generateDropEdgeDiff(e schema.EdgeDefinition) SchemaDiff {
+	return SchemaDiff{
+		Operation:   DiffOperationDropTable,
+		Table:       e.Name,
+		Description: fmt.Sprintf("Drop edge %s", e.Name),
+		ForwardSQL:  fmt.Sprintf("REMOVE TABLE %s;", e.Name),
+		BackwardSQL: "",
+	}
+}
+
+// fieldToSQL renders a standalone DEFINE FIELD statement matching the Python
+// port. It does not call FieldDefinition.ToSurql because that helper emits
+// clauses in a different order (assertion before default/value) — we preserve
+// the Python ordering plus the default/value allow-list validation.
+func fieldToSQL(tableName string, f schema.FieldDefinition) (string, error) {
+	var b strings.Builder
+	b.WriteString("DEFINE FIELD ")
+	b.WriteString(f.Name)
+	b.WriteString(" ON TABLE ")
+	b.WriteString(tableName)
+	b.WriteString(" TYPE ")
+	b.WriteString(string(f.Type))
+
+	if f.Assertion != "" {
+		b.WriteString(" ASSERT ")
+		b.WriteString(f.Assertion)
+	}
+	if f.Default != "" {
+		if err := validateDefaultValue(f.Default); err != nil {
+			return "", err
+		}
+		b.WriteString(" DEFAULT ")
+		b.WriteString(f.Default)
+	}
+	if f.Value != "" {
+		if err := validateDefaultValue(f.Value); err != nil {
+			return "", err
+		}
+		b.WriteString(" VALUE ")
+		b.WriteString(f.Value)
+	}
+	if f.ReadOnly {
+		b.WriteString(" READONLY")
+	}
+	if f.Flexible {
+		b.WriteString(" FLEXIBLE")
+	}
+	b.WriteString(";")
+	return b.String(), nil
+}
+
+// indexToSQL renders a DEFINE INDEX statement. Standard / UNIQUE / SEARCH
+// indexes use the basic form; MTREE and HNSW flavours route through their
+// dedicated helpers. Returns ErrValidation for MTREE / HNSW indexes missing
+// a dimension.
+func indexToSQL(tableName string, idx schema.IndexDefinition) (string, error) {
+	switch idx.Type {
+	case schema.IndexTypeMTree:
+		return mtreeIndexToSQL(tableName, idx)
+	case schema.IndexTypeHNSW:
+		return hnswIndexToSQL(tableName, idx)
+	}
+
+	var b strings.Builder
+	b.WriteString("DEFINE INDEX ")
+	b.WriteString(idx.Name)
+	b.WriteString(" ON TABLE ")
+	b.WriteString(tableName)
+	b.WriteString(" COLUMNS ")
+	b.WriteString(strings.Join(idx.Columns, ", "))
+
+	if string(idx.Type) != string(schema.IndexTypeStandard) && idx.Type != "" {
+		b.WriteString(" ")
+		b.WriteString(string(idx.Type))
+	}
+	b.WriteString(";")
+	return b.String(), nil
+}
+
+func mtreeIndexToSQL(tableName string, idx schema.IndexDefinition) (string, error) {
+	if idx.Dimension <= 0 {
+		return "", surqlerrors.Newf(surqlerrors.ErrValidation,
+			"MTREE index %q must have dimension specified", idx.Name)
+	}
+	field := ""
+	if len(idx.Columns) > 0 {
+		field = idx.Columns[0]
+	}
+
+	var b strings.Builder
+	b.WriteString("DEFINE INDEX ")
+	b.WriteString(idx.Name)
+	b.WriteString(" ON TABLE ")
+	b.WriteString(tableName)
+	b.WriteString(" COLUMNS ")
+	b.WriteString(field)
+	b.WriteString(" MTREE DIMENSION ")
+	b.WriteString(strconv.Itoa(idx.Dimension))
+	if idx.Distance != "" {
+		b.WriteString(" DIST ")
+		b.WriteString(string(idx.Distance))
+	}
+	if idx.VectorType != "" {
+		b.WriteString(" TYPE ")
+		b.WriteString(string(idx.VectorType))
+	}
+	b.WriteString(";")
+	return b.String(), nil
+}
+
+func hnswIndexToSQL(tableName string, idx schema.IndexDefinition) (string, error) {
+	if idx.Dimension <= 0 {
+		return "", surqlerrors.Newf(surqlerrors.ErrValidation,
+			"HNSW index %q must have dimension specified", idx.Name)
+	}
+	field := ""
+	if len(idx.Columns) > 0 {
+		field = idx.Columns[0]
+	}
+
+	var b strings.Builder
+	b.WriteString("DEFINE INDEX ")
+	b.WriteString(idx.Name)
+	b.WriteString(" ON TABLE ")
+	b.WriteString(tableName)
+	b.WriteString(" COLUMNS ")
+	b.WriteString(field)
+	b.WriteString(" HNSW DIMENSION ")
+	b.WriteString(strconv.Itoa(idx.Dimension))
+	if idx.HnswDistance != "" {
+		b.WriteString(" DIST ")
+		b.WriteString(string(idx.HnswDistance))
+	}
+	if idx.VectorType != "" {
+		b.WriteString(" TYPE ")
+		b.WriteString(string(idx.VectorType))
+	}
+	if idx.EFC > 0 {
+		b.WriteString(" EFC ")
+		b.WriteString(strconv.Itoa(idx.EFC))
+	}
+	if idx.M > 0 {
+		b.WriteString(" M ")
+		b.WriteString(strconv.Itoa(idx.M))
+	}
+	b.WriteString(";")
+	return b.String(), nil
+}

--- a/pkg/surql/migration/diff_test.go
+++ b/pkg/surql/migration/diff_test.go
@@ -1,0 +1,1187 @@
+package migration
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/schema"
+)
+
+// --- helpers -----------------------------------------------------------------
+
+func findByOp(diffs []SchemaDiff, op DiffOperation) []SchemaDiff {
+	out := make([]SchemaDiff, 0)
+	for _, d := range diffs {
+		if d.Operation == op {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// --- DiffTables --------------------------------------------------------------
+
+func TestDiffTablesAddOnly(t *testing.T) {
+	newT := schema.NewTable("user",
+		schema.WithMode(schema.TableModeSchemafull),
+		schema.WithFields(schema.StringField("email")),
+	)
+	diffs, err := DiffTables(nil, &newT)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 2 {
+		t.Fatalf("expected 2 diffs (table + field), got %d", len(diffs))
+	}
+	if diffs[0].Operation != DiffOperationAddTable {
+		t.Errorf("expected add_table first, got %s", diffs[0].Operation)
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "DEFINE TABLE user SCHEMAFULL") {
+		t.Errorf("unexpected forward sql: %s", diffs[0].ForwardSQL)
+	}
+	if diffs[0].BackwardSQL != "REMOVE TABLE user;" {
+		t.Errorf("unexpected backward sql: %s", diffs[0].BackwardSQL)
+	}
+	if diffs[1].Operation != DiffOperationAddField {
+		t.Errorf("expected add_field, got %s", diffs[1].Operation)
+	}
+}
+
+func TestDiffTablesAddWithIndexesEventsPermissions(t *testing.T) {
+	newT := schema.NewTable("post",
+		schema.WithFields(schema.StringField("title")),
+		schema.WithIndexes(schema.UniqueIndex("title_idx", []string{"title"})),
+		schema.WithEvents(schema.NewEvent("touch", "$before != $after", "UPDATE post SET updated = time::now()")),
+		schema.WithTablePermissions(map[string]string{"select": "true"}),
+	)
+	diffs, err := DiffTables(nil, &newT)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 5 {
+		t.Fatalf("expected 5 diffs, got %d (%v)", len(diffs), diffs)
+	}
+	got := make([]DiffOperation, len(diffs))
+	for i, d := range diffs {
+		got[i] = d.Operation
+	}
+	want := []DiffOperation{
+		DiffOperationAddTable, DiffOperationAddField,
+		DiffOperationAddIndex, DiffOperationAddEvent,
+		DiffOperationModifyPermissions,
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("diffs[%d] = %s, want %s", i, got[i], w)
+		}
+	}
+}
+
+func TestDiffTablesDropOnly(t *testing.T) {
+	oldT := schema.NewTable("legacy", schema.WithMode(schema.TableModeSchemaless))
+	diffs, err := DiffTables(&oldT, nil)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	d := diffs[0]
+	if d.Operation != DiffOperationDropTable {
+		t.Errorf("op = %s, want drop_table", d.Operation)
+	}
+	if d.ForwardSQL != "REMOVE TABLE legacy;" {
+		t.Errorf("forward sql = %q", d.ForwardSQL)
+	}
+	if d.BackwardSQL != "DEFINE TABLE legacy SCHEMALESS;" {
+		t.Errorf("backward sql = %q", d.BackwardSQL)
+	}
+}
+
+func TestDiffTablesBothNil(t *testing.T) {
+	diffs, err := DiffTables(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected empty diffs, got %d", len(diffs))
+	}
+}
+
+func TestDiffTablesNoChange(t *testing.T) {
+	old := schema.NewTable("user", schema.WithFields(schema.StringField("email")))
+	new := schema.NewTable("user", schema.WithFields(schema.StringField("email")))
+	diffs, err := DiffTables(&old, &new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %d: %v", len(diffs), diffs)
+	}
+}
+
+// --- DiffFields --------------------------------------------------------------
+
+func TestDiffFieldsAdded(t *testing.T) {
+	old := schema.NewTable("user")
+	new := schema.NewTable("user", schema.WithFields(schema.StringField("email")))
+	diffs, err := DiffFields(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationAddField {
+		t.Fatalf("expected 1 add_field, got %v", diffs)
+	}
+	if diffs[0].Field != "email" {
+		t.Errorf("field = %s", diffs[0].Field)
+	}
+}
+
+func TestDiffFieldsAddedWithDefaultBackfill(t *testing.T) {
+	old := schema.NewTable("user")
+	new := schema.NewTable("user", schema.WithFields(
+		schema.StringField("created_at", schema.WithDefault("time::now()")),
+	))
+	diffs, err := DiffFields(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "UPDATE user SET created_at = time::now() WHERE created_at IS NONE") {
+		t.Errorf("expected backfill in forward sql, got: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffFieldsAddedWithUnsafeDefault(t *testing.T) {
+	new := schema.NewTable("user", schema.WithFields(
+		schema.StringField("email", schema.WithDefault("'x'; DROP TABLE user; --")),
+	))
+	_, err := DiffFields(schema.NewTable("user"), new)
+	if err == nil {
+		t.Fatal("expected validation error for unsafe default")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestDiffFieldsDropped(t *testing.T) {
+	old := schema.NewTable("user", schema.WithFields(schema.StringField("email")))
+	new := schema.NewTable("user")
+	diffs, err := DiffFields(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationDropField {
+		t.Fatalf("expected 1 drop_field, got %v", diffs)
+	}
+	if !strings.Contains(diffs[0].BackwardSQL, "DEFINE FIELD email ON TABLE user TYPE string") {
+		t.Errorf("unexpected backward sql: %s", diffs[0].BackwardSQL)
+	}
+}
+
+func TestDiffFieldsModifiedType(t *testing.T) {
+	old := schema.NewTable("user", schema.WithFields(schema.StringField("age")))
+	new := schema.NewTable("user", schema.WithFields(schema.IntField("age")))
+	diffs, err := DiffFields(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	d := diffs[0]
+	if d.Operation != DiffOperationModifyField {
+		t.Errorf("op = %s", d.Operation)
+	}
+	if d.Details["old_type"] != "string" || d.Details["new_type"] != "int" {
+		t.Errorf("details = %v", d.Details)
+	}
+}
+
+func TestDiffFieldsModifiedAssertion(t *testing.T) {
+	old := schema.NewTable("user", schema.WithFields(
+		schema.StringField("email", schema.WithAssertion("string::is::email($value)")),
+	))
+	new := schema.NewTable("user", schema.WithFields(
+		schema.StringField("email", schema.WithAssertion("string::len($value) > 3")),
+	))
+	diffs, err := DiffFields(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationModifyField {
+		t.Fatalf("expected modify_field, got %v", diffs)
+	}
+}
+
+func TestDiffFieldsModifiedReadonlyFlexible(t *testing.T) {
+	old := schema.NewTable("user", schema.WithFields(schema.NewField("meta", schema.FieldTypeObject)))
+	new := schema.NewTable("user", schema.WithFields(schema.NewField("meta", schema.FieldTypeObject, schema.WithFlexible(true))))
+	diffs, err := DiffFields(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+}
+
+func TestDiffFieldsNoChange(t *testing.T) {
+	f := schema.StringField("email", schema.WithAssertion("string::len($value) > 0"))
+	old := schema.NewTable("user", schema.WithFields(f))
+	new := schema.NewTable("user", schema.WithFields(f))
+	diffs, err := DiffFields(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %v", diffs)
+	}
+}
+
+func TestDiffFieldsMixedOperations(t *testing.T) {
+	old := schema.NewTable("user", schema.WithFields(
+		schema.StringField("email"),
+		schema.StringField("legacy"),
+		schema.IntField("age"),
+	))
+	new := schema.NewTable("user", schema.WithFields(
+		schema.StringField("email"),
+		schema.FloatField("age"),   // modified
+		schema.BoolField("active"), // added
+	))
+	diffs, err := DiffFields(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 3 {
+		t.Fatalf("expected 3 diffs, got %d", len(diffs))
+	}
+	if len(findByOp(diffs, DiffOperationAddField)) != 1 {
+		t.Errorf("expected 1 add_field, got %d", len(findByOp(diffs, DiffOperationAddField)))
+	}
+	if len(findByOp(diffs, DiffOperationDropField)) != 1 {
+		t.Errorf("expected 1 drop_field, got %d", len(findByOp(diffs, DiffOperationDropField)))
+	}
+	if len(findByOp(diffs, DiffOperationModifyField)) != 1 {
+		t.Errorf("expected 1 modify_field, got %d", len(findByOp(diffs, DiffOperationModifyField)))
+	}
+}
+
+func TestFieldsEqualValueAndReadOnly(t *testing.T) {
+	a := schema.ComputedField("full", "string::concat(first, ' ', last)", schema.FieldTypeString)
+	b := schema.ComputedField("full", "string::concat(first, ' ', last)", schema.FieldTypeString)
+	if !fieldsEqual(a, b) {
+		t.Fatal("expected fields equal")
+	}
+	c := schema.ComputedField("full", "string::concat(first, last)", schema.FieldTypeString)
+	if fieldsEqual(a, c) {
+		t.Fatal("expected fields unequal when value differs")
+	}
+}
+
+// --- DiffIndexes -------------------------------------------------------------
+
+func TestDiffIndexesAddedStandard(t *testing.T) {
+	old := schema.NewTable("post")
+	new := schema.NewTable("post", schema.WithIndexes(
+		schema.NewIndex("title_idx", []string{"title"}, schema.IndexTypeStandard),
+	))
+	diffs, err := DiffIndexes(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationAddIndex {
+		t.Fatalf("expected 1 add_index, got %v", diffs)
+	}
+	if !strings.HasPrefix(diffs[0].ForwardSQL, "DEFINE INDEX title_idx ON TABLE post COLUMNS title") {
+		t.Errorf("unexpected sql: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffIndexesAddedUnique(t *testing.T) {
+	new := schema.NewTable("user", schema.WithIndexes(
+		schema.UniqueIndex("email_uq", []string{"email"}),
+	))
+	diffs, err := DiffIndexes(schema.NewTable("user"), new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "UNIQUE") {
+		t.Errorf("expected UNIQUE in sql: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffIndexesAddedMultiColumn(t *testing.T) {
+	new := schema.NewTable("event", schema.WithIndexes(
+		schema.NewIndex("by_ts_user", []string{"timestamp", "user_id"}, schema.IndexTypeStandard),
+	))
+	diffs, err := DiffIndexes(schema.NewTable("event"), new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "COLUMNS timestamp, user_id") {
+		t.Errorf("expected multi-column sql, got: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffIndexesDropped(t *testing.T) {
+	old := schema.NewTable("post", schema.WithIndexes(
+		schema.NewIndex("title_idx", []string{"title"}, schema.IndexTypeStandard),
+	))
+	new := schema.NewTable("post")
+	diffs, err := DiffIndexes(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationDropIndex {
+		t.Fatalf("expected drop_index, got %v", diffs)
+	}
+	if diffs[0].ForwardSQL != "REMOVE INDEX title_idx ON TABLE post;" {
+		t.Errorf("unexpected sql: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffIndexesNoChange(t *testing.T) {
+	idx := schema.UniqueIndex("email_uq", []string{"email"})
+	old := schema.NewTable("user", schema.WithIndexes(idx))
+	new := schema.NewTable("user", schema.WithIndexes(idx))
+	diffs, err := DiffIndexes(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %v", diffs)
+	}
+}
+
+// --- MTREE / HNSW ------------------------------------------------------------
+
+func TestDiffIndexesAddMTree(t *testing.T) {
+	new := schema.NewTable("documents", schema.WithIndexes(
+		schema.MTreeIndex("emb_idx", "embedding", 1536, schema.MTreeIndexOptions{}),
+	))
+	diffs, err := DiffIndexes(schema.NewTable("documents"), new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	expect := "DEFINE INDEX emb_idx ON TABLE documents COLUMNS embedding MTREE DIMENSION 1536 DIST EUCLIDEAN TYPE F64;"
+	if diffs[0].ForwardSQL != expect {
+		t.Errorf("mtree sql mismatch.\n  got:  %s\n  want: %s", diffs[0].ForwardSQL, expect)
+	}
+}
+
+func TestDiffIndexesAddMTreeCosine(t *testing.T) {
+	new := schema.NewTable("documents", schema.WithIndexes(
+		schema.MTreeIndex("emb", "embedding", 768, schema.MTreeIndexOptions{
+			Distance:   schema.MTreeDistanceCosine,
+			VectorType: schema.MTreeVectorF32,
+		}),
+	))
+	diffs, err := DiffIndexes(schema.NewTable("documents"), new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "DIST COSINE") ||
+		!strings.Contains(diffs[0].ForwardSQL, "TYPE F32") {
+		t.Errorf("unexpected sql: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffIndexesAddMTreeNoDimension(t *testing.T) {
+	new := schema.NewTable("documents", schema.WithIndexes(schema.IndexDefinition{
+		Name:    "bad",
+		Columns: []string{"embedding"},
+		Type:    schema.IndexTypeMTree,
+	}))
+	_, err := DiffIndexes(schema.NewTable("documents"), new)
+	if err == nil || !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestDiffIndexesDropMTree(t *testing.T) {
+	idx := schema.MTreeIndex("emb_idx", "embedding", 1536, schema.MTreeIndexOptions{})
+	old := schema.NewTable("documents", schema.WithIndexes(idx))
+	new := schema.NewTable("documents")
+	diffs, err := DiffIndexes(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if diffs[0].Operation != DiffOperationDropIndex {
+		t.Errorf("op = %s", diffs[0].Operation)
+	}
+	if !strings.Contains(diffs[0].BackwardSQL, "MTREE DIMENSION 1536") {
+		t.Errorf("expected MTREE restore in backward sql: %s", diffs[0].BackwardSQL)
+	}
+}
+
+func TestDiffIndexesAddHNSW(t *testing.T) {
+	new := schema.NewTable("vectors", schema.WithIndexes(
+		schema.HnswIndex("vec_idx", "vector", 512, schema.HnswIndexOptions{}),
+	))
+	diffs, err := DiffIndexes(schema.NewTable("vectors"), new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "HNSW DIMENSION 512") {
+		t.Errorf("hnsw sql: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffIndexesAddHNSWWithTuning(t *testing.T) {
+	new := schema.NewTable("vectors", schema.WithIndexes(
+		schema.HnswIndex("vec_idx", "vector", 128, schema.HnswIndexOptions{
+			Distance: schema.HnswDistanceCosine, EFC: 200, M: 32,
+		}),
+	))
+	diffs, err := DiffIndexes(schema.NewTable("vectors"), new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	sql := diffs[0].ForwardSQL
+	if !strings.Contains(sql, "EFC 200") || !strings.Contains(sql, "M 32") ||
+		!strings.Contains(sql, "DIST COSINE") {
+		t.Errorf("unexpected sql: %s", sql)
+	}
+}
+
+func TestDiffIndexesAddHNSWNoDimension(t *testing.T) {
+	new := schema.NewTable("v", schema.WithIndexes(schema.IndexDefinition{
+		Name: "x", Columns: []string{"vec"}, Type: schema.IndexTypeHNSW,
+	}))
+	_, err := DiffIndexes(schema.NewTable("v"), new)
+	if err == nil || !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestDiffIndexesDropHNSW(t *testing.T) {
+	idx := schema.HnswIndex("vec_idx", "vector", 256, schema.HnswIndexOptions{})
+	old := schema.NewTable("vectors", schema.WithIndexes(idx))
+	new := schema.NewTable("vectors")
+	diffs, err := DiffIndexes(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if !strings.Contains(diffs[0].BackwardSQL, "HNSW DIMENSION 256") {
+		t.Errorf("expected HNSW in backward: %s", diffs[0].BackwardSQL)
+	}
+}
+
+func TestDiffIndexesMixedTypes(t *testing.T) {
+	old := schema.NewTable("v")
+	new := schema.NewTable("v", schema.WithIndexes(
+		schema.UniqueIndex("name_uq", []string{"name"}),
+		schema.MTreeIndex("emb_idx", "embedding", 512, schema.MTreeIndexOptions{}),
+		schema.HnswIndex("vec_idx", "vector", 256, schema.HnswIndexOptions{}),
+	))
+	diffs, err := DiffIndexes(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 3 {
+		t.Fatalf("expected 3 add_index diffs, got %d", len(diffs))
+	}
+}
+
+// --- DiffEvents --------------------------------------------------------------
+
+func TestDiffEventsAdded(t *testing.T) {
+	new := schema.NewTable("user", schema.WithEvents(
+		schema.NewEvent("touch", "$before.updated != $after.updated", "UPDATE user SET updated_at = time::now()"),
+	))
+	diffs, err := DiffEvents(schema.NewTable("user"), new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationAddEvent {
+		t.Fatalf("expected add_event, got %v", diffs)
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "DEFINE EVENT touch ON TABLE user WHEN") {
+		t.Errorf("unexpected sql: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffEventsDropped(t *testing.T) {
+	old := schema.NewTable("user", schema.WithEvents(
+		schema.NewEvent("touch", "true", "UPDATE user SET t = time::now()"),
+	))
+	diffs, err := DiffEvents(old, schema.NewTable("user"))
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if diffs[0].Operation != DiffOperationDropEvent {
+		t.Errorf("op = %s", diffs[0].Operation)
+	}
+	if diffs[0].ForwardSQL != "REMOVE EVENT touch ON TABLE user;" {
+		t.Errorf("forward sql: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffEventsNoChange(t *testing.T) {
+	ev := schema.NewEvent("touch", "true", "UPDATE user SET t = time::now()")
+	old := schema.NewTable("user", schema.WithEvents(ev))
+	new := schema.NewTable("user", schema.WithEvents(ev))
+	diffs, err := DiffEvents(old, new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %v", diffs)
+	}
+}
+
+func TestDiffEventsUnsafeCondition(t *testing.T) {
+	new := schema.NewTable("user", schema.WithEvents(
+		schema.NewEvent("bad", "true; DROP TABLE user;", "UPDATE user SET t = time::now()"),
+	))
+	_, err := DiffEvents(schema.NewTable("user"), new)
+	if err == nil || !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestDiffEventsUnsafeAction(t *testing.T) {
+	new := schema.NewTable("user", schema.WithEvents(
+		schema.NewEvent("bad", "true", "UPDATE user SET t = time::now() -- drop"),
+	))
+	_, err := DiffEvents(schema.NewTable("user"), new)
+	if err == nil || !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestValidateEventExpressionTrailingSemicolon(t *testing.T) {
+	if err := validateEventExpression("true;", "condition"); err == nil {
+		t.Error("expected error for trailing semicolon")
+	}
+}
+
+func TestValidateEventExpressionComment(t *testing.T) {
+	if err := validateEventExpression("true -- nope", "condition"); err == nil {
+		t.Error("expected error for SQL comment")
+	}
+}
+
+func TestValidateEventExpressionValid(t *testing.T) {
+	if err := validateEventExpression("$before != $after", "condition"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// --- DiffPermissions ---------------------------------------------------------
+
+func TestDiffPermissionsAdded(t *testing.T) {
+	old := schema.NewTable("user")
+	new := schema.NewTable("user", schema.WithTablePermissions(map[string]string{"select": "true"}))
+	diffs := DiffPermissions(old, new)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if diffs[0].Operation != DiffOperationModifyPermissions {
+		t.Errorf("op = %s", diffs[0].Operation)
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "DEFINE FIELD PERMISSIONS FOR SELECT ON TABLE user WHERE true") {
+		t.Errorf("unexpected forward sql: %s", diffs[0].ForwardSQL)
+	}
+	if diffs[0].BackwardSQL != "" {
+		t.Errorf("expected empty backward sql, got %q", diffs[0].BackwardSQL)
+	}
+}
+
+func TestDiffPermissionsChanged(t *testing.T) {
+	old := schema.NewTable("user", schema.WithTablePermissions(map[string]string{"select": "false"}))
+	new := schema.NewTable("user", schema.WithTablePermissions(map[string]string{"select": "true"}))
+	diffs := DiffPermissions(old, new)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if !strings.Contains(diffs[0].BackwardSQL, "WHERE false") {
+		t.Errorf("expected old perms in backward sql: %s", diffs[0].BackwardSQL)
+	}
+	if !strings.Contains(diffs[0].ForwardSQL, "WHERE true") {
+		t.Errorf("expected new perms in forward sql: %s", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffPermissionsRemoved(t *testing.T) {
+	old := schema.NewTable("user", schema.WithTablePermissions(map[string]string{"select": "true"}))
+	new := schema.NewTable("user")
+	diffs := DiffPermissions(old, new)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if diffs[0].ForwardSQL != "" {
+		t.Errorf("expected empty forward sql, got %q", diffs[0].ForwardSQL)
+	}
+	if !strings.Contains(diffs[0].BackwardSQL, "WHERE true") {
+		t.Errorf("unexpected backward sql: %s", diffs[0].BackwardSQL)
+	}
+}
+
+func TestDiffPermissionsNoChange(t *testing.T) {
+	perms := map[string]string{"select": "true"}
+	old := schema.NewTable("user", schema.WithTablePermissions(perms))
+	new := schema.NewTable("user", schema.WithTablePermissions(perms))
+	diffs := DiffPermissions(old, new)
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %v", diffs)
+	}
+}
+
+func TestDiffPermissionsNilVsEmptyNoChange(t *testing.T) {
+	old := schema.NewTable("user")
+	new := schema.NewTable("user", schema.WithTablePermissions(map[string]string{}))
+	diffs := DiffPermissions(old, new)
+	if len(diffs) != 0 {
+		t.Errorf("expected nil and empty map to match, got %v", diffs)
+	}
+}
+
+func TestDiffPermissionsMultipleStableOrder(t *testing.T) {
+	new := schema.NewTable("user", schema.WithTablePermissions(map[string]string{
+		"select": "true", "update": "false", "create": "true",
+	}))
+	diffs := DiffPermissions(schema.NewTable("user"), new)
+	sql := diffs[0].ForwardSQL
+	// Sorted key order: create, select, update
+	iCreate := strings.Index(sql, "FOR CREATE")
+	iSelect := strings.Index(sql, "FOR SELECT")
+	iUpdate := strings.Index(sql, "FOR UPDATE")
+	if !(iCreate < iSelect && iSelect < iUpdate) {
+		t.Errorf("expected sorted order, got: %s", sql)
+	}
+}
+
+// --- DiffEdges ---------------------------------------------------------------
+
+func TestDiffEdgesAdded(t *testing.T) {
+	e := schema.TypedEdge("likes", "user", "post")
+	diffs, err := DiffEdges(nil, &e)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationAddTable {
+		t.Fatalf("expected 1 add_table for edge, got %v", diffs)
+	}
+	expect := "DEFINE TABLE likes TYPE RELATION FROM user TO post;"
+	if diffs[0].ForwardSQL != expect {
+		t.Errorf("edge sql = %q, want %q", diffs[0].ForwardSQL, expect)
+	}
+}
+
+func TestDiffEdgesAddedSchemafull(t *testing.T) {
+	e := schema.NewEdge("owns", schema.WithEdgeMode(schema.EdgeModeSchemafull))
+	diffs, err := DiffEdges(nil, &e)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if diffs[0].ForwardSQL != "DEFINE TABLE owns SCHEMAFULL;" {
+		t.Errorf("sql = %q", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffEdgesAddedSchemaless(t *testing.T) {
+	e := schema.NewEdge("rel", schema.WithEdgeMode(schema.EdgeModeSchemaless))
+	diffs, err := DiffEdges(nil, &e)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if diffs[0].ForwardSQL != "DEFINE TABLE rel SCHEMALESS;" {
+		t.Errorf("sql = %q", diffs[0].ForwardSQL)
+	}
+}
+
+func TestDiffEdgesAddedWithFieldsIndexesEvents(t *testing.T) {
+	e := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgeFields(schema.IntField("weight")),
+		schema.WithEdgeIndexes(schema.NewIndex("w_idx", []string{"weight"}, schema.IndexTypeStandard)),
+		schema.WithEdgeEvents(schema.NewEvent("touch", "true", "UPDATE likes SET t = time::now()")),
+	)
+	diffs, err := DiffEdges(nil, &e)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 4 {
+		t.Fatalf("expected 4 diffs (table + field + index + event), got %d", len(diffs))
+	}
+}
+
+func TestDiffEdgesDropped(t *testing.T) {
+	e := schema.TypedEdge("likes", "user", "post")
+	diffs, err := DiffEdges(&e, nil)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationDropTable {
+		t.Fatalf("expected drop_table, got %v", diffs)
+	}
+	if diffs[0].BackwardSQL != "" {
+		t.Errorf("expected empty backward sql for dropped edge, got %q", diffs[0].BackwardSQL)
+	}
+}
+
+func TestDiffEdgesFieldAdded(t *testing.T) {
+	oldE := schema.TypedEdge("likes", "user", "post")
+	newE := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgeFields(schema.IntField("weight")))
+	diffs, err := DiffEdges(&oldE, &newE)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationAddField {
+		t.Fatalf("expected add_field, got %v", diffs)
+	}
+	if diffs[0].Field != "weight" {
+		t.Errorf("field = %s", diffs[0].Field)
+	}
+}
+
+func TestDiffEdgesFieldRemoved(t *testing.T) {
+	oldE := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgeFields(schema.IntField("weight")))
+	newE := schema.TypedEdge("likes", "user", "post")
+	diffs, err := DiffEdges(&oldE, &newE)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationDropField {
+		t.Fatalf("expected drop_field, got %v", diffs)
+	}
+}
+
+func TestDiffEdgesFieldModified(t *testing.T) {
+	oldE := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgeFields(schema.IntField("weight")))
+	newE := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgeFields(schema.FloatField("weight")))
+	diffs, err := DiffEdges(&oldE, &newE)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationModifyField {
+		t.Fatalf("expected modify_field, got %v", diffs)
+	}
+}
+
+func TestDiffEdgesIndexAdded(t *testing.T) {
+	oldE := schema.TypedEdge("likes", "user", "post")
+	newE := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgeIndexes(schema.NewIndex("w_idx", []string{"weight"}, schema.IndexTypeStandard)))
+	diffs, err := DiffEdges(&oldE, &newE)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if diffs[0].Operation != DiffOperationAddIndex {
+		t.Errorf("op = %s", diffs[0].Operation)
+	}
+}
+
+func TestDiffEdgesEventAdded(t *testing.T) {
+	oldE := schema.TypedEdge("likes", "user", "post")
+	newE := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgeEvents(schema.NewEvent("touch", "true", "UPDATE likes SET t = time::now()")))
+	diffs, err := DiffEdges(&oldE, &newE)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if diffs[0].Operation != DiffOperationAddEvent {
+		t.Errorf("op = %s", diffs[0].Operation)
+	}
+}
+
+func TestDiffEdgesPermissionsChanged(t *testing.T) {
+	oldE := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgePermissions(map[string]string{"select": "false"}))
+	newE := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgePermissions(map[string]string{"select": "true"}))
+	diffs, err := DiffEdges(&oldE, &newE)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationModifyPermissions {
+		t.Fatalf("expected modify_permissions, got %v", diffs)
+	}
+}
+
+func TestDiffEdgesNoChange(t *testing.T) {
+	e := schema.TypedEdge("likes", "user", "post",
+		schema.WithEdgeFields(schema.IntField("weight")))
+	diffs, err := DiffEdges(&e, &e)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %v", diffs)
+	}
+}
+
+func TestDiffEdgesBothNil(t *testing.T) {
+	diffs, err := DiffEdges(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diffs != nil && len(diffs) != 0 {
+		t.Errorf("expected empty, got %v", diffs)
+	}
+}
+
+// --- DiffSchemas -------------------------------------------------------------
+
+func TestDiffSchemasAddTable(t *testing.T) {
+	code := SchemaSnapshot{Tables: []schema.TableDefinition{schema.NewTable("user")}}
+	db := SchemaSnapshot{}
+	diffs, err := DiffSchemas(code, db)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationAddTable {
+		t.Fatalf("expected add_table, got %v", diffs)
+	}
+}
+
+func TestDiffSchemasDropTable(t *testing.T) {
+	code := SchemaSnapshot{}
+	db := SchemaSnapshot{Tables: []schema.TableDefinition{schema.NewTable("legacy")}}
+	diffs, err := DiffSchemas(code, db)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationDropTable {
+		t.Fatalf("expected drop_table, got %v", diffs)
+	}
+}
+
+func TestDiffSchemasModifyTable(t *testing.T) {
+	code := SchemaSnapshot{Tables: []schema.TableDefinition{
+		schema.NewTable("user", schema.WithFields(schema.StringField("email"), schema.IntField("age"))),
+	}}
+	db := SchemaSnapshot{Tables: []schema.TableDefinition{
+		schema.NewTable("user", schema.WithFields(schema.StringField("email"))),
+	}}
+	diffs, err := DiffSchemas(code, db)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationAddField {
+		t.Fatalf("expected add_field, got %v", diffs)
+	}
+}
+
+func TestDiffSchemasAddEdge(t *testing.T) {
+	code := SchemaSnapshot{Edges: []schema.EdgeDefinition{schema.TypedEdge("likes", "user", "post")}}
+	db := SchemaSnapshot{}
+	diffs, err := DiffSchemas(code, db)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationAddTable {
+		t.Fatalf("expected edge add_table, got %v", diffs)
+	}
+}
+
+func TestDiffSchemasDropEdge(t *testing.T) {
+	code := SchemaSnapshot{}
+	db := SchemaSnapshot{Edges: []schema.EdgeDefinition{schema.TypedEdge("likes", "user", "post")}}
+	diffs, err := DiffSchemas(code, db)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 1 || diffs[0].Operation != DiffOperationDropTable {
+		t.Fatalf("expected drop_table, got %v", diffs)
+	}
+}
+
+func TestDiffSchemasEmptyBoth(t *testing.T) {
+	diffs, err := DiffSchemas(SchemaSnapshot{}, SchemaSnapshot{})
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected empty, got %v", diffs)
+	}
+}
+
+func TestDiffSchemasNoChange(t *testing.T) {
+	snap := SchemaSnapshot{
+		Tables: []schema.TableDefinition{schema.NewTable("user", schema.WithFields(schema.StringField("email")))},
+		Edges:  []schema.EdgeDefinition{schema.TypedEdge("likes", "user", "post")},
+	}
+	diffs, err := DiffSchemas(snap, snap)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %v", diffs)
+	}
+}
+
+func TestDiffSchemasComplex(t *testing.T) {
+	code := SchemaSnapshot{
+		Tables: []schema.TableDefinition{
+			schema.NewTable("user", schema.WithFields(schema.StringField("email"), schema.StringField("name"))),
+			schema.NewTable("post", schema.WithFields(schema.StringField("title"))),
+		},
+		Edges: []schema.EdgeDefinition{
+			schema.TypedEdge("likes", "user", "post"),
+		},
+	}
+	db := SchemaSnapshot{
+		Tables: []schema.TableDefinition{
+			schema.NewTable("user", schema.WithFields(schema.StringField("email"))),
+			schema.NewTable("legacy"),
+		},
+	}
+	diffs, err := DiffSchemas(code, db)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	// Expected: add post (table + title field), drop legacy, add user.name, add likes edge.
+	opsSeen := map[DiffOperation]int{}
+	for _, d := range diffs {
+		opsSeen[d.Operation]++
+	}
+	if opsSeen[DiffOperationAddTable] != 2 {
+		t.Errorf("add_table count = %d, want 2 (post + likes)", opsSeen[DiffOperationAddTable])
+	}
+	if opsSeen[DiffOperationDropTable] != 1 {
+		t.Errorf("drop_table count = %d, want 1 (legacy)", opsSeen[DiffOperationDropTable])
+	}
+	if opsSeen[DiffOperationAddField] != 2 {
+		t.Errorf("add_field count = %d, want 2 (post.title, user.name)", opsSeen[DiffOperationAddField])
+	}
+}
+
+func TestDiffSchemasModifyTableSortedOrder(t *testing.T) {
+	// Modified tables should be emitted in sorted name order for determinism.
+	code := SchemaSnapshot{Tables: []schema.TableDefinition{
+		schema.NewTable("zebra", schema.WithFields(schema.StringField("stripes"))),
+		schema.NewTable("alpha", schema.WithFields(schema.StringField("name"))),
+	}}
+	db := SchemaSnapshot{Tables: []schema.TableDefinition{
+		schema.NewTable("zebra"),
+		schema.NewTable("alpha"),
+	}}
+	diffs, err := DiffSchemas(code, db)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(diffs) != 2 {
+		t.Fatalf("expected 2 diffs, got %d", len(diffs))
+	}
+	if diffs[0].Table != "alpha" || diffs[1].Table != "zebra" {
+		t.Errorf("expected sorted table order, got %s, %s", diffs[0].Table, diffs[1].Table)
+	}
+}
+
+// --- Default-value validation ------------------------------------------------
+
+func TestValidateDefaultValueFunctionCall(t *testing.T) {
+	if err := validateDefaultValue("time::now()"); err != nil {
+		t.Errorf("unexpected: %v", err)
+	}
+	if err := validateDefaultValue("rand::uuid()"); err != nil {
+		t.Errorf("unexpected: %v", err)
+	}
+}
+
+func TestValidateDefaultValueLiterals(t *testing.T) {
+	cases := []string{"42", "-1", "3.14", "true", "false", "NONE", "NULL", "'hello'", "$session"}
+	for _, c := range cases {
+		if err := validateDefaultValue(c); err != nil {
+			t.Errorf("expected %q safe, got %v", c, err)
+		}
+	}
+}
+
+func TestValidateDefaultValueUnsafe(t *testing.T) {
+	cases := []string{
+		"'x'; DROP TABLE user; --",
+		"1; SELECT",
+		"foo + 1", // not a pure function call
+	}
+	for _, c := range cases {
+		if err := validateDefaultValue(c); err == nil {
+			t.Errorf("expected %q unsafe", c)
+		}
+	}
+}
+
+// --- Sanity: modify table routes all child diffs -----------------------------
+
+func TestDiffTablesModifyFieldAndIndex(t *testing.T) {
+	old := schema.NewTable("user",
+		schema.WithFields(schema.StringField("email")),
+		schema.WithIndexes(schema.UniqueIndex("email_uq", []string{"email"})),
+	)
+	new := schema.NewTable("user",
+		schema.WithFields(schema.StringField("email"), schema.IntField("age")),
+		schema.WithIndexes(
+			schema.UniqueIndex("email_uq", []string{"email"}),
+			schema.NewIndex("age_idx", []string{"age"}, schema.IndexTypeStandard),
+		),
+	)
+	diffs, err := DiffTables(&old, &new)
+
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+
+	}
+	if len(findByOp(diffs, DiffOperationAddField)) != 1 {
+		t.Errorf("expected 1 add_field, got %d", len(findByOp(diffs, DiffOperationAddField)))
+	}
+	if len(findByOp(diffs, DiffOperationAddIndex)) != 1 {
+		t.Errorf("expected 1 add_index, got %d", len(findByOp(diffs, DiffOperationAddIndex)))
+	}
+}

--- a/pkg/surql/migration/discovery.go
+++ b/pkg/surql/migration/discovery.go
@@ -1,0 +1,335 @@
+package migration
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// Section markers used inside migration files.
+const (
+	markerUp          = "-- @up"
+	markerDown        = "-- @down"
+	markerDescription = "-- @description:"
+	markerDependsOn   = "-- @depends_on:"
+)
+
+// filenameRe matches the YYYYMMDD_HHMMSS_description.surql convention.
+// The description may contain additional underscores and alphanumerics.
+var filenameRe = regexp.MustCompile(`^(\d{8})_(\d{6})_([A-Za-z0-9][A-Za-z0-9_-]*)\.surql$`)
+
+// DiscoverMigrations scans directory for `.surql` migration files and returns
+// them sorted by version (timestamp).
+//
+// Files whose names do not conform to the YYYYMMDD_HHMMSS_*.surql convention
+// are skipped silently (mirroring the Python port's glob-plus-validate
+// behaviour). A non-existent directory is not an error and yields an empty
+// slice. A path that exists but is not a directory returns a wrapped
+// surqlerrors.ErrMigrationDiscovery.
+func DiscoverMigrations(directory string) ([]Migration, error) {
+	info, err := os.Stat(directory)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []Migration{}, nil
+		}
+		return nil, surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationDiscovery, err,
+			"cannot stat migration directory %q", directory,
+		)
+	}
+	if !info.IsDir() {
+		return nil, surqlerrors.Newf(
+			surqlerrors.ErrMigrationDiscovery,
+			"path is not a directory: %q", directory,
+		)
+	}
+
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return nil, surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationDiscovery, err,
+			"cannot read migration directory %q", directory,
+		)
+	}
+
+	migrations := make([]Migration, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !ValidateMigrationName(name) {
+			continue
+		}
+		full := filepath.Join(directory, name)
+		m, err := LoadMigration(full)
+		if err != nil {
+			return nil, surqlerrors.Wrapf(
+				surqlerrors.ErrMigrationDiscovery, err,
+				"failed to load migration %q", full,
+			)
+		}
+		migrations = append(migrations, m)
+	}
+
+	sort.SliceStable(migrations, func(i, j int) bool {
+		return migrations[i].Version < migrations[j].Version
+	})
+	return migrations, nil
+}
+
+// LoadMigration loads a single `.surql` migration file.
+//
+// The file must contain `-- @up` and `-- @down` section markers. Optional
+// `-- @description:` and `-- @depends_on:` header lines override the values
+// derived from the file name.
+func LoadMigration(path string) (Migration, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Migration{}, surqlerrors.Newf(
+				surqlerrors.ErrMigrationLoad,
+				"migration file not found: %q", path,
+			)
+		}
+		return Migration{}, surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationLoad, err,
+			"cannot stat migration file %q", path,
+		)
+	}
+	if info.IsDir() {
+		return Migration{}, surqlerrors.Newf(
+			surqlerrors.ErrMigrationLoad,
+			"path is not a file: %q", path,
+		)
+	}
+
+	filename := filepath.Base(path)
+	if !ValidateMigrationName(filename) {
+		return Migration{}, surqlerrors.Newf(
+			surqlerrors.ErrMigrationLoad,
+			"invalid migration filename: %q", filename,
+		)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return Migration{}, surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationLoad, err,
+			"cannot read migration file %q", path,
+		)
+	}
+
+	parsed, err := parseMigrationContent(string(content))
+	if err != nil {
+		return Migration{}, surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationLoad, err,
+			"failed to parse migration %q", path,
+		)
+	}
+
+	version, _ := GetVersionFromFilename(filename)
+	description := parsed.description
+	if description == "" {
+		desc, _ := GetDescriptionFromFilename(filename)
+		description = humanizeDescription(desc)
+	}
+
+	return Migration{
+		Version:        version,
+		Description:    description,
+		Path:           path,
+		UpStatements:   parsed.up,
+		DownStatements: parsed.down,
+		Checksum:       sha256Hex(content),
+		DependsOn:      parsed.dependsOn,
+	}, nil
+}
+
+// ValidateMigrationName reports whether filename matches the
+// YYYYMMDD_HHMMSS_description.surql convention.
+func ValidateMigrationName(filename string) bool {
+	return filenameRe.MatchString(filename)
+}
+
+// GetVersionFromFilename returns the YYYYMMDD_HHMMSS version component of a
+// migration file name. The boolean is false when the filename does not match
+// the expected convention.
+func GetVersionFromFilename(filename string) (string, bool) {
+	m := filenameRe.FindStringSubmatch(filename)
+	if m == nil {
+		return "", false
+	}
+	return m[1] + "_" + m[2], true
+}
+
+// GetDescriptionFromFilename returns the description component of a
+// migration file name. The boolean is false when the filename does not match
+// the expected convention.
+func GetDescriptionFromFilename(filename string) (string, bool) {
+	m := filenameRe.FindStringSubmatch(filename)
+	if m == nil {
+		return "", false
+	}
+	return m[3], true
+}
+
+// parsed holds the three logical sections extracted from a migration file.
+type parsed struct {
+	description string
+	dependsOn   []string
+	up          []string
+	down        []string
+}
+
+// parseMigrationContent splits a migration file body into header, up, and
+// down sections and returns cleaned statement slices.
+func parseMigrationContent(body string) (parsed, error) {
+	var p parsed
+
+	// Normalize line endings and split.
+	body = strings.ReplaceAll(body, "\r\n", "\n")
+	lines := strings.Split(body, "\n")
+
+	// Locate section markers. Markers are expected on their own line (after
+	// any leading whitespace).
+	upIdx, downIdx := -1, -1
+	for i, raw := range lines {
+		trim := strings.TrimSpace(raw)
+		switch {
+		case trim == markerUp:
+			if upIdx != -1 {
+				return parsed{}, surqlerrors.New(
+					surqlerrors.ErrMigrationLoad,
+					"duplicate '-- @up' marker",
+				)
+			}
+			upIdx = i
+		case trim == markerDown:
+			if downIdx != -1 {
+				return parsed{}, surqlerrors.New(
+					surqlerrors.ErrMigrationLoad,
+					"duplicate '-- @down' marker",
+				)
+			}
+			downIdx = i
+		}
+	}
+
+	if upIdx == -1 {
+		return parsed{}, surqlerrors.New(
+			surqlerrors.ErrMigrationLoad,
+			"missing '-- @up' section marker",
+		)
+	}
+	if downIdx == -1 {
+		return parsed{}, surqlerrors.New(
+			surqlerrors.ErrMigrationLoad,
+			"missing '-- @down' section marker",
+		)
+	}
+	if downIdx < upIdx {
+		return parsed{}, surqlerrors.New(
+			surqlerrors.ErrMigrationLoad,
+			"'-- @down' marker must follow '-- @up'",
+		)
+	}
+
+	// Header lines: everything above upIdx.
+	for _, raw := range lines[:upIdx] {
+		trim := strings.TrimSpace(raw)
+		switch {
+		case strings.HasPrefix(trim, markerDescription):
+			p.description = strings.TrimSpace(strings.TrimPrefix(trim, markerDescription))
+		case strings.HasPrefix(trim, markerDependsOn):
+			p.dependsOn = splitCSV(strings.TrimPrefix(trim, markerDependsOn))
+		}
+	}
+
+	// Up / down sections.
+	p.up = splitStatements(lines[upIdx+1 : downIdx])
+	p.down = splitStatements(lines[downIdx+1:])
+
+	return p, nil
+}
+
+// splitStatements joins the given lines, removes pure-comment and blank
+// lines, and splits the remainder on `;` boundaries, trimming whitespace.
+func splitStatements(lines []string) []string {
+	cleaned := make([]string, 0, len(lines))
+	for _, raw := range lines {
+		trim := strings.TrimSpace(raw)
+		if trim == "" {
+			continue
+		}
+		if strings.HasPrefix(trim, "--") {
+			continue
+		}
+		cleaned = append(cleaned, raw)
+	}
+	if len(cleaned) == 0 {
+		return nil
+	}
+	joined := strings.Join(cleaned, "\n")
+	parts := strings.Split(joined, ";")
+
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		stmt := strings.TrimSpace(part)
+		if stmt == "" {
+			continue
+		}
+		out = append(out, stmt+";")
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// splitCSV splits a comma-separated header value, trimming whitespace and
+// dropping empty entries. Returns nil when the input has no values.
+func splitCSV(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	raw := strings.Split(s, ",")
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		out = append(out, v)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// humanizeDescription converts an underscore/dash-separated slug into a
+// space-separated label: `create_user_table` -> `create user table`.
+func humanizeDescription(slug string) string {
+	if slug == "" {
+		return ""
+	}
+	slug = strings.ReplaceAll(slug, "-", " ")
+	slug = strings.ReplaceAll(slug, "_", " ")
+	// Collapse duplicated whitespace.
+	fields := strings.Fields(slug)
+	return strings.Join(fields, " ")
+}
+
+// sha256Hex returns the hex-encoded SHA-256 digest of the given bytes.
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/surql/migration/discovery_test.go
+++ b/pkg/surql/migration/discovery_test.go
@@ -1,0 +1,615 @@
+package migration
+
+import (
+	stdErrors "errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// writeFile is a small test helper that creates a file with the given body.
+func writeFile(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+const sampleMigration = `-- @description: create user table
+-- @depends_on: 20260101_000000_init
+-- @up
+DEFINE TABLE user SCHEMAFULL;
+DEFINE FIELD email ON user TYPE string;
+-- @down
+REMOVE TABLE user;
+`
+
+const sampleNoHeaders = `-- @up
+DEFINE TABLE foo SCHEMAFULL;
+-- @down
+REMOVE TABLE foo;
+`
+
+func TestValidateMigrationName_Valid(t *testing.T) {
+	cases := []string{
+		"20260102_120000_create_user.surql",
+		"20260101_000000_init.surql",
+		"20991231_235959_create_user_table.surql",
+		"20260102_120000_name-with-dash.surql",
+	}
+	for _, name := range cases {
+		if !ValidateMigrationName(name) {
+			t.Errorf("expected %q to be valid", name)
+		}
+	}
+}
+
+func TestValidateMigrationName_Invalid(t *testing.T) {
+	cases := []string{
+		"",
+		"invalid.surql",
+		"20260102_120000.surql",
+		"20260102_120000_.surql",
+		"2026010_120000_x.surql",
+		"20260102_12000_x.surql",
+		"20260102-120000_x.surql",
+		"20260102_120000_create_user.py",
+		"20260102_120000_create_user",
+		"_20260102_120000_create_user.surql",
+		"20260102_120000_bad!.surql",
+	}
+	for _, name := range cases {
+		if ValidateMigrationName(name) {
+			t.Errorf("expected %q to be invalid", name)
+		}
+	}
+}
+
+func TestGetVersionFromFilename(t *testing.T) {
+	v, ok := GetVersionFromFilename("20260102_120000_create_user.surql")
+	if !ok || v != "20260102_120000" {
+		t.Errorf("version = %q, ok = %v", v, ok)
+	}
+	if _, ok := GetVersionFromFilename("invalid.surql"); ok {
+		t.Errorf("expected ok = false for invalid name")
+	}
+}
+
+func TestGetDescriptionFromFilename(t *testing.T) {
+	d, ok := GetDescriptionFromFilename("20260102_120000_create_user_table.surql")
+	if !ok || d != "create_user_table" {
+		t.Errorf("description = %q, ok = %v", d, ok)
+	}
+	if _, ok := GetDescriptionFromFilename("invalid.surql"); ok {
+		t.Errorf("expected ok = false for invalid name")
+	}
+}
+
+func TestLoadMigration_Happy(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_create_user_table.surql", sampleMigration)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if m.Version != "20260102_120000" {
+		t.Errorf("version = %q", m.Version)
+	}
+	if m.Description != "create user table" {
+		t.Errorf("description = %q", m.Description)
+	}
+	if m.Path != p {
+		t.Errorf("path = %q", m.Path)
+	}
+	if len(m.UpStatements) != 2 {
+		t.Fatalf("up statements = %d, want 2", len(m.UpStatements))
+	}
+	if m.UpStatements[0] != "DEFINE TABLE user SCHEMAFULL;" {
+		t.Errorf("up[0] = %q", m.UpStatements[0])
+	}
+	if m.UpStatements[1] != "DEFINE FIELD email ON user TYPE string;" {
+		t.Errorf("up[1] = %q", m.UpStatements[1])
+	}
+	if len(m.DownStatements) != 1 || m.DownStatements[0] != "REMOVE TABLE user;" {
+		t.Errorf("down = %+v", m.DownStatements)
+	}
+	if len(m.DependsOn) != 1 || m.DependsOn[0] != "20260101_000000_init" {
+		t.Errorf("depends_on = %+v", m.DependsOn)
+	}
+	if len(m.Checksum) != 64 {
+		t.Errorf("checksum len = %d", len(m.Checksum))
+	}
+}
+
+func TestLoadMigration_DescriptionFallback(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_create_user_table.surql", sampleNoHeaders)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	// No explicit description header -> derived from filename, humanized.
+	// Note that filename description is "create_user_table".
+	if m.Description != "create user table" {
+		t.Errorf("description fallback = %q", m.Description)
+	}
+	if len(m.DependsOn) != 0 {
+		t.Errorf("depends_on = %+v", m.DependsOn)
+	}
+}
+
+func TestLoadMigration_FileNotFound(t *testing.T) {
+	dir := t.TempDir()
+	_, err := LoadMigration(filepath.Join(dir, "missing.surql"))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestLoadMigration_DirectoryRejected(t *testing.T) {
+	dir := t.TempDir()
+	_, err := LoadMigration(dir)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestLoadMigration_InvalidFilename(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "bad_name.surql", sampleMigration)
+
+	_, err := LoadMigration(p)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestLoadMigration_MissingUpMarker(t *testing.T) {
+	body := `-- @description: x
+DEFINE TABLE foo;
+-- @down
+REMOVE TABLE foo;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_x.surql", body)
+
+	_, err := LoadMigration(p)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestLoadMigration_MissingDownMarker(t *testing.T) {
+	body := `-- @up
+DEFINE TABLE foo;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_x.surql", body)
+
+	_, err := LoadMigration(p)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestLoadMigration_DownBeforeUp(t *testing.T) {
+	body := `-- @down
+REMOVE TABLE foo;
+-- @up
+DEFINE TABLE foo;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_x.surql", body)
+
+	_, err := LoadMigration(p)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestLoadMigration_DuplicateUpMarker(t *testing.T) {
+	body := `-- @up
+DEFINE TABLE foo;
+-- @up
+DEFINE TABLE bar;
+-- @down
+REMOVE TABLE foo;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_x.surql", body)
+
+	_, err := LoadMigration(p)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestLoadMigration_DuplicateDownMarker(t *testing.T) {
+	body := `-- @up
+DEFINE TABLE foo;
+-- @down
+REMOVE TABLE foo;
+-- @down
+REMOVE TABLE bar;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_x.surql", body)
+
+	_, err := LoadMigration(p)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestLoadMigration_CRLFEndings(t *testing.T) {
+	body := "-- @up\r\nDEFINE TABLE foo;\r\n-- @down\r\nREMOVE TABLE foo;\r\n"
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_crlf_test.surql", body)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if len(m.UpStatements) != 1 || m.UpStatements[0] != "DEFINE TABLE foo;" {
+		t.Errorf("up = %+v", m.UpStatements)
+	}
+	if len(m.DownStatements) != 1 || m.DownStatements[0] != "REMOVE TABLE foo;" {
+		t.Errorf("down = %+v", m.DownStatements)
+	}
+}
+
+func TestLoadMigration_MultiStatementLine(t *testing.T) {
+	body := `-- @up
+DEFINE TABLE a; DEFINE TABLE b;
+DEFINE TABLE c;
+-- @down
+REMOVE TABLE c; REMOVE TABLE b; REMOVE TABLE a;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_multi.surql", body)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if len(m.UpStatements) != 3 {
+		t.Errorf("up len = %d: %+v", len(m.UpStatements), m.UpStatements)
+	}
+	if len(m.DownStatements) != 3 {
+		t.Errorf("down len = %d: %+v", len(m.DownStatements), m.DownStatements)
+	}
+}
+
+func TestLoadMigration_CommentsAndBlankLinesDropped(t *testing.T) {
+	body := `-- @up
+-- this is a comment
+
+DEFINE TABLE a;
+
+-- another comment
+DEFINE TABLE b;
+-- @down
+REMOVE TABLE b;
+REMOVE TABLE a;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_comments.surql", body)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if len(m.UpStatements) != 2 {
+		t.Errorf("up = %+v", m.UpStatements)
+	}
+	if m.UpStatements[0] != "DEFINE TABLE a;" || m.UpStatements[1] != "DEFINE TABLE b;" {
+		t.Errorf("up contents = %+v", m.UpStatements)
+	}
+}
+
+func TestLoadMigration_ExplicitDescriptionOverridesFilename(t *testing.T) {
+	body := `-- @description: Shiny user table
+-- @up
+DEFINE TABLE user;
+-- @down
+REMOVE TABLE user;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_create_user.surql", body)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if m.Description != "Shiny user table" {
+		t.Errorf("description = %q", m.Description)
+	}
+}
+
+func TestLoadMigration_DependsOnMultipleValues(t *testing.T) {
+	body := `-- @depends_on: 20260101_000000_init,  20260101_010000_seed
+-- @up
+SELECT 1;
+-- @down
+SELECT 0;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_multi_dep.surql", body)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if len(m.DependsOn) != 2 {
+		t.Fatalf("depends_on len = %d: %+v", len(m.DependsOn), m.DependsOn)
+	}
+	if m.DependsOn[0] != "20260101_000000_init" || m.DependsOn[1] != "20260101_010000_seed" {
+		t.Errorf("depends_on = %+v", m.DependsOn)
+	}
+}
+
+func TestLoadMigration_DependsOnEmptyValue(t *testing.T) {
+	body := `-- @depends_on:
+-- @up
+SELECT 1;
+-- @down
+SELECT 0;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_empty_dep.surql", body)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if len(m.DependsOn) != 0 {
+		t.Errorf("depends_on = %+v", m.DependsOn)
+	}
+}
+
+func TestLoadMigration_ChecksumStableAcrossReads(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_stable.surql", sampleMigration)
+
+	m1, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	m2, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	if m1.Checksum != m2.Checksum {
+		t.Errorf("checksum mismatch: %q vs %q", m1.Checksum, m2.Checksum)
+	}
+}
+
+func TestLoadMigration_ChecksumChangesWithContent(t *testing.T) {
+	dir := t.TempDir()
+	p1 := writeFile(t, dir, "20260102_120000_one.surql", sampleMigration)
+	p2 := writeFile(t, dir, "20260102_120001_two.surql", sampleNoHeaders)
+
+	m1, err := LoadMigration(p1)
+	if err != nil {
+		t.Fatalf("load p1: %v", err)
+	}
+	m2, err := LoadMigration(p2)
+	if err != nil {
+		t.Fatalf("load p2: %v", err)
+	}
+	if m1.Checksum == m2.Checksum {
+		t.Errorf("different content produced identical checksum")
+	}
+}
+
+func TestDiscoverMigrations_EmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	ms, err := DiscoverMigrations(dir)
+	if err != nil {
+		t.Fatalf("DiscoverMigrations: %v", err)
+	}
+	if len(ms) != 0 {
+		t.Errorf("expected empty, got %d", len(ms))
+	}
+}
+
+func TestDiscoverMigrations_NonexistentDirectory(t *testing.T) {
+	ms, err := DiscoverMigrations(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatalf("DiscoverMigrations: %v", err)
+	}
+	if len(ms) != 0 {
+		t.Errorf("expected empty, got %d", len(ms))
+	}
+}
+
+func TestDiscoverMigrations_PathIsFileRejected(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_x.surql", sampleMigration)
+
+	_, err := DiscoverMigrations(p)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationDiscovery) {
+		t.Errorf("error kind = %v", err)
+	}
+}
+
+func TestDiscoverMigrations_SortedByVersion(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "20260103_120000_c.surql", sampleNoHeaders)
+	writeFile(t, dir, "20260101_120000_a.surql", sampleNoHeaders)
+	writeFile(t, dir, "20260102_120000_b.surql", sampleNoHeaders)
+
+	ms, err := DiscoverMigrations(dir)
+	if err != nil {
+		t.Fatalf("DiscoverMigrations: %v", err)
+	}
+	if len(ms) != 3 {
+		t.Fatalf("len = %d", len(ms))
+	}
+	wantOrder := []string{"20260101_120000", "20260102_120000", "20260103_120000"}
+	for i, want := range wantOrder {
+		if ms[i].Version != want {
+			t.Errorf("ms[%d].Version = %q, want %q", i, ms[i].Version, want)
+		}
+	}
+}
+
+func TestDiscoverMigrations_SkipsInvalidNames(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "20260102_120000_ok.surql", sampleNoHeaders)
+	writeFile(t, dir, "not-a-migration.surql", "random body")
+	writeFile(t, dir, "README.md", "hi")
+	writeFile(t, dir, ".hidden.surql", "SELECT 1;")
+
+	ms, err := DiscoverMigrations(dir)
+	if err != nil {
+		t.Fatalf("DiscoverMigrations: %v", err)
+	}
+	if len(ms) != 1 || ms[0].Version != "20260102_120000" {
+		t.Errorf("unexpected result: %+v", ms)
+	}
+}
+
+func TestDiscoverMigrations_SkipsSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "20260102_120000_looks_like_migration.surql")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeFile(t, dir, "20260103_120000_real.surql", sampleNoHeaders)
+
+	ms, err := DiscoverMigrations(dir)
+	if err != nil {
+		t.Fatalf("DiscoverMigrations: %v", err)
+	}
+	if len(ms) != 1 || ms[0].Version != "20260103_120000" {
+		t.Errorf("unexpected result: %+v", ms)
+	}
+}
+
+func TestDiscoverMigrations_PropagatesLoadError(t *testing.T) {
+	dir := t.TempDir()
+	// Valid filename but no markers -> load error.
+	writeFile(t, dir, "20260102_120000_broken.surql", "SELECT 1;\n")
+
+	_, err := DiscoverMigrations(dir)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationDiscovery) {
+		t.Errorf("discovery kind not found: %v", err)
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("load kind not found in chain: %v", err)
+	}
+}
+
+func TestDiscoverMigrations_MultipleValidFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "20260101_000000_init.surql", sampleNoHeaders)
+	writeFile(t, dir, "20260102_120000_create_user_table.surql", sampleMigration)
+
+	ms, err := DiscoverMigrations(dir)
+	if err != nil {
+		t.Fatalf("DiscoverMigrations: %v", err)
+	}
+	if len(ms) != 2 {
+		t.Fatalf("len = %d", len(ms))
+	}
+	if ms[0].Version != "20260101_000000" || ms[1].Version != "20260102_120000" {
+		t.Errorf("unexpected versions: %+v", ms)
+	}
+	if ms[1].Description != "create user table" {
+		t.Errorf("description = %q", ms[1].Description)
+	}
+}
+
+func TestLoadMigration_EmptyUpSectionAllowed(t *testing.T) {
+	// An empty up section is unusual but not structurally illegal; it just
+	// yields nil statements. We assert the parser doesn't crash and caller
+	// gets back an empty slice, not an error.
+	body := `-- @up
+-- @down
+REMOVE TABLE foo;
+`
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_empty_up.surql", body)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if len(m.UpStatements) != 0 {
+		t.Errorf("expected empty up, got %+v", m.UpStatements)
+	}
+	if len(m.DownStatements) != 1 {
+		t.Errorf("down = %+v", m.DownStatements)
+	}
+}
+
+func TestLoadMigration_TrailingWhitespaceInStatements(t *testing.T) {
+	body := "-- @up\n   DEFINE TABLE foo ;   \n-- @down\nREMOVE TABLE foo;\n"
+	dir := t.TempDir()
+	p := writeFile(t, dir, "20260102_120000_ws.surql", body)
+
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if len(m.UpStatements) != 1 || m.UpStatements[0] != "DEFINE TABLE foo;" {
+		t.Errorf("up = %+v", m.UpStatements)
+	}
+}
+
+func TestHumanizeDescriptionFallback_Empty(t *testing.T) {
+	// If somehow the filename regex succeeds with an empty description (it
+	// cannot today), the helper should still behave sensibly. We test the
+	// exported path via a filename whose description is a single word.
+	dir := t.TempDir()
+	body := `-- @up
+SELECT 1;
+-- @down
+SELECT 0;
+`
+	p := writeFile(t, dir, "20260102_120000_single.surql", body)
+	m, err := LoadMigration(p)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if m.Description != "single" {
+		t.Errorf("description = %q", m.Description)
+	}
+}

--- a/pkg/surql/migration/doc.go
+++ b/pkg/surql/migration/doc.go
@@ -1,0 +1,38 @@
+// Package migration provides schema migration primitives for surql.
+//
+// This package is a Go port of surql-py/src/surql/migration/. The current
+// increment covers only migration models and file-system discovery. Diff,
+// executor, generator, history store, hooks, rollback, squash, versioning,
+// and watcher tooling are tracked in follow-up work.
+//
+// # File format
+//
+// Python loads `.py` migration files at runtime and invokes `up()` / `down()`
+// callables plus a `metadata` dict. Go has no equivalent dynamic-import
+// mechanism, so the Go port switches to a flat-file `.surql` format with
+// section markers:
+//
+//	-- @description: create user table
+//	-- @depends_on: 20260101_000000_init
+//	-- @up
+//	DEFINE TABLE user SCHEMAFULL;
+//	DEFINE FIELD email ON user TYPE string;
+//	-- @down
+//	REMOVE TABLE user;
+//
+// Rules:
+//
+//   - The file name follows the Python convention:
+//     YYYYMMDD_HHMMSS_description.surql.
+//   - `-- @up` and `-- @down` markers are required; content above `-- @up`
+//     is header metadata, content between `-- @up` and `-- @down` is the
+//     forward migration, and content after `-- @down` is the rollback.
+//   - Statements are split on semicolons; empty statements and pure
+//     comment lines inside a section are discarded.
+//   - `-- @description:` and `-- @depends_on:` headers are optional.
+//     When missing, description falls back to the filename-derived value
+//     and depends_on defaults to the empty slice.
+//
+// The migration Checksum is a SHA-256 digest of the raw file contents,
+// matching the Python port for cross-language compatibility.
+package migration

--- a/pkg/surql/migration/generator.go
+++ b/pkg/surql/migration/generator.go
@@ -1,0 +1,406 @@
+package migration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/schema"
+)
+
+// timestampLayout is the UTC timestamp layout used for migration versions.
+// Format: YYYYMMDD_HHMMSS (e.g. 20260102_120000).
+const timestampLayout = "20060102_150405"
+
+// slugFilterPattern is used to sanitize a description into a filename slug.
+// Any character that is not lower-case alphanumeric or underscore is dropped.
+var slugFilterPattern = regexp.MustCompile(`[^a-z0-9_]`)
+
+// slugCollapsePattern collapses runs of underscores into a single underscore.
+var slugCollapsePattern = regexp.MustCompile(`_+`)
+
+// initialDescriptionDefault matches surql-py's default.
+const initialDescriptionDefault = "Initial schema"
+
+// now is the clock source used by the generator. Tests override this to make
+// timestamps deterministic; production code always uses time.Now.
+var now = func() time.Time { return time.Now().UTC() }
+
+// GenerateMigration writes a migration file to dir containing the given up
+// and down SurrealQL statements. The file name is derived from a UTC
+// timestamp and a slug of name.
+//
+// Both upStatements and downStatements may be nil or empty, but at least one
+// statement must be present across the two directions. An empty name is
+// rejected with ErrMigrationGeneration. The returned Migration carries the
+// absolute Path of the written file along with the parsed metadata.
+//
+// The write is atomic: a temporary file is created in dir and renamed to the
+// final name only after it has been fully written and fsynced.
+func GenerateMigration(
+	name string,
+	upStatements []string,
+	downStatements []string,
+	dir string,
+) (Migration, error) {
+	if strings.TrimSpace(name) == "" {
+		return Migration{}, surqlerrors.New(
+			surqlerrors.ErrMigrationGeneration,
+			"migration name must not be empty",
+		)
+	}
+	if len(upStatements) == 0 && len(downStatements) == 0 {
+		return Migration{}, surqlerrors.New(
+			surqlerrors.ErrMigrationGeneration,
+			"migration must define at least one up or down statement",
+		)
+	}
+
+	version := now().Format(timestampLayout)
+	return writeMigrationFile(version, name, name, nil, upStatements, downStatements, dir)
+}
+
+// GenerateInitialMigration renders the full DEFINE script for every table and
+// edge registered in registry as the up section of a single migration file.
+// The down section is empty (initial migrations are not auto-reversible).
+//
+// A nil or empty registry is rejected with ErrMigrationGeneration.
+func GenerateInitialMigration(registry *schema.SchemaRegistry, dir string) (Migration, error) {
+	if registry == nil {
+		return Migration{}, surqlerrors.New(
+			surqlerrors.ErrMigrationGeneration,
+			"registry must not be nil",
+		)
+	}
+	if registry.TableCount() == 0 && registry.EdgeCount() == 0 {
+		return Migration{}, surqlerrors.New(
+			surqlerrors.ErrMigrationGeneration,
+			"registry contains no tables or edges",
+		)
+	}
+
+	script, err := schema.GenerateSchemaSQL(registry, false)
+	if err != nil {
+		return Migration{}, surqlerrors.Wrap(
+			surqlerrors.ErrMigrationGeneration,
+			"failed to render initial schema SQL",
+			err,
+		)
+	}
+
+	up := splitScriptStatements(script)
+	if len(up) == 0 {
+		return Migration{}, surqlerrors.New(
+			surqlerrors.ErrMigrationGeneration,
+			"registry produced no DEFINE statements",
+		)
+	}
+
+	version := now().Format(timestampLayout)
+	return writeMigrationFile(
+		version,
+		initialDescriptionDefault,
+		initialDescriptionDefault,
+		nil,
+		up,
+		nil,
+		dir,
+	)
+}
+
+// CreateBlankMigration writes an empty migration template to dir. The file
+// contains no up or down statements; callers are expected to edit it before
+// applying. name is used to form the filename slug, description (when
+// non-empty) is written to the -- @description: header.
+//
+// An empty name is rejected with ErrMigrationGeneration.
+func CreateBlankMigration(name, description, dir string) (Migration, error) {
+	if strings.TrimSpace(name) == "" {
+		return Migration{}, surqlerrors.New(
+			surqlerrors.ErrMigrationGeneration,
+			"migration name must not be empty",
+		)
+	}
+
+	effectiveDescription := description
+	if strings.TrimSpace(effectiveDescription) == "" {
+		effectiveDescription = name
+	}
+
+	version := now().Format(timestampLayout)
+	return writeMigrationFile(
+		version,
+		name,
+		effectiveDescription,
+		nil,
+		nil,
+		nil,
+		dir,
+	)
+}
+
+// GenerateMigrationFromDiffs converts a pre-computed list of SchemaDiff
+// entries into a migration file. Forward SQL is emitted in diff order; down
+// statements are emitted in reverse order to satisfy drop-before-define
+// rollback semantics.
+//
+// An empty diffs slice is rejected with ErrMigrationGeneration.
+func GenerateMigrationFromDiffs(
+	name string,
+	diffs []SchemaDiff,
+	dir string,
+) (Migration, error) {
+	if strings.TrimSpace(name) == "" {
+		return Migration{}, surqlerrors.New(
+			surqlerrors.ErrMigrationGeneration,
+			"migration name must not be empty",
+		)
+	}
+	if len(diffs) == 0 {
+		return Migration{}, surqlerrors.New(
+			surqlerrors.ErrMigrationGeneration,
+			"at least one diff is required",
+		)
+	}
+
+	up := make([]string, 0, len(diffs))
+	for _, d := range diffs {
+		if d.ForwardSQL == "" {
+			continue
+		}
+		up = append(up, splitScriptStatements(d.ForwardSQL)...)
+	}
+
+	down := make([]string, 0, len(diffs))
+	for i := len(diffs) - 1; i >= 0; i-- {
+		d := diffs[i]
+		if d.BackwardSQL == "" {
+			continue
+		}
+		down = append(down, splitScriptStatements(d.BackwardSQL)...)
+	}
+
+	if len(up) == 0 && len(down) == 0 {
+		return Migration{}, surqlerrors.New(
+			surqlerrors.ErrMigrationGeneration,
+			"diffs produced no SQL statements",
+		)
+	}
+
+	version := now().Format(timestampLayout)
+	return writeMigrationFile(version, name, name, nil, up, down, dir)
+}
+
+// BuildFilename returns the canonical migration filename for the given
+// version timestamp and description slug. It is exported primarily for
+// tooling; callers of the generator API receive fully resolved paths back
+// from the Migration.Path field.
+func BuildFilename(version, description string) string {
+	slug := sanitizeSlug(description)
+	if slug == "" {
+		slug = "migration"
+	}
+	return fmt.Sprintf("%s_%s.surql", version, slug)
+}
+
+// sanitizeSlug lower-cases the input, replaces spaces with underscores, drops
+// any characters that are not alphanumeric or underscore, and collapses
+// consecutive underscores.
+func sanitizeSlug(s string) string {
+	out := strings.ToLower(strings.TrimSpace(s))
+	out = strings.ReplaceAll(out, "-", "_")
+	out = strings.ReplaceAll(out, " ", "_")
+	out = slugFilterPattern.ReplaceAllString(out, "")
+	out = slugCollapsePattern.ReplaceAllString(out, "_")
+	out = strings.Trim(out, "_")
+	return out
+}
+
+// splitScriptStatements breaks a SurrealQL script into individual terminated
+// statements, mirroring how discovery.splitStatements re-parses an on-disk
+// file. It keeps generator output round-trippable through LoadMigration.
+func splitScriptStatements(script string) []string {
+	if strings.TrimSpace(script) == "" {
+		return nil
+	}
+	// Normalize line endings and drop pure-comment / blank lines.
+	script = strings.ReplaceAll(script, "\r\n", "\n")
+	lines := strings.Split(script, "\n")
+	cleaned := make([]string, 0, len(lines))
+	for _, raw := range lines {
+		trim := strings.TrimSpace(raw)
+		if trim == "" {
+			continue
+		}
+		if strings.HasPrefix(trim, "--") {
+			continue
+		}
+		cleaned = append(cleaned, trim)
+	}
+	if len(cleaned) == 0 {
+		return nil
+	}
+	joined := strings.Join(cleaned, " ")
+	parts := strings.Split(joined, ";")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		stmt := strings.TrimSpace(part)
+		if stmt == "" {
+			continue
+		}
+		out = append(out, stmt+";")
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// renderMigrationContent produces the body of a `.surql` migration file.
+// Header lines are emitted in a stable order (description, depends_on)
+// followed by the `-- @up` and `-- @down` sections.
+func renderMigrationContent(
+	description string,
+	dependsOn []string,
+	up []string,
+	down []string,
+) string {
+	var b strings.Builder
+	if description != "" {
+		b.WriteString("-- @description: ")
+		b.WriteString(description)
+		b.WriteByte('\n')
+	}
+	if len(dependsOn) > 0 {
+		b.WriteString("-- @depends_on: ")
+		b.WriteString(strings.Join(dependsOn, ", "))
+		b.WriteByte('\n')
+	}
+	b.WriteString("-- @up\n")
+	for _, stmt := range up {
+		b.WriteString(stmt)
+		if !strings.HasSuffix(stmt, "\n") {
+			b.WriteByte('\n')
+		}
+	}
+	b.WriteString("-- @down\n")
+	for _, stmt := range down {
+		b.WriteString(stmt)
+		if !strings.HasSuffix(stmt, "\n") {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// writeMigrationFile renders the migration content and writes it atomically
+// to <dir>/<version>_<slug>.surql. On success it returns a Migration populated
+// with parsed metadata (via LoadMigration) so callers get the final on-disk
+// representation, including the computed checksum.
+func writeMigrationFile(
+	version string,
+	slugSource string,
+	description string,
+	dependsOn []string,
+	up []string,
+	down []string,
+	dir string,
+) (Migration, error) {
+	if strings.TrimSpace(dir) == "" {
+		return Migration{}, surqlerrors.New(
+			surqlerrors.ErrMigrationGeneration,
+			"migration directory must not be empty",
+		)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return Migration{}, surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationGeneration, err,
+			"cannot create migration directory %q", dir,
+		)
+	}
+
+	filename := BuildFilename(version, slugSource)
+	if !ValidateMigrationName(filename) {
+		return Migration{}, surqlerrors.Newf(
+			surqlerrors.ErrMigrationGeneration,
+			"generated filename %q is not a valid migration name", filename,
+		)
+	}
+	finalPath := filepath.Join(dir, filename)
+
+	content := renderMigrationContent(description, dependsOn, up, down)
+
+	if err := atomicWriteFile(finalPath, []byte(content)); err != nil {
+		return Migration{}, surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationGeneration, err,
+			"failed to write migration %q", finalPath,
+		)
+	}
+
+	// Load the written file back so the returned Migration is exactly what
+	// discovery would see. This also guarantees the round-trip contract
+	// documented on each generator function.
+	m, err := LoadMigration(finalPath)
+	if err != nil {
+		// Best-effort cleanup; the on-disk file is malformed which is a
+		// programmer error in the generator, not a caller error.
+		_ = os.Remove(finalPath)
+		return Migration{}, surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationGeneration, err,
+			"generator produced invalid migration file %q", finalPath,
+		)
+	}
+	return m, nil
+}
+
+// atomicWriteFile writes data to path via a temporary file in the same
+// directory, fsyncs it, and renames it into place. This avoids readers ever
+// seeing a partially-written migration file.
+func atomicWriteFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+
+	tmp, err := os.CreateTemp(dir, "."+base+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	// Clean up the temp file on any failure after CreateTemp.
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+
+	// Best-effort: fsync the containing directory so the rename is durable.
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+	return nil
+}

--- a/pkg/surql/migration/generator_test.go
+++ b/pkg/surql/migration/generator_test.go
@@ -1,0 +1,658 @@
+package migration
+
+import (
+	stdErrors "errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/schema"
+)
+
+// withFrozenClock overrides the generator's clock for the duration of a test.
+// It returns a cleanup function the caller defers.
+func withFrozenClock(t *testing.T, ts time.Time) func() {
+	t.Helper()
+	prev := now
+	now = func() time.Time { return ts.UTC() }
+	return func() { now = prev }
+}
+
+// -----------------------------------------------------------------------------
+// Timestamp / filename helpers
+// -----------------------------------------------------------------------------
+
+func TestTimestampLayoutFormat(t *testing.T) {
+	ts := time.Date(2026, 4, 18, 7, 9, 3, 0, time.UTC)
+	got := ts.Format(timestampLayout)
+	if got != "20260418_070903" {
+		t.Fatalf("timestamp = %q, want %q", got, "20260418_070903")
+	}
+	if !regexp.MustCompile(`^\d{8}_\d{6}$`).MatchString(got) {
+		t.Fatalf("timestamp does not match YYYYMMDD_HHMMSS: %q", got)
+	}
+}
+
+func TestSanitizeSlug(t *testing.T) {
+	cases := map[string]string{
+		"Create user table":       "create_user_table",
+		"  Create   user  table ": "create_user_table",
+		"create-user-table":       "create_user_table",
+		"MiXeD Case!@#":           "mixed_case",
+		"users/orders":            "usersorders",
+		"":                        "",
+		"__already__snake__":      "already_snake",
+		"drop user":               "drop_user",
+		"123 numeric start":       "123_numeric_start",
+	}
+	for in, want := range cases {
+		got := sanitizeSlug(in)
+		if got != want {
+			t.Errorf("sanitizeSlug(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBuildFilename(t *testing.T) {
+	got := BuildFilename("20260418_070903", "Create User Table")
+	if got != "20260418_070903_create_user_table.surql" {
+		t.Fatalf("BuildFilename = %q", got)
+	}
+	if !ValidateMigrationName(got) {
+		t.Fatalf("generated filename %q is not a valid migration name", got)
+	}
+}
+
+func TestBuildFilename_FallsBackToMigration(t *testing.T) {
+	// All characters filtered out -> slug empty -> falls back to "migration".
+	got := BuildFilename("20260418_070903", "***")
+	if got != "20260418_070903_migration.surql" {
+		t.Fatalf("BuildFilename fallback = %q", got)
+	}
+	if !ValidateMigrationName(got) {
+		t.Fatalf("fallback filename %q invalid", got)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// splitScriptStatements
+// -----------------------------------------------------------------------------
+
+func TestSplitScriptStatements_Basic(t *testing.T) {
+	script := "DEFINE TABLE user SCHEMAFULL;\nDEFINE FIELD email ON user TYPE string;"
+	got := splitScriptStatements(script)
+	want := []string{
+		"DEFINE TABLE user SCHEMAFULL;",
+		"DEFINE FIELD email ON user TYPE string;",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v want %#v", got, want)
+	}
+}
+
+func TestSplitScriptStatements_DropsCommentsAndBlanks(t *testing.T) {
+	script := "-- comment\nDEFINE TABLE u SCHEMAFULL;\n\n-- another\nDEFINE FIELD x ON u TYPE int;\n"
+	got := splitScriptStatements(script)
+	want := []string{"DEFINE TABLE u SCHEMAFULL;", "DEFINE FIELD x ON u TYPE int;"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v want %#v", got, want)
+	}
+}
+
+func TestSplitScriptStatements_Empty(t *testing.T) {
+	if got := splitScriptStatements(""); got != nil {
+		t.Fatalf("empty -> %#v", got)
+	}
+	if got := splitScriptStatements("   \n-- only a comment\n"); got != nil {
+		t.Fatalf("only comments -> %#v", got)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// renderMigrationContent
+// -----------------------------------------------------------------------------
+
+func TestRenderMigrationContent_FullBody(t *testing.T) {
+	body := renderMigrationContent(
+		"create user",
+		[]string{"20260101_000000_init"},
+		[]string{"DEFINE TABLE user SCHEMAFULL;"},
+		[]string{"REMOVE TABLE user;"},
+	)
+	if !strings.Contains(body, "-- @description: create user\n") {
+		t.Errorf("description header missing:\n%s", body)
+	}
+	if !strings.Contains(body, "-- @depends_on: 20260101_000000_init\n") {
+		t.Errorf("depends_on header missing:\n%s", body)
+	}
+	if !strings.Contains(body, "-- @up\nDEFINE TABLE user SCHEMAFULL;\n-- @down\n") {
+		t.Errorf("up section wrong:\n%s", body)
+	}
+	if !strings.HasSuffix(body, "REMOVE TABLE user;\n") {
+		t.Errorf("down section wrong:\n%s", body)
+	}
+}
+
+func TestRenderMigrationContent_OmitsEmptyHeaders(t *testing.T) {
+	body := renderMigrationContent("", nil, nil, nil)
+	if strings.Contains(body, "-- @description:") {
+		t.Errorf("unexpected description header: %q", body)
+	}
+	if strings.Contains(body, "-- @depends_on:") {
+		t.Errorf("unexpected depends_on header: %q", body)
+	}
+	if !strings.Contains(body, "-- @up\n") || !strings.Contains(body, "-- @down\n") {
+		t.Errorf("missing up/down markers: %q", body)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// GenerateMigration
+// -----------------------------------------------------------------------------
+
+func TestGenerateMigration_WritesAndRoundTrips(t *testing.T) {
+	defer withFrozenClock(t, time.Date(2026, 4, 18, 7, 9, 3, 0, time.UTC))()
+	dir := t.TempDir()
+
+	up := []string{"DEFINE TABLE user SCHEMAFULL;", "DEFINE FIELD email ON user TYPE string;"}
+	down := []string{"REMOVE TABLE user;"}
+
+	m, mgErr := GenerateMigration("Create user", up, down, dir)
+	if mgErr != nil {
+		t.Fatalf("generator error: %v", mgErr)
+	}
+
+	wantName := "20260418_070903_create_user.surql"
+	if filepath.Base(m.Path) != wantName {
+		t.Fatalf("filename = %q, want %q", filepath.Base(m.Path), wantName)
+	}
+	if m.Version != "20260418_070903" {
+		t.Errorf("version = %q", m.Version)
+	}
+	if !reflect.DeepEqual(m.UpStatements, up) {
+		t.Errorf("up = %#v", m.UpStatements)
+	}
+	if !reflect.DeepEqual(m.DownStatements, down) {
+		t.Errorf("down = %#v", m.DownStatements)
+	}
+
+	// Re-load from disk to verify the round-trip.
+	reloaded, err := LoadMigration(m.Path)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if !reflect.DeepEqual(reloaded.UpStatements, up) {
+		t.Errorf("reload up = %#v", reloaded.UpStatements)
+	}
+	if !reflect.DeepEqual(reloaded.DownStatements, down) {
+		t.Errorf("reload down = %#v", reloaded.DownStatements)
+	}
+	if reloaded.Version != m.Version {
+		t.Errorf("reload version = %q", reloaded.Version)
+	}
+	if reloaded.Checksum != m.Checksum {
+		t.Errorf("checksum drifted: %q vs %q", reloaded.Checksum, m.Checksum)
+	}
+}
+
+func TestGenerateMigration_CreatesDirectory(t *testing.T) {
+	defer withFrozenClock(t, time.Date(2026, 4, 18, 7, 9, 3, 0, time.UTC))()
+	root := t.TempDir()
+	dir := filepath.Join(root, "does", "not", "exist")
+
+	m, err := GenerateMigration("init", []string{"DEFINE TABLE t SCHEMAFULL;"}, nil, dir)
+	if err != nil {
+		t.Fatalf("generator error: %v", err)
+	}
+
+	if _, err := os.Stat(m.Path); err != nil {
+		t.Fatalf("expected file, got %v", err)
+	}
+}
+
+func TestGenerateMigration_RejectsEmptyName(t *testing.T) {
+	_, err := GenerateMigration("   ", []string{"X;"}, nil, t.TempDir())
+	if err == nil || !stdErrors.Is(err, surqlerrors.ErrMigrationGeneration) {
+		t.Fatalf("expected ErrMigrationGeneration, got %v", err)
+	}
+}
+
+func TestGenerateMigration_RejectsEmptyStatements(t *testing.T) {
+	_, err := GenerateMigration("name", nil, nil, t.TempDir())
+	if err == nil || !stdErrors.Is(err, surqlerrors.ErrMigrationGeneration) {
+		t.Fatalf("expected ErrMigrationGeneration, got %v", err)
+	}
+}
+
+func TestGenerateMigration_RejectsEmptyDir(t *testing.T) {
+	_, err := GenerateMigration("x", []string{"X;"}, nil, "")
+	if err == nil || !stdErrors.Is(err, surqlerrors.ErrMigrationGeneration) {
+		t.Fatalf("expected ErrMigrationGeneration, got %v", err)
+	}
+}
+
+func TestGenerateMigration_DirIsFile(t *testing.T) {
+	root := t.TempDir()
+	filePath := filepath.Join(root, "not-a-dir")
+	if err := os.WriteFile(filePath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	_, err := GenerateMigration("x", []string{"X;"}, nil, filePath)
+	if err == nil || !stdErrors.Is(err, surqlerrors.ErrMigrationGeneration) {
+		t.Fatalf("expected ErrMigrationGeneration, got %v", err)
+	}
+}
+
+func TestGenerateMigration_PathIsAbsolute(t *testing.T) {
+	defer withFrozenClock(t, time.Date(2026, 4, 18, 7, 9, 3, 0, time.UTC))()
+	dir := t.TempDir()
+	m, mgErr := GenerateMigration("abs", []string{"X;"}, nil, dir)
+	if mgErr != nil {
+		t.Fatalf("generator error: %v", mgErr)
+	}
+	if !filepath.IsAbs(m.Path) {
+		t.Fatalf("expected absolute path, got %q", m.Path)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// GenerateInitialMigration
+// -----------------------------------------------------------------------------
+
+func TestGenerateInitialMigration_MultiTableRegistry(t *testing.T) {
+	defer withFrozenClock(t, time.Date(2026, 4, 18, 8, 0, 0, 0, time.UTC))()
+	dir := t.TempDir()
+
+	reg := schema.NewSchemaRegistry()
+	if err := reg.RegisterTable(schema.NewTable("user",
+		schema.WithMode(schema.TableModeSchemafull),
+		schema.WithFields(schema.StringField("email")),
+	)); err != nil {
+		t.Fatalf("register user: %v", err)
+	}
+	if err := reg.RegisterTable(schema.NewTable("post",
+		schema.WithMode(schema.TableModeSchemafull),
+		schema.WithFields(schema.StringField("title")),
+	)); err != nil {
+		t.Fatalf("register post: %v", err)
+	}
+
+	m, mgErr := GenerateInitialMigration(reg, dir)
+	if mgErr != nil {
+		t.Fatalf("generator error: %v", mgErr)
+	}
+
+	if filepath.Base(m.Path) != "20260418_080000_initial_schema.surql" {
+		t.Errorf("filename = %q", filepath.Base(m.Path))
+	}
+	if len(m.UpStatements) == 0 {
+		t.Fatalf("expected up statements, got none")
+	}
+	if len(m.DownStatements) != 0 {
+		t.Errorf("expected no down statements, got %d", len(m.DownStatements))
+	}
+
+	// All emitted statements must be terminated and contain user + post.
+	joined := strings.Join(m.UpStatements, "\n")
+	if !strings.Contains(joined, "DEFINE TABLE user") {
+		t.Errorf("missing DEFINE TABLE user in:\n%s", joined)
+	}
+	if !strings.Contains(joined, "DEFINE TABLE post") {
+		t.Errorf("missing DEFINE TABLE post in:\n%s", joined)
+	}
+
+	// Round-trip through LoadMigration.
+	reloaded, err := LoadMigration(m.Path)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if !reflect.DeepEqual(reloaded.UpStatements, m.UpStatements) {
+		t.Errorf("round-trip up statements changed")
+	}
+}
+
+func TestGenerateInitialMigration_NilRegistry(t *testing.T) {
+	_, err := GenerateInitialMigration(nil, t.TempDir())
+	if err == nil || !stdErrors.Is(err, surqlerrors.ErrMigrationGeneration) {
+		t.Fatalf("expected ErrMigrationGeneration, got %v", err)
+	}
+}
+
+func TestGenerateInitialMigration_EmptyRegistry(t *testing.T) {
+	reg := schema.NewSchemaRegistry()
+	_, err := GenerateInitialMigration(reg, t.TempDir())
+	if err == nil || !stdErrors.Is(err, surqlerrors.ErrMigrationGeneration) {
+		t.Fatalf("expected ErrMigrationGeneration, got %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// CreateBlankMigration
+// -----------------------------------------------------------------------------
+
+func TestCreateBlankMigration_Roundtrip(t *testing.T) {
+	defer withFrozenClock(t, time.Date(2026, 4, 18, 9, 0, 0, 0, time.UTC))()
+	dir := t.TempDir()
+
+	m, mgErr := CreateBlankMigration("custom_data", "Custom data migration", dir)
+	if mgErr != nil {
+		t.Fatalf("generator error: %v", mgErr)
+	}
+
+	if filepath.Base(m.Path) != "20260418_090000_custom_data.surql" {
+		t.Errorf("filename = %q", filepath.Base(m.Path))
+	}
+	if m.Description != "Custom data migration" {
+		t.Errorf("description = %q", m.Description)
+	}
+	if len(m.UpStatements) != 0 || len(m.DownStatements) != 0 {
+		t.Errorf("expected empty statements, got up=%v down=%v",
+			m.UpStatements, m.DownStatements)
+	}
+
+	reloaded, err := LoadMigration(m.Path)
+	if err != nil {
+		t.Fatalf("LoadMigration: %v", err)
+	}
+	if reloaded.Description != "Custom data migration" {
+		t.Errorf("reload description = %q", reloaded.Description)
+	}
+}
+
+func TestCreateBlankMigration_DescriptionDefaultsToName(t *testing.T) {
+	defer withFrozenClock(t, time.Date(2026, 4, 18, 9, 0, 0, 0, time.UTC))()
+	dir := t.TempDir()
+
+	m, mgErr := CreateBlankMigration("empty_desc", "", dir)
+	if mgErr != nil {
+		t.Fatalf("generator error: %v", mgErr)
+	}
+	if m.Description != "empty_desc" {
+		t.Errorf("description fallback failed: %q", m.Description)
+	}
+}
+
+func TestCreateBlankMigration_RejectsEmptyName(t *testing.T) {
+	_, err := CreateBlankMigration("", "x", t.TempDir())
+	if err == nil || !stdErrors.Is(err, surqlerrors.ErrMigrationGeneration) {
+		t.Fatalf("expected ErrMigrationGeneration, got %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// GenerateMigrationFromDiffs
+// -----------------------------------------------------------------------------
+
+func TestGenerateMigrationFromDiffs_OrdersDownInReverse(t *testing.T) {
+	defer withFrozenClock(t, time.Date(2026, 4, 18, 10, 0, 0, 0, time.UTC))()
+	dir := t.TempDir()
+
+	diffs := []SchemaDiff{
+		{
+			Operation:   DiffOperationAddTable,
+			Table:       "user",
+			ForwardSQL:  "DEFINE TABLE user SCHEMAFULL;",
+			BackwardSQL: "REMOVE TABLE user;",
+		},
+		{
+			Operation:   DiffOperationAddField,
+			Table:       "user",
+			Field:       "email",
+			ForwardSQL:  "DEFINE FIELD email ON TABLE user TYPE string;",
+			BackwardSQL: "REMOVE FIELD email ON TABLE user;",
+		},
+	}
+
+	m, mgErr := GenerateMigrationFromDiffs("add user", diffs, dir)
+	if mgErr != nil {
+		t.Fatalf("generator error: %v", mgErr)
+	}
+
+	wantUp := []string{
+		"DEFINE TABLE user SCHEMAFULL;",
+		"DEFINE FIELD email ON TABLE user TYPE string;",
+	}
+	wantDown := []string{
+		"REMOVE FIELD email ON TABLE user;",
+		"REMOVE TABLE user;",
+	}
+	if !reflect.DeepEqual(m.UpStatements, wantUp) {
+		t.Errorf("up = %#v want %#v", m.UpStatements, wantUp)
+	}
+	if !reflect.DeepEqual(m.DownStatements, wantDown) {
+		t.Errorf("down = %#v want %#v", m.DownStatements, wantDown)
+	}
+}
+
+func TestGenerateMigrationFromDiffs_SkipsEmptyStatements(t *testing.T) {
+	defer withFrozenClock(t, time.Date(2026, 4, 18, 10, 0, 0, 0, time.UTC))()
+	dir := t.TempDir()
+
+	diffs := []SchemaDiff{
+		{ForwardSQL: "DEFINE TABLE t SCHEMAFULL;", BackwardSQL: ""},
+	}
+	m, mgErr := GenerateMigrationFromDiffs("x", diffs, dir)
+	if mgErr != nil {
+		t.Fatalf("generator error: %v", mgErr)
+	}
+	if len(m.DownStatements) != 0 {
+		t.Errorf("expected empty down, got %#v", m.DownStatements)
+	}
+}
+
+func TestGenerateMigrationFromDiffs_EmptySlice(t *testing.T) {
+	_, err := GenerateMigrationFromDiffs("x", nil, t.TempDir())
+	if err == nil || !stdErrors.Is(err, surqlerrors.ErrMigrationGeneration) {
+		t.Fatalf("expected ErrMigrationGeneration, got %v", err)
+	}
+}
+
+func TestGenerateMigrationFromDiffs_RejectsEmptyName(t *testing.T) {
+	_, err := GenerateMigrationFromDiffs("", []SchemaDiff{{ForwardSQL: "X;"}}, t.TempDir())
+	if err == nil || !stdErrors.Is(err, surqlerrors.ErrMigrationGeneration) {
+		t.Fatalf("expected ErrMigrationGeneration, got %v", err)
+	}
+}
+
+func TestGenerateMigrationFromDiffs_AllEmptySQL(t *testing.T) {
+	diffs := []SchemaDiff{{Operation: DiffOperationAddTable, Table: "t"}}
+	_, err := GenerateMigrationFromDiffs("x", diffs, t.TempDir())
+	if err == nil || !stdErrors.Is(err, surqlerrors.ErrMigrationGeneration) {
+		t.Fatalf("expected ErrMigrationGeneration, got %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Integration: diff engine -> generator -> discovery
+// -----------------------------------------------------------------------------
+
+func TestGeneratorDiscoveryIntegration(t *testing.T) {
+	defer withFrozenClock(t, time.Date(2026, 4, 18, 11, 0, 0, 0, time.UTC))()
+	dir := t.TempDir()
+
+	newTable := schema.NewTable("user",
+		schema.WithMode(schema.TableModeSchemafull),
+		schema.WithFields(schema.StringField("email")),
+	)
+	diffs, err := DiffTables(nil, &newTable)
+	if err != nil {
+		t.Fatalf("DiffTables: %v", err)
+	}
+
+	m, mgErr := GenerateMigrationFromDiffs("add user table", diffs, dir)
+	if mgErr != nil {
+		t.Fatalf("generator error: %v", mgErr)
+	}
+
+	discovered, err := DiscoverMigrations(dir)
+	if err != nil {
+		t.Fatalf("DiscoverMigrations: %v", err)
+	}
+	if len(discovered) != 1 {
+		t.Fatalf("discovered %d migrations", len(discovered))
+	}
+	if discovered[0].Version != m.Version {
+		t.Errorf("discovered version = %q", discovered[0].Version)
+	}
+	if !reflect.DeepEqual(discovered[0].UpStatements, m.UpStatements) {
+		t.Errorf("discovered up differs")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Atomic write semantics
+// -----------------------------------------------------------------------------
+
+func TestAtomicWriteFile_LeavesNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "20260418_070903_atomic.surql")
+	if err := atomicWriteFile(target, []byte("hello")); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("expected exactly one file after atomic write, got %v", names)
+	}
+	if entries[0].Name() != filepath.Base(target) {
+		t.Fatalf("unexpected file %q", entries[0].Name())
+	}
+}
+
+func TestAtomicWriteFile_Overwrites(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "20260418_070903_overwrite.surql")
+	if err := atomicWriteFile(target, []byte("first")); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := atomicWriteFile(target, []byte("second")); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	body, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(body) != "second" {
+		t.Fatalf("file body = %q", string(body))
+	}
+}
+
+func TestAtomicWriteFile_FailsOnBadDir(t *testing.T) {
+	err := atomicWriteFile("/no/such/dir/file.surql", []byte("x"))
+	if err == nil {
+		t.Fatalf("expected error for bad directory")
+	}
+}
+
+func TestGenerateMigration_FilenameIsValidForDiscovery(t *testing.T) {
+	defer withFrozenClock(t, time.Date(2026, 4, 18, 11, 0, 0, 0, time.UTC))()
+	dir := t.TempDir()
+
+	// Many edge-case descriptions that should all normalize to valid filenames.
+	cases := []string{
+		"Add users",
+		"  complex !@# Title ",
+		"a-b-c",
+		"snake_case_already",
+		"UPPERCASE",
+	}
+	for _, desc := range cases {
+		// Different descriptions still share the same timestamp under the
+		// frozen clock; clean the directory between runs to avoid collisions.
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatalf("clean: %v", err)
+		}
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		m, err := GenerateMigration(desc, []string{"X;"}, nil, dir)
+		if err != nil {
+			t.Fatalf("GenerateMigration(%q): %v", desc, err)
+		}
+		if !ValidateMigrationName(filepath.Base(m.Path)) {
+			t.Errorf("filename %q invalid for discovery", filepath.Base(m.Path))
+		}
+	}
+}
+
+func TestGenerateInitialMigration_Roundtrip(t *testing.T) {
+	defer withFrozenClock(t, time.Date(2026, 4, 18, 11, 5, 0, 0, time.UTC))()
+	dir := t.TempDir()
+
+	reg := schema.NewSchemaRegistry()
+	if err := reg.RegisterTable(schema.NewTable("product",
+		schema.WithMode(schema.TableModeSchemafull),
+		schema.WithFields(schema.StringField("sku"), schema.IntField("qty")),
+	)); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	m, mgErr := GenerateInitialMigration(reg, dir)
+	if mgErr != nil {
+		t.Fatalf("generator error: %v", mgErr)
+	}
+	reloaded, err := LoadMigration(m.Path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !reflect.DeepEqual(reloaded.UpStatements, m.UpStatements) {
+		t.Errorf("round-trip up mismatch")
+	}
+	if reloaded.Description != m.Description {
+		t.Errorf("description mismatch: %q vs %q", reloaded.Description, m.Description)
+	}
+}
+
+func TestGenerateMigration_UpOnlyAndDownOnly(t *testing.T) {
+	defer withFrozenClock(t, time.Date(2026, 4, 18, 11, 6, 0, 0, time.UTC))()
+
+	t.Run("up only", func(t *testing.T) {
+		dir := t.TempDir()
+		m, mgErr := GenerateMigration("up only", []string{"X;"}, nil, dir)
+		if mgErr != nil {
+			t.Fatalf("generator error: %v", mgErr)
+		}
+		if len(m.DownStatements) != 0 {
+			t.Errorf("down non-empty: %#v", m.DownStatements)
+		}
+	})
+
+	t.Run("down only", func(t *testing.T) {
+		dir := t.TempDir()
+		m, mgErr := GenerateMigration("down only", nil, []string{"Y;"}, dir)
+		if mgErr != nil {
+			t.Fatalf("generator error: %v", mgErr)
+		}
+		if len(m.UpStatements) != 0 {
+			t.Errorf("up non-empty: %#v", m.UpStatements)
+		}
+	})
+}
+
+func TestGenerator_ChecksumMatchesFileContent(t *testing.T) {
+	defer withFrozenClock(t, time.Date(2026, 4, 18, 11, 7, 0, 0, time.UTC))()
+	dir := t.TempDir()
+
+	m, mgErr := GenerateMigration("checksum", []string{"X;"}, nil, dir)
+	if mgErr != nil {
+		t.Fatalf("generator error: %v", mgErr)
+	}
+	raw, err := os.ReadFile(m.Path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if got := sha256Hex(raw); got != m.Checksum {
+		t.Fatalf("checksum %q != computed %q", m.Checksum, got)
+	}
+}

--- a/pkg/surql/migration/models.go
+++ b/pkg/surql/migration/models.go
@@ -1,0 +1,164 @@
+package migration
+
+import (
+	"time"
+)
+
+// MigrationState is the state of a migration in the execution lifecycle.
+type MigrationState string
+
+// MigrationState values mirrored from surql-py MigrationState enum.
+const (
+	MigrationStatePending MigrationState = "pending"
+	MigrationStateApplied MigrationState = "applied"
+	MigrationStateFailed  MigrationState = "failed"
+)
+
+// IsValid reports whether the receiver is one of the defined MigrationState
+// constants.
+func (s MigrationState) IsValid() bool {
+	switch s {
+	case MigrationStatePending, MigrationStateApplied, MigrationStateFailed:
+		return true
+	}
+	return false
+}
+
+// String returns the serialized form of the state.
+func (s MigrationState) String() string { return string(s) }
+
+// MigrationDirection indicates whether a migration is applied forward (up)
+// or rolled back (down).
+type MigrationDirection string
+
+// MigrationDirection values mirrored from surql-py MigrationDirection enum.
+const (
+	MigrationDirectionUp   MigrationDirection = "up"
+	MigrationDirectionDown MigrationDirection = "down"
+)
+
+// IsValid reports whether the receiver is one of the defined
+// MigrationDirection constants.
+func (d MigrationDirection) IsValid() bool {
+	switch d {
+	case MigrationDirectionUp, MigrationDirectionDown:
+		return true
+	}
+	return false
+}
+
+// String returns the serialized form of the direction.
+func (d MigrationDirection) String() string { return string(d) }
+
+// DiffOperation enumerates the kinds of schema changes a diff can produce.
+type DiffOperation string
+
+// DiffOperation values mirrored from surql-py DiffOperation enum.
+const (
+	DiffOperationAddTable          DiffOperation = "add_table"
+	DiffOperationDropTable         DiffOperation = "drop_table"
+	DiffOperationAddField          DiffOperation = "add_field"
+	DiffOperationDropField         DiffOperation = "drop_field"
+	DiffOperationModifyField       DiffOperation = "modify_field"
+	DiffOperationAddIndex          DiffOperation = "add_index"
+	DiffOperationDropIndex         DiffOperation = "drop_index"
+	DiffOperationAddEvent          DiffOperation = "add_event"
+	DiffOperationDropEvent         DiffOperation = "drop_event"
+	DiffOperationModifyPermissions DiffOperation = "modify_permissions"
+)
+
+// IsValid reports whether the receiver is one of the defined DiffOperation
+// constants.
+func (o DiffOperation) IsValid() bool {
+	switch o {
+	case DiffOperationAddTable, DiffOperationDropTable,
+		DiffOperationAddField, DiffOperationDropField, DiffOperationModifyField,
+		DiffOperationAddIndex, DiffOperationDropIndex,
+		DiffOperationAddEvent, DiffOperationDropEvent,
+		DiffOperationModifyPermissions:
+		return true
+	}
+	return false
+}
+
+// String returns the serialized form of the operation.
+func (o DiffOperation) String() string { return string(o) }
+
+// Migration is a single migration definition, parsed from a `.surql` file.
+//
+// Unlike the Python port (which carries Python callables), the Go model
+// stores pre-parsed SurrealQL statement slices for the forward and rollback
+// directions. This keeps the struct trivially serializable and thread-safe.
+type Migration struct {
+	// Version is the timestamp-based version string (YYYYMMDD_HHMMSS).
+	Version string `json:"version"`
+	// Description is a short human-readable summary.
+	Description string `json:"description"`
+	// Path is the absolute or relative path the migration was loaded from.
+	// Empty when the migration was constructed in memory.
+	Path string `json:"path,omitempty"`
+	// UpStatements are the SurrealQL statements executed for a forward migration.
+	UpStatements []string `json:"up_statements"`
+	// DownStatements are the SurrealQL statements executed on rollback.
+	DownStatements []string `json:"down_statements"`
+	// Checksum is a SHA-256 digest of the raw file contents, used to detect
+	// drift between applied and on-disk migrations. Empty when unknown.
+	Checksum string `json:"checksum,omitempty"`
+	// DependsOn lists version strings this migration requires to be applied
+	// first. Empty when there are no explicit dependencies.
+	DependsOn []string `json:"depends_on,omitempty"`
+}
+
+// MigrationHistory is a record of a migration that has been applied to the
+// database. It is intended to be persisted (JSON-serializable).
+type MigrationHistory struct {
+	Version         string    `json:"version"`
+	Description     string    `json:"description"`
+	AppliedAt       time.Time `json:"applied_at"`
+	Checksum        string    `json:"checksum"`
+	ExecutionTimeMs *int64    `json:"execution_time_ms,omitempty"`
+}
+
+// MigrationPlan is an ordered list of migrations with a direction.
+type MigrationPlan struct {
+	Migrations []Migration        `json:"migrations"`
+	Direction  MigrationDirection `json:"direction"`
+}
+
+// Count returns the number of migrations in the plan.
+func (p MigrationPlan) Count() int { return len(p.Migrations) }
+
+// IsEmpty reports whether the plan contains no migrations.
+func (p MigrationPlan) IsEmpty() bool { return len(p.Migrations) == 0 }
+
+// MigrationMetadata is the parsed header metadata of a migration file,
+// mirroring the Python MigrationMetadata model.
+type MigrationMetadata struct {
+	Version     string   `json:"version"`
+	Description string   `json:"description"`
+	Author      string   `json:"author,omitempty"`
+	DependsOn   []string `json:"depends_on,omitempty"`
+}
+
+// MigrationStatus combines a migration definition with its observed state,
+// optionally with the application timestamp and a last-error message.
+type MigrationStatus struct {
+	Migration Migration      `json:"migration"`
+	State     MigrationState `json:"state"`
+	AppliedAt *time.Time     `json:"applied_at,omitempty"`
+	Error     string         `json:"error,omitempty"`
+}
+
+// SchemaDiff represents a single difference between two schema versions,
+// carrying both the forward and backward SurrealQL to apply / revert it.
+type SchemaDiff struct {
+	Operation   DiffOperation  `json:"operation"`
+	Table       string         `json:"table"`
+	Field       string         `json:"field,omitempty"`
+	Index       string         `json:"index,omitempty"`
+	Event       string         `json:"event,omitempty"`
+	Description string         `json:"description"`
+	ForwardSQL  string         `json:"forward_sql"`
+	BackwardSQL string         `json:"backward_sql"`
+	Details     map[string]any `json:"details,omitempty"`
+}

--- a/pkg/surql/migration/models_test.go
+++ b/pkg/surql/migration/models_test.go
@@ -1,0 +1,355 @@
+package migration
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestMigrationState_IsValid(t *testing.T) {
+	cases := []struct {
+		in   MigrationState
+		want bool
+	}{
+		{MigrationStatePending, true},
+		{MigrationStateApplied, true},
+		{MigrationStateFailed, true},
+		{MigrationState(""), false},
+		{MigrationState("bogus"), false},
+	}
+	for _, tc := range cases {
+		if got := tc.in.IsValid(); got != tc.want {
+			t.Errorf("MigrationState(%q).IsValid() = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMigrationState_String(t *testing.T) {
+	pairs := map[MigrationState]string{
+		MigrationStatePending: "pending",
+		MigrationStateApplied: "applied",
+		MigrationStateFailed:  "failed",
+	}
+	for state, want := range pairs {
+		if got := state.String(); got != want {
+			t.Errorf("MigrationState(%q).String() = %q, want %q", state, got, want)
+		}
+	}
+}
+
+func TestMigrationDirection_IsValid(t *testing.T) {
+	cases := []struct {
+		in   MigrationDirection
+		want bool
+	}{
+		{MigrationDirectionUp, true},
+		{MigrationDirectionDown, true},
+		{MigrationDirection(""), false},
+		{MigrationDirection("sideways"), false},
+	}
+	for _, tc := range cases {
+		if got := tc.in.IsValid(); got != tc.want {
+			t.Errorf("MigrationDirection(%q).IsValid() = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMigrationDirection_String(t *testing.T) {
+	if MigrationDirectionUp.String() != "up" {
+		t.Errorf("up direction string = %q", MigrationDirectionUp.String())
+	}
+	if MigrationDirectionDown.String() != "down" {
+		t.Errorf("down direction string = %q", MigrationDirectionDown.String())
+	}
+}
+
+func TestDiffOperation_IsValid(t *testing.T) {
+	valid := []DiffOperation{
+		DiffOperationAddTable,
+		DiffOperationDropTable,
+		DiffOperationAddField,
+		DiffOperationDropField,
+		DiffOperationModifyField,
+		DiffOperationAddIndex,
+		DiffOperationDropIndex,
+		DiffOperationAddEvent,
+		DiffOperationDropEvent,
+		DiffOperationModifyPermissions,
+	}
+	for _, op := range valid {
+		if !op.IsValid() {
+			t.Errorf("DiffOperation(%q) should be valid", op)
+		}
+	}
+	invalid := []DiffOperation{"", "unknown", "ADD_TABLE"}
+	for _, op := range invalid {
+		if op.IsValid() {
+			t.Errorf("DiffOperation(%q) should be invalid", op)
+		}
+	}
+}
+
+func TestDiffOperation_String(t *testing.T) {
+	if DiffOperationAddTable.String() != "add_table" {
+		t.Errorf("add_table string = %q", DiffOperationAddTable.String())
+	}
+}
+
+func TestMigrationPlan_CountAndIsEmpty(t *testing.T) {
+	empty := MigrationPlan{Direction: MigrationDirectionUp}
+	if empty.Count() != 0 {
+		t.Errorf("empty plan Count = %d", empty.Count())
+	}
+	if !empty.IsEmpty() {
+		t.Errorf("empty plan IsEmpty = false")
+	}
+
+	full := MigrationPlan{
+		Migrations: []Migration{
+			{Version: "20260101_000000", Description: "a"},
+			{Version: "20260102_000000", Description: "b"},
+		},
+		Direction: MigrationDirectionDown,
+	}
+	if full.Count() != 2 {
+		t.Errorf("full plan Count = %d", full.Count())
+	}
+	if full.IsEmpty() {
+		t.Errorf("full plan IsEmpty = true")
+	}
+}
+
+func TestMigration_JSONRoundTrip(t *testing.T) {
+	m := Migration{
+		Version:        "20260102_120000",
+		Description:    "create user table",
+		Path:           "migrations/20260102_120000_create_user_table.surql",
+		UpStatements:   []string{"DEFINE TABLE user SCHEMAFULL;"},
+		DownStatements: []string{"REMOVE TABLE user;"},
+		Checksum:       "abc123",
+		DependsOn:      []string{"20260101_000000_init"},
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round Migration
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if round.Version != m.Version || round.Description != m.Description {
+		t.Errorf("mismatch after round trip: %+v vs %+v", round, m)
+	}
+	if len(round.UpStatements) != 1 || round.UpStatements[0] != m.UpStatements[0] {
+		t.Errorf("up statements mismatch: %+v", round.UpStatements)
+	}
+	if len(round.DownStatements) != 1 || round.DownStatements[0] != m.DownStatements[0] {
+		t.Errorf("down statements mismatch: %+v", round.DownStatements)
+	}
+	if round.Checksum != m.Checksum {
+		t.Errorf("checksum mismatch: %q", round.Checksum)
+	}
+	if len(round.DependsOn) != 1 || round.DependsOn[0] != m.DependsOn[0] {
+		t.Errorf("depends_on mismatch: %+v", round.DependsOn)
+	}
+}
+
+func TestMigration_JSONOmitsEmptyOptionalFields(t *testing.T) {
+	m := Migration{
+		Version:        "20260102_120000",
+		Description:    "noop",
+		UpStatements:   []string{"SELECT 1;"},
+		DownStatements: []string{"SELECT 1;"},
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(data)
+	for _, key := range []string{`"path":`, `"checksum":`, `"depends_on":`} {
+		if contains(s, key) {
+			t.Errorf("expected %s to be omitted, got %s", key, s)
+		}
+	}
+}
+
+func TestMigrationHistory_JSONRoundTrip(t *testing.T) {
+	execMs := int64(1234)
+	applied := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+	h := MigrationHistory{
+		Version:         "20260102_120000",
+		Description:     "create user",
+		AppliedAt:       applied,
+		Checksum:        "deadbeef",
+		ExecutionTimeMs: &execMs,
+	}
+	data, err := json.Marshal(h)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round MigrationHistory
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !round.AppliedAt.Equal(applied) {
+		t.Errorf("applied_at mismatch: %v", round.AppliedAt)
+	}
+	if round.ExecutionTimeMs == nil || *round.ExecutionTimeMs != execMs {
+		t.Errorf("execution_time_ms mismatch: %v", round.ExecutionTimeMs)
+	}
+}
+
+func TestMigrationHistory_OmitsExecutionTimeWhenNil(t *testing.T) {
+	h := MigrationHistory{
+		Version:     "20260102_120000",
+		Description: "x",
+		AppliedAt:   time.Unix(0, 0).UTC(),
+		Checksum:    "x",
+	}
+	data, err := json.Marshal(h)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if contains(string(data), `"execution_time_ms":`) {
+		t.Errorf("execution_time_ms should be omitted: %s", data)
+	}
+}
+
+func TestMigrationPlan_JSONRoundTrip(t *testing.T) {
+	p := MigrationPlan{
+		Migrations: []Migration{
+			{
+				Version:        "20260102_120000",
+				Description:    "x",
+				UpStatements:   []string{"SELECT 1;"},
+				DownStatements: []string{"SELECT 0;"},
+			},
+		},
+		Direction: MigrationDirectionUp,
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round MigrationPlan
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if round.Direction != MigrationDirectionUp {
+		t.Errorf("direction mismatch: %v", round.Direction)
+	}
+	if len(round.Migrations) != 1 {
+		t.Errorf("migrations len = %d", len(round.Migrations))
+	}
+}
+
+func TestMigrationMetadata_JSONRoundTrip(t *testing.T) {
+	md := MigrationMetadata{
+		Version:     "20260102_120000",
+		Description: "test",
+		Author:      "surql",
+		DependsOn:   []string{"20260101_000000_init"},
+	}
+	data, err := json.Marshal(md)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round MigrationMetadata
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if round.Version != md.Version || round.Description != md.Description || round.Author != md.Author {
+		t.Errorf("scalars mismatch: %+v vs %+v", round, md)
+	}
+	if len(round.DependsOn) != 1 || round.DependsOn[0] != md.DependsOn[0] {
+		t.Errorf("depends_on mismatch: %+v", round.DependsOn)
+	}
+}
+
+func TestMigrationStatus_JSONRoundTrip(t *testing.T) {
+	applied := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	s := MigrationStatus{
+		Migration: Migration{
+			Version:        "20260102_120000",
+			Description:    "x",
+			UpStatements:   []string{"SELECT 1;"},
+			DownStatements: []string{"SELECT 0;"},
+		},
+		State:     MigrationStateApplied,
+		AppliedAt: &applied,
+		Error:     "",
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round MigrationStatus
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if round.State != MigrationStateApplied {
+		t.Errorf("state mismatch: %v", round.State)
+	}
+	if round.AppliedAt == nil || !round.AppliedAt.Equal(applied) {
+		t.Errorf("applied_at mismatch: %v", round.AppliedAt)
+	}
+}
+
+func TestSchemaDiff_JSONRoundTrip(t *testing.T) {
+	d := SchemaDiff{
+		Operation:   DiffOperationAddTable,
+		Table:       "user",
+		Description: "add user table",
+		ForwardSQL:  "DEFINE TABLE user SCHEMAFULL;",
+		BackwardSQL: "REMOVE TABLE user;",
+		Details:     map[string]any{"mode": "schemafull"},
+	}
+	data, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round SchemaDiff
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if round.Operation != DiffOperationAddTable {
+		t.Errorf("operation mismatch: %v", round.Operation)
+	}
+	if round.Table != "user" || round.ForwardSQL != "DEFINE TABLE user SCHEMAFULL;" {
+		t.Errorf("scalars mismatch: %+v", round)
+	}
+	if got := round.Details["mode"]; got != "schemafull" {
+		t.Errorf("details[mode] = %v", got)
+	}
+}
+
+func TestSchemaDiff_OmitsEmptyOptionalFields(t *testing.T) {
+	d := SchemaDiff{
+		Operation:   DiffOperationAddTable,
+		Table:       "user",
+		Description: "x",
+		ForwardSQL:  "SELECT 1;",
+		BackwardSQL: "SELECT 0;",
+	}
+	data, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(data)
+	for _, key := range []string{`"field":`, `"index":`, `"event":`, `"details":`} {
+		if contains(s, key) {
+			t.Errorf("expected %s omitted, got %s", key, s)
+		}
+	}
+}
+
+// contains is a tiny substring helper to avoid pulling in strings in tests
+// that only need this one check.
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/surql/migration/versioning.go
+++ b/pkg/surql/migration/versioning.go
@@ -1,0 +1,525 @@
+package migration
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/schema"
+)
+
+// snapshotFileSuffix is the filename suffix used for persisted snapshots.
+// Snapshots are stored as "<version>.snapshot.json".
+const snapshotFileSuffix = ".snapshot.json"
+
+// snapshotClock is the clock source used by CreateSnapshot. Tests override it
+// to make Version / Timestamp deterministic; production code always uses
+// time.Now in UTC.
+var snapshotClock = func() time.Time { return time.Now().UTC() }
+
+// CreateSnapshot builds a SchemaSnapshot from the given SchemaRegistry.
+//
+// The Version is a UTC timestamp in YYYYMMDD_HHMMSS form matching the
+// migration file convention. Tables, Edges, and Accesses are copied from the
+// registry in deterministic (alphabetical) order. The snapshot captures the
+// registry as-of the call; subsequent registry mutations do not affect the
+// returned value.
+//
+// A nil registry is rejected with ErrValidation; an empty description is
+// allowed (matches surql-py where description is optional metadata).
+func CreateSnapshot(registry *schema.SchemaRegistry, description string) (SchemaSnapshot, error) {
+	if registry == nil {
+		return SchemaSnapshot{}, surqlerrors.New(surqlerrors.ErrValidation,
+			"cannot create snapshot from nil registry")
+	}
+
+	ts := snapshotClock()
+	version := ts.Format(timestampLayout)
+
+	return SchemaSnapshot{
+		Version:     version,
+		Timestamp:   ts,
+		Description: description,
+		Tables:      registry.Tables(),
+		Edges:       registry.Edges(),
+		Accesses:    []schema.AccessDefinition{},
+	}, nil
+}
+
+// StoreSnapshot writes a snapshot to a JSON file at path.
+//
+// If path is a directory, the snapshot is written to
+// "<path>/<version>.snapshot.json". If path already ends with the expected
+// suffix it is used verbatim. The snapshot must have a non-empty Version.
+// Parent directories are created as needed with 0o755 permissions; the file
+// itself is written with 0o644.
+func StoreSnapshot(snapshot SchemaSnapshot, path string) error {
+	if snapshot.Version == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"cannot store snapshot with empty version")
+	}
+	if path == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"snapshot path cannot be empty")
+	}
+
+	target, err := resolveSnapshotPath(path, snapshot.Version)
+	if err != nil {
+		return err
+	}
+
+	if dir := filepath.Dir(target); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return surqlerrors.Wrapf(surqlerrors.ErrSerialization, err,
+				"failed to create snapshot directory %q", dir)
+		}
+	}
+
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return surqlerrors.Wrapf(surqlerrors.ErrSerialization, err,
+			"failed to marshal snapshot %q", snapshot.Version)
+	}
+
+	if err := os.WriteFile(target, data, 0o644); err != nil {
+		return surqlerrors.Wrapf(surqlerrors.ErrSerialization, err,
+			"failed to write snapshot file %q", target)
+	}
+	return nil
+}
+
+// LoadSnapshot reads a snapshot JSON file from path and returns the decoded
+// SchemaSnapshot.
+//
+// A missing file returns ErrMigrationLoad; a malformed file returns
+// ErrSerialization. The returned snapshot is validated for a non-empty
+// Version field — legacy snapshots without versioning metadata are rejected
+// so that callers can rely on Version being present.
+func LoadSnapshot(path string) (SchemaSnapshot, error) {
+	if path == "" {
+		return SchemaSnapshot{}, surqlerrors.New(surqlerrors.ErrValidation,
+			"snapshot path cannot be empty")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return SchemaSnapshot{}, surqlerrors.Wrapf(surqlerrors.ErrMigrationLoad, err,
+			"failed to read snapshot file %q", path)
+	}
+
+	var snapshot SchemaSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return SchemaSnapshot{}, surqlerrors.Wrapf(surqlerrors.ErrSerialization, err,
+			"failed to decode snapshot file %q", path)
+	}
+
+	if snapshot.Version == "" {
+		return SchemaSnapshot{}, surqlerrors.Newf(surqlerrors.ErrSerialization,
+			"snapshot file %q has empty version", path)
+	}
+	return snapshot, nil
+}
+
+// ListSnapshots scans dir for snapshot files and returns the decoded
+// snapshots in ascending Version order.
+//
+// Files that do not match the snapshot suffix are skipped. Individual decode
+// failures are surfaced as errors (rather than silently dropped) so callers
+// can detect corruption. A non-existent directory returns
+// ErrMigrationDiscovery.
+func ListSnapshots(dir string) ([]SchemaSnapshot, error) {
+	if dir == "" {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation,
+			"snapshot directory cannot be empty")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, surqlerrors.Wrapf(surqlerrors.ErrMigrationDiscovery, err,
+			"failed to read snapshot directory %q", dir)
+	}
+
+	snapshots := make([]SchemaSnapshot, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, snapshotFileSuffix) {
+			continue
+		}
+		snap, err := LoadSnapshot(filepath.Join(dir, name))
+		if err != nil {
+			return nil, err
+		}
+		snapshots = append(snapshots, snap)
+	}
+
+	sort.Slice(snapshots, func(i, j int) bool {
+		return snapshots[i].Version < snapshots[j].Version
+	})
+	return snapshots, nil
+}
+
+// CompareSnapshots computes the set of SchemaDiff operations needed to evolve
+// the "from" snapshot into the "to" snapshot.
+//
+// Internally this is DiffSchemas(to, from) — DiffSchemas treats the first
+// argument as the desired (code) state and the second as the current (db)
+// state, so passing to/from in that order yields ADD diffs for entries
+// present in "to" but missing in "from", DROP diffs for the reverse.
+//
+// Accesses are not yet part of DiffSchemas; CompareSnapshots reports only
+// table and edge differences. Future work can extend the diff engine to
+// cover DEFINE ACCESS statements.
+func CompareSnapshots(from, to SchemaSnapshot) ([]SchemaDiff, error) {
+	return DiffSchemas(to, from)
+}
+
+// VersionNode is a node in the VersionGraph, tying a snapshot to its parent
+// (previous schema version) and child (subsequent) versions.
+//
+// Parent is the empty string for root nodes. Children is maintained by the
+// owning VersionGraph and is always kept in sorted order for deterministic
+// traversal.
+type VersionNode struct {
+	Version  string         `json:"version"`
+	Parent   string         `json:"parent,omitempty"`
+	Snapshot SchemaSnapshot `json:"snapshot"`
+	Children []string       `json:"children,omitempty"`
+}
+
+// VersionGraph is a thread-safe DAG of schema snapshots keyed by Version.
+//
+// It mirrors surql-py's VersionGraph: snapshots are inserted with an optional
+// parent, and the graph exposes path-finding (BFS), ancestor, descendant, and
+// bulk version listing helpers used by rollback and version comparison
+// tooling.
+type VersionGraph struct {
+	mu    sync.RWMutex
+	nodes map[string]*VersionNode
+	root  string
+}
+
+// NewVersionGraph returns an empty VersionGraph.
+func NewVersionGraph() *VersionGraph {
+	return &VersionGraph{nodes: make(map[string]*VersionNode)}
+}
+
+// Add inserts a snapshot into the graph under the given parent.
+//
+// Parent may be the empty string to register a root node; the first
+// parentless node becomes the graph's root. A duplicate Version returns
+// ErrValidation. A non-empty parent that does not yet exist in the graph
+// also returns ErrValidation. The snapshot must have a non-empty Version.
+func (g *VersionGraph) Add(snapshot SchemaSnapshot, parent string) error {
+	if snapshot.Version == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"cannot add snapshot with empty version to graph")
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if _, exists := g.nodes[snapshot.Version]; exists {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"version %q already exists in graph", snapshot.Version)
+	}
+	if parent != "" {
+		if _, ok := g.nodes[parent]; !ok {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"parent version %q not found in graph", parent)
+		}
+	}
+
+	node := &VersionNode{
+		Version:  snapshot.Version,
+		Parent:   parent,
+		Snapshot: snapshot,
+	}
+	g.nodes[snapshot.Version] = node
+
+	if parent != "" {
+		parentNode := g.nodes[parent]
+		parentNode.Children = insertSorted(parentNode.Children, snapshot.Version)
+	} else if g.root == "" {
+		g.root = snapshot.Version
+	}
+	return nil
+}
+
+// Remove deletes a node from the graph.
+//
+// Removal rewires the graph: each child of the removed node is re-parented
+// to the removed node's parent (or becomes a root if no parent exists). A
+// missing version returns ErrValidation.
+func (g *VersionGraph) Remove(version string) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	node, ok := g.nodes[version]
+	if !ok {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"version %q not found in graph", version)
+	}
+
+	// Detach from parent's children list.
+	if node.Parent != "" {
+		if parentNode, ok := g.nodes[node.Parent]; ok {
+			parentNode.Children = removeFromSlice(parentNode.Children, version)
+		}
+	}
+
+	// Re-parent children onto the removed node's parent (or promote to root).
+	for _, childVersion := range node.Children {
+		child, ok := g.nodes[childVersion]
+		if !ok {
+			continue
+		}
+		child.Parent = node.Parent
+		if node.Parent != "" {
+			if parentNode, ok := g.nodes[node.Parent]; ok {
+				parentNode.Children = insertSorted(parentNode.Children, childVersion)
+			}
+		}
+	}
+
+	delete(g.nodes, version)
+
+	// Reset root if we just removed it; promote an arbitrary remaining root.
+	if g.root == version {
+		g.root = ""
+		for v, n := range g.nodes {
+			if n.Parent == "" {
+				g.root = v
+				break
+			}
+		}
+	}
+	return nil
+}
+
+// Get returns the VersionNode for the given version (and whether it exists).
+// The returned node is a shallow copy; mutating its Children slice is safe
+// and will not affect graph state.
+func (g *VersionGraph) Get(version string) (VersionNode, bool) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	node, ok := g.nodes[version]
+	if !ok {
+		return VersionNode{}, false
+	}
+	cp := *node
+	cp.Children = append([]string(nil), node.Children...)
+	return cp, true
+}
+
+// Has reports whether the given version exists in the graph.
+func (g *VersionGraph) Has(version string) bool {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	_, ok := g.nodes[version]
+	return ok
+}
+
+// Root returns the root version (empty string when the graph is empty).
+func (g *VersionGraph) Root() string {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.root
+}
+
+// Len returns the number of versions in the graph.
+func (g *VersionGraph) Len() int {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return len(g.nodes)
+}
+
+// Versions returns every version in the graph sorted alphabetically.
+func (g *VersionGraph) Versions() []string {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	out := make([]string, 0, len(g.nodes))
+	for v := range g.nodes {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Path returns the shortest path from one version to another, traversing
+// both parent and child edges (BFS). An empty slice is returned when either
+// endpoint is missing; a nil slice is returned when no path exists between
+// existing nodes.
+func (g *VersionGraph) Path(from, to string) []string {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	if _, ok := g.nodes[from]; !ok {
+		return nil
+	}
+	if _, ok := g.nodes[to]; !ok {
+		return nil
+	}
+	if from == to {
+		return []string{from}
+	}
+
+	type state struct {
+		version string
+		path    []string
+	}
+	queue := []state{{version: from, path: []string{from}}}
+	visited := map[string]struct{}{from: {}}
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+
+		node := g.nodes[cur.version]
+		neighbours := make([]string, 0, len(node.Children)+1)
+		neighbours = append(neighbours, node.Children...)
+		if node.Parent != "" {
+			neighbours = append(neighbours, node.Parent)
+		}
+
+		for _, n := range neighbours {
+			if _, seen := visited[n]; seen {
+				continue
+			}
+			visited[n] = struct{}{}
+			newPath := make([]string, len(cur.path)+1)
+			copy(newPath, cur.path)
+			newPath[len(cur.path)] = n
+			if n == to {
+				return newPath
+			}
+			queue = append(queue, state{version: n, path: newPath})
+		}
+	}
+	return nil
+}
+
+// Ancestors returns every ancestor of the given version, ordered from root
+// down to the immediate parent. An unknown version returns nil.
+func (g *VersionGraph) Ancestors(version string) []string {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	if _, ok := g.nodes[version]; !ok {
+		return nil
+	}
+
+	var ancestors []string
+	current := version
+	for {
+		node := g.nodes[current]
+		if node == nil || node.Parent == "" {
+			break
+		}
+		ancestors = append([]string{node.Parent}, ancestors...)
+		current = node.Parent
+	}
+	return ancestors
+}
+
+// Descendants returns every descendant of the given version in BFS order.
+// An unknown version returns nil.
+func (g *VersionGraph) Descendants(version string) []string {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	node, ok := g.nodes[version]
+	if !ok {
+		return nil
+	}
+
+	descendants := make([]string, 0)
+	queue := append([]string(nil), node.Children...)
+	visited := make(map[string]struct{}, len(node.Children))
+	for _, c := range node.Children {
+		visited[c] = struct{}{}
+	}
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		descendants = append(descendants, cur)
+
+		childNode, ok := g.nodes[cur]
+		if !ok {
+			continue
+		}
+		for _, c := range childNode.Children {
+			if _, seen := visited[c]; seen {
+				continue
+			}
+			visited[c] = struct{}{}
+			queue = append(queue, c)
+		}
+	}
+	return descendants
+}
+
+// resolveSnapshotPath normalises a caller-supplied path + version into the
+// absolute snapshot filename. When path names an existing directory the
+// snapshot is placed under "<path>/<version>.snapshot.json"; when path ends
+// with the snapshot suffix it is used verbatim; otherwise the path is
+// treated as the destination file name (directory created on write).
+func resolveSnapshotPath(path, version string) (string, error) {
+	if strings.HasSuffix(path, snapshotFileSuffix) {
+		return path, nil
+	}
+
+	info, err := os.Stat(path)
+	switch {
+	case err == nil && info.IsDir():
+		return filepath.Join(path, fmt.Sprintf("%s%s", version, snapshotFileSuffix)), nil
+	case err == nil:
+		return "", surqlerrors.Newf(surqlerrors.ErrValidation,
+			"snapshot path %q exists and is neither a directory nor a %s file",
+			path, snapshotFileSuffix)
+	case os.IsNotExist(err):
+		// Non-existent paths without the snapshot suffix are treated as a
+		// directory that should be created lazily on write.
+		return filepath.Join(path, fmt.Sprintf("%s%s", version, snapshotFileSuffix)), nil
+	default:
+		return "", surqlerrors.Wrapf(surqlerrors.ErrValidation, err,
+			"failed to stat snapshot path %q", path)
+	}
+}
+
+// insertSorted returns a copy of slice with value inserted in sorted order,
+// preserving uniqueness.
+func insertSorted(slice []string, value string) []string {
+	idx := sort.SearchStrings(slice, value)
+	if idx < len(slice) && slice[idx] == value {
+		return slice
+	}
+	out := make([]string, len(slice)+1)
+	copy(out, slice[:idx])
+	out[idx] = value
+	copy(out[idx+1:], slice[idx:])
+	return out
+}
+
+// removeFromSlice returns a copy of slice with the first occurrence of value
+// removed.
+func removeFromSlice(slice []string, value string) []string {
+	for i, v := range slice {
+		if v == value {
+			out := make([]string, 0, len(slice)-1)
+			out = append(out, slice[:i]...)
+			out = append(out, slice[i+1:]...)
+			return out
+		}
+	}
+	return append([]string(nil), slice...)
+}

--- a/pkg/surql/migration/versioning_test.go
+++ b/pkg/surql/migration/versioning_test.go
@@ -1,0 +1,778 @@
+package migration
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/schema"
+)
+
+// withSnapshotClock overrides snapshotClock for the duration of the test.
+func withSnapshotClock(t *testing.T, fixed time.Time) {
+	t.Helper()
+	previous := snapshotClock
+	snapshotClock = func() time.Time { return fixed }
+	t.Cleanup(func() { snapshotClock = previous })
+}
+
+// fixedTime is a deterministic timestamp used across tests.
+func fixedTime() time.Time {
+	return time.Date(2026, 4, 18, 12, 30, 45, 0, time.UTC)
+}
+
+// populatedRegistry returns a registry containing one table + one edge.
+func populatedRegistry(t *testing.T) *schema.SchemaRegistry {
+	t.Helper()
+	reg := schema.NewSchemaRegistry()
+	if err := reg.RegisterTable(schema.NewTable("user",
+		schema.WithFields(schema.StringField("email"), schema.StringField("name")),
+	)); err != nil {
+		t.Fatalf("failed to register table: %v", err)
+	}
+	if err := reg.RegisterEdge(schema.TypedEdge("likes", "user", "post")); err != nil {
+		t.Fatalf("failed to register edge: %v", err)
+	}
+	return reg
+}
+
+func TestCreateSnapshotPopulatesVersionAndTimestamp(t *testing.T) {
+	withSnapshotClock(t, fixedTime())
+	reg := populatedRegistry(t)
+
+	snap, err := CreateSnapshot(reg, "initial")
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+	if snap.Version != "20260418_123045" {
+		t.Errorf("Version = %q, want 20260418_123045", snap.Version)
+	}
+	if !snap.Timestamp.Equal(fixedTime()) {
+		t.Errorf("Timestamp = %v, want %v", snap.Timestamp, fixedTime())
+	}
+	if snap.Description != "initial" {
+		t.Errorf("Description = %q, want %q", snap.Description, "initial")
+	}
+}
+
+func TestCreateSnapshotCopiesRegistryContents(t *testing.T) {
+	withSnapshotClock(t, fixedTime())
+	reg := populatedRegistry(t)
+
+	snap, err := CreateSnapshot(reg, "")
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+	if len(snap.Tables) != 1 || snap.Tables[0].Name != "user" {
+		t.Errorf("Tables = %v, want [user]", snap.Tables)
+	}
+	if len(snap.Edges) != 1 || snap.Edges[0].Name != "likes" {
+		t.Errorf("Edges = %v, want [likes]", snap.Edges)
+	}
+}
+
+func TestCreateSnapshotAllowsEmptyDescription(t *testing.T) {
+	withSnapshotClock(t, fixedTime())
+	snap, err := CreateSnapshot(schema.NewSchemaRegistry(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap.Description != "" {
+		t.Errorf("Description = %q, want empty", snap.Description)
+	}
+}
+
+func TestCreateSnapshotRejectsNilRegistry(t *testing.T) {
+	_, err := CreateSnapshot(nil, "nope")
+	if err == nil {
+		t.Fatal("expected error for nil registry")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestCreateSnapshotIsIndependentOfLaterRegistryMutation(t *testing.T) {
+	withSnapshotClock(t, fixedTime())
+	reg := populatedRegistry(t)
+	snap, err := CreateSnapshot(reg, "")
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+
+	// Mutating the registry after snapshot must not alter the snapshot.
+	if err := reg.RegisterTable(schema.NewTable("added_after")); err != nil {
+		t.Fatalf("failed to register later table: %v", err)
+	}
+	if len(snap.Tables) != 1 {
+		t.Errorf("snapshot Tables len = %d, want 1 after registry mutation",
+			len(snap.Tables))
+	}
+}
+
+func TestStoreAndLoadSnapshotRoundTrip(t *testing.T) {
+	withSnapshotClock(t, fixedTime())
+	reg := populatedRegistry(t)
+	snap, err := CreateSnapshot(reg, "initial schema")
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := StoreSnapshot(snap, dir); err != nil {
+		t.Fatalf("StoreSnapshot returned error: %v", err)
+	}
+
+	expectedPath := filepath.Join(dir, snap.Version+snapshotFileSuffix)
+	loaded, err := LoadSnapshot(expectedPath)
+	if err != nil {
+		t.Fatalf("LoadSnapshot returned error: %v", err)
+	}
+
+	if loaded.Version != snap.Version {
+		t.Errorf("Version mismatch: got %q, want %q", loaded.Version, snap.Version)
+	}
+	if loaded.Description != snap.Description {
+		t.Errorf("Description mismatch: got %q, want %q",
+			loaded.Description, snap.Description)
+	}
+	if len(loaded.Tables) != len(snap.Tables) {
+		t.Errorf("Tables len: got %d, want %d",
+			len(loaded.Tables), len(snap.Tables))
+	}
+	if len(loaded.Edges) != len(snap.Edges) {
+		t.Errorf("Edges len: got %d, want %d",
+			len(loaded.Edges), len(snap.Edges))
+	}
+	if !loaded.Timestamp.Equal(snap.Timestamp) {
+		t.Errorf("Timestamp mismatch: got %v, want %v",
+			loaded.Timestamp, snap.Timestamp)
+	}
+}
+
+func TestStoreSnapshotCreatesParentDirectory(t *testing.T) {
+	withSnapshotClock(t, fixedTime())
+	snap, err := CreateSnapshot(schema.NewSchemaRegistry(), "x")
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+
+	base := t.TempDir()
+	nested := filepath.Join(base, "sub", "dir")
+	if err := StoreSnapshot(snap, nested); err != nil {
+		t.Fatalf("StoreSnapshot returned error: %v", err)
+	}
+	// Directory should exist now.
+	info, err := os.Stat(nested)
+	if err != nil {
+		t.Fatalf("expected nested dir to exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected nested path to be a directory")
+	}
+}
+
+func TestStoreSnapshotAcceptsExplicitFilePath(t *testing.T) {
+	withSnapshotClock(t, fixedTime())
+	snap, err := CreateSnapshot(schema.NewSchemaRegistry(), "x")
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), "explicit"+snapshotFileSuffix)
+	if err := StoreSnapshot(snap, target); err != nil {
+		t.Fatalf("StoreSnapshot returned error: %v", err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("expected file at %q: %v", target, err)
+	}
+}
+
+func TestStoreSnapshotRejectsEmptyVersion(t *testing.T) {
+	err := StoreSnapshot(SchemaSnapshot{}, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for empty version")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestStoreSnapshotRejectsEmptyPath(t *testing.T) {
+	err := StoreSnapshot(SchemaSnapshot{Version: "v1"}, "")
+	if err == nil {
+		t.Fatal("expected error for empty path")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestLoadSnapshotMissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist"+snapshotFileSuffix)
+	_, err := LoadSnapshot(missing)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !errors.Is(err, surqlerrors.ErrMigrationLoad) {
+		t.Errorf("expected ErrMigrationLoad, got %v", err)
+	}
+}
+
+func TestLoadSnapshotMalformedJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad"+snapshotFileSuffix)
+	if err := os.WriteFile(path, []byte("not json"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	_, err := LoadSnapshot(path)
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+	if !errors.Is(err, surqlerrors.ErrSerialization) {
+		t.Errorf("expected ErrSerialization, got %v", err)
+	}
+}
+
+func TestLoadSnapshotRejectsEmptyVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "noversion"+snapshotFileSuffix)
+	payload, _ := json.Marshal(map[string]any{"tables": []any{}})
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	_, err := LoadSnapshot(path)
+	if err == nil {
+		t.Fatal("expected error for empty version")
+	}
+	if !errors.Is(err, surqlerrors.ErrSerialization) {
+		t.Errorf("expected ErrSerialization, got %v", err)
+	}
+}
+
+func TestLoadSnapshotRejectsEmptyPath(t *testing.T) {
+	_, err := LoadSnapshot("")
+	if err == nil {
+		t.Fatal("expected error for empty path")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestListSnapshotsReturnsSortedByVersion(t *testing.T) {
+	dir := t.TempDir()
+
+	versions := []string{"20260103_000000", "20260101_000000", "20260102_000000"}
+	for _, v := range versions {
+		snap := SchemaSnapshot{Version: v, Timestamp: time.Now().UTC()}
+		if err := StoreSnapshot(snap, dir); err != nil {
+			t.Fatalf("StoreSnapshot failed for %s: %v", v, err)
+		}
+	}
+
+	got, err := ListSnapshots(dir)
+	if err != nil {
+		t.Fatalf("ListSnapshots returned error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 snapshots, got %d", len(got))
+	}
+	sorted := sort.SliceIsSorted(got, func(i, j int) bool {
+		return got[i].Version < got[j].Version
+	})
+	if !sorted {
+		t.Errorf("expected sorted by version, got %v",
+			versionsOf(got))
+	}
+	want := []string{"20260101_000000", "20260102_000000", "20260103_000000"}
+	for i, v := range want {
+		if got[i].Version != v {
+			t.Errorf("index %d: got %q, want %q", i, got[i].Version, v)
+		}
+	}
+}
+
+func TestListSnapshotsIgnoresNonSnapshotFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create one real snapshot and two decoys.
+	snap := SchemaSnapshot{Version: "v1", Timestamp: time.Now().UTC()}
+	if err := StoreSnapshot(snap, dir); err != nil {
+		t.Fatalf("StoreSnapshot failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "readme.md"),
+		[]byte("nope"), 0o644); err != nil {
+		t.Fatalf("write decoy failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "data.json"),
+		[]byte("{}"), 0o644); err != nil {
+		t.Fatalf("write decoy failed: %v", err)
+	}
+
+	got, err := ListSnapshots(dir)
+	if err != nil {
+		t.Fatalf("ListSnapshots returned error: %v", err)
+	}
+	if len(got) != 1 || got[0].Version != "v1" {
+		t.Errorf("expected only the single snapshot v1, got %v",
+			versionsOf(got))
+	}
+}
+
+func TestListSnapshotsEmptyDir(t *testing.T) {
+	got, err := ListSnapshots(t.TempDir())
+	if err != nil {
+		t.Fatalf("ListSnapshots returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 snapshots, got %d", len(got))
+	}
+}
+
+func TestListSnapshotsMissingDir(t *testing.T) {
+	_, err := ListSnapshots(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err == nil {
+		t.Fatal("expected error for missing directory")
+	}
+	if !errors.Is(err, surqlerrors.ErrMigrationDiscovery) {
+		t.Errorf("expected ErrMigrationDiscovery, got %v", err)
+	}
+}
+
+func TestListSnapshotsEmptyDirPath(t *testing.T) {
+	_, err := ListSnapshots("")
+	if err == nil {
+		t.Fatal("expected error for empty dir")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestListSnapshotsPropagatesCorruption(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "bad"+snapshotFileSuffix),
+		[]byte("totally invalid"), 0o644); err != nil {
+		t.Fatalf("write corrupt snapshot: %v", err)
+	}
+	_, err := ListSnapshots(dir)
+	if err == nil {
+		t.Fatal("expected corruption to be surfaced")
+	}
+	if !errors.Is(err, surqlerrors.ErrSerialization) {
+		t.Errorf("expected ErrSerialization, got %v", err)
+	}
+}
+
+func TestCompareSnapshotsIdentity(t *testing.T) {
+	reg := populatedRegistry(t)
+	withSnapshotClock(t, fixedTime())
+	snap, err := CreateSnapshot(reg, "")
+	if err != nil {
+		t.Fatalf("CreateSnapshot returned error: %v", err)
+	}
+
+	diffs, err := CompareSnapshots(snap, snap)
+	if err != nil {
+		t.Fatalf("CompareSnapshots returned error: %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs for identical snapshots, got %v", diffs)
+	}
+}
+
+func TestCompareSnapshotsAddTable(t *testing.T) {
+	from := SchemaSnapshot{Version: "v0"}
+	to := SchemaSnapshot{
+		Version: "v1",
+		Tables:  []schema.TableDefinition{schema.NewTable("user")},
+	}
+
+	diffs, err := CompareSnapshots(from, to)
+	if err != nil {
+		t.Fatalf("CompareSnapshots returned error: %v", err)
+	}
+	if len(diffs) == 0 {
+		t.Fatal("expected at least one diff")
+	}
+	if diffs[0].Operation != DiffOperationAddTable ||
+		diffs[0].Table != "user" {
+		t.Errorf("first diff = %+v, want add_table on user", diffs[0])
+	}
+}
+
+func TestCompareSnapshotsDropTable(t *testing.T) {
+	from := SchemaSnapshot{
+		Version: "v0",
+		Tables:  []schema.TableDefinition{schema.NewTable("legacy")},
+	}
+	to := SchemaSnapshot{Version: "v1"}
+
+	diffs, err := CompareSnapshots(from, to)
+	if err != nil {
+		t.Fatalf("CompareSnapshots returned error: %v", err)
+	}
+	found := false
+	for _, d := range diffs {
+		if d.Operation == DiffOperationDropTable && d.Table == "legacy" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected drop_table diff for legacy, got %v", diffs)
+	}
+}
+
+func TestCompareSnapshotsEndToEnd(t *testing.T) {
+	// Round-trip via disk, then compare.
+	dir := t.TempDir()
+
+	reg1 := schema.NewSchemaRegistry()
+	_ = reg1.RegisterTable(schema.NewTable("user",
+		schema.WithFields(schema.StringField("email"))))
+	withSnapshotClock(t, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	snap1, err := CreateSnapshot(reg1, "v1")
+	if err != nil {
+		t.Fatalf("CreateSnapshot v1: %v", err)
+	}
+	if err := StoreSnapshot(snap1, dir); err != nil {
+		t.Fatalf("StoreSnapshot v1: %v", err)
+	}
+
+	reg2 := schema.NewSchemaRegistry()
+	_ = reg2.RegisterTable(schema.NewTable("user",
+		schema.WithFields(schema.StringField("email"), schema.StringField("name"))))
+	_ = reg2.RegisterTable(schema.NewTable("post"))
+	withSnapshotClock(t, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
+	snap2, err := CreateSnapshot(reg2, "v2")
+	if err != nil {
+		t.Fatalf("CreateSnapshot v2: %v", err)
+	}
+	if err := StoreSnapshot(snap2, dir); err != nil {
+		t.Fatalf("StoreSnapshot v2: %v", err)
+	}
+
+	snapshots, err := ListSnapshots(dir)
+	if err != nil {
+		t.Fatalf("ListSnapshots: %v", err)
+	}
+	if len(snapshots) != 2 {
+		t.Fatalf("expected 2 snapshots, got %d", len(snapshots))
+	}
+
+	diffs, err := CompareSnapshots(snapshots[0], snapshots[1])
+	if err != nil {
+		t.Fatalf("CompareSnapshots: %v", err)
+	}
+
+	ops := map[DiffOperation]int{}
+	for _, d := range diffs {
+		ops[d.Operation]++
+	}
+	if ops[DiffOperationAddTable] != 1 {
+		t.Errorf("expected 1 add_table (post), got %d", ops[DiffOperationAddTable])
+	}
+	if ops[DiffOperationAddField] != 1 {
+		t.Errorf("expected 1 add_field (user.name), got %d", ops[DiffOperationAddField])
+	}
+}
+
+// --- VersionGraph tests ---
+
+func TestVersionGraphAddRoot(t *testing.T) {
+	g := NewVersionGraph()
+	if err := g.Add(SchemaSnapshot{Version: "v1"}, ""); err != nil {
+		t.Fatalf("Add root: %v", err)
+	}
+	if g.Root() != "v1" {
+		t.Errorf("Root = %q, want v1", g.Root())
+	}
+	if g.Len() != 1 {
+		t.Errorf("Len = %d, want 1", g.Len())
+	}
+}
+
+func TestVersionGraphAddWithParent(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	if err := g.Add(SchemaSnapshot{Version: "v2"}, "v1"); err != nil {
+		t.Fatalf("Add child: %v", err)
+	}
+	node, ok := g.Get("v1")
+	if !ok {
+		t.Fatal("v1 missing")
+	}
+	if len(node.Children) != 1 || node.Children[0] != "v2" {
+		t.Errorf("v1 children = %v, want [v2]", node.Children)
+	}
+	child, ok := g.Get("v2")
+	if !ok || child.Parent != "v1" {
+		t.Errorf("v2 parent = %q, want v1", child.Parent)
+	}
+}
+
+func TestVersionGraphAddDuplicateVersion(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	err := g.Add(SchemaSnapshot{Version: "v1"}, "")
+	if err == nil {
+		t.Fatal("expected duplicate error")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestVersionGraphAddUnknownParent(t *testing.T) {
+	g := NewVersionGraph()
+	err := g.Add(SchemaSnapshot{Version: "v2"}, "nonexistent")
+	if err == nil {
+		t.Fatal("expected unknown-parent error")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestVersionGraphAddEmptyVersion(t *testing.T) {
+	g := NewVersionGraph()
+	err := g.Add(SchemaSnapshot{}, "")
+	if err == nil {
+		t.Fatal("expected empty-version error")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestVersionGraphLookup(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+
+	if !g.Has("v1") {
+		t.Error("Has(v1) = false")
+	}
+	if g.Has("missing") {
+		t.Error("Has(missing) = true")
+	}
+	if _, ok := g.Get("missing"); ok {
+		t.Error("Get(missing) returned ok")
+	}
+}
+
+func TestVersionGraphVersionsSorted(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v3"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "v3")
+	_ = g.Add(SchemaSnapshot{Version: "v2"}, "v3")
+
+	got := g.Versions()
+	want := []string{"v1", "v2", "v3"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("Versions = %v, want %v", got, want)
+	}
+}
+
+func TestVersionGraphPathLinear(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v2"}, "v1")
+	_ = g.Add(SchemaSnapshot{Version: "v3"}, "v2")
+
+	path := g.Path("v1", "v3")
+	want := []string{"v1", "v2", "v3"}
+	if strings.Join(path, ",") != strings.Join(want, ",") {
+		t.Errorf("Path(v1, v3) = %v, want %v", path, want)
+	}
+}
+
+func TestVersionGraphPathReverse(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v2"}, "v1")
+
+	path := g.Path("v2", "v1")
+	want := []string{"v2", "v1"}
+	if strings.Join(path, ",") != strings.Join(want, ",") {
+		t.Errorf("Path(v2, v1) = %v, want %v", path, want)
+	}
+}
+
+func TestVersionGraphPathSameNode(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+
+	path := g.Path("v1", "v1")
+	if len(path) != 1 || path[0] != "v1" {
+		t.Errorf("Path(v1, v1) = %v, want [v1]", path)
+	}
+}
+
+func TestVersionGraphPathUnknown(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	if path := g.Path("v1", "unknown"); path != nil {
+		t.Errorf("expected nil path for unknown endpoint, got %v", path)
+	}
+}
+
+func TestVersionGraphAncestors(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v2"}, "v1")
+	_ = g.Add(SchemaSnapshot{Version: "v3"}, "v2")
+
+	got := g.Ancestors("v3")
+	want := []string{"v1", "v2"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("Ancestors(v3) = %v, want %v", got, want)
+	}
+}
+
+func TestVersionGraphAncestorsRootHasNone(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	if got := g.Ancestors("v1"); len(got) != 0 {
+		t.Errorf("Ancestors(root) = %v, want empty", got)
+	}
+}
+
+func TestVersionGraphAncestorsUnknown(t *testing.T) {
+	g := NewVersionGraph()
+	if got := g.Ancestors("nope"); got != nil {
+		t.Errorf("Ancestors(unknown) = %v, want nil", got)
+	}
+}
+
+func TestVersionGraphDescendants(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v2a"}, "v1")
+	_ = g.Add(SchemaSnapshot{Version: "v2b"}, "v1")
+	_ = g.Add(SchemaSnapshot{Version: "v3"}, "v2a")
+
+	got := g.Descendants("v1")
+	sort.Strings(got)
+	want := []string{"v2a", "v2b", "v3"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("Descendants(v1) = %v, want %v", got, want)
+	}
+}
+
+func TestVersionGraphDescendantsLeaf(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	if got := g.Descendants("v1"); len(got) != 0 {
+		t.Errorf("Descendants(leaf) = %v, want empty", got)
+	}
+}
+
+func TestVersionGraphDescendantsUnknown(t *testing.T) {
+	g := NewVersionGraph()
+	if got := g.Descendants("nope"); got != nil {
+		t.Errorf("Descendants(unknown) = %v, want nil", got)
+	}
+}
+
+func TestVersionGraphRemoveLeaf(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v2"}, "v1")
+
+	if err := g.Remove("v2"); err != nil {
+		t.Fatalf("Remove leaf: %v", err)
+	}
+	if g.Has("v2") {
+		t.Error("v2 should be removed")
+	}
+	parent, _ := g.Get("v1")
+	if len(parent.Children) != 0 {
+		t.Errorf("v1 Children = %v, want []", parent.Children)
+	}
+}
+
+func TestVersionGraphRemoveMiddleRewiresChildren(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v2"}, "v1")
+	_ = g.Add(SchemaSnapshot{Version: "v3"}, "v2")
+
+	if err := g.Remove("v2"); err != nil {
+		t.Fatalf("Remove middle: %v", err)
+	}
+	child, _ := g.Get("v3")
+	if child.Parent != "v1" {
+		t.Errorf("v3 parent after remove = %q, want v1", child.Parent)
+	}
+	parent, _ := g.Get("v1")
+	if len(parent.Children) != 1 || parent.Children[0] != "v3" {
+		t.Errorf("v1 Children = %v, want [v3]", parent.Children)
+	}
+}
+
+func TestVersionGraphRemoveRootPromotesChild(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v2"}, "v1")
+
+	if err := g.Remove("v1"); err != nil {
+		t.Fatalf("Remove root: %v", err)
+	}
+	child, _ := g.Get("v2")
+	if child.Parent != "" {
+		t.Errorf("v2 parent after root removal = %q, want empty", child.Parent)
+	}
+	if g.Root() != "v2" {
+		t.Errorf("Root after removal = %q, want v2", g.Root())
+	}
+}
+
+func TestVersionGraphRemoveUnknown(t *testing.T) {
+	g := NewVersionGraph()
+	err := g.Remove("nope")
+	if err == nil {
+		t.Fatal("expected error for unknown version")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestVersionGraphRootEmpty(t *testing.T) {
+	g := NewVersionGraph()
+	if g.Root() != "" {
+		t.Errorf("empty graph Root = %q, want empty", g.Root())
+	}
+	if g.Len() != 0 {
+		t.Errorf("empty Len = %d, want 0", g.Len())
+	}
+}
+
+func TestVersionGraphGetReturnsCopy(t *testing.T) {
+	g := NewVersionGraph()
+	_ = g.Add(SchemaSnapshot{Version: "v1"}, "")
+	_ = g.Add(SchemaSnapshot{Version: "v2"}, "v1")
+
+	node, _ := g.Get("v1")
+	node.Children[0] = "mutated"
+
+	original, _ := g.Get("v1")
+	if original.Children[0] != "v2" {
+		t.Errorf("graph was mutated via returned node: Children[0] = %q",
+			original.Children[0])
+	}
+}
+
+// versionsOf is a small debug helper pulling the version strings from a list
+// of snapshots.
+func versionsOf(snaps []SchemaSnapshot) []string {
+	out := make([]string, 0, len(snaps))
+	for _, s := range snaps {
+		out = append(out, s.Version)
+	}
+	return out
+}

--- a/pkg/surql/query/builder.go
+++ b/pkg/surql/query/builder.go
@@ -1,0 +1,784 @@
+package query
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/types"
+)
+
+// Operation tags the high-level SurrealQL statement a Query produces.
+type Operation string
+
+const (
+	// OpSelect renders `SELECT ... FROM ...`.
+	OpSelect Operation = "SELECT"
+	// OpInsert renders `CREATE ... CONTENT {...}`.
+	OpInsert Operation = "INSERT"
+	// OpUpdate renders `UPDATE ... SET ...`.
+	OpUpdate Operation = "UPDATE"
+	// OpUpsert renders `UPSERT ... CONTENT {...}`.
+	OpUpsert Operation = "UPSERT"
+	// OpDelete renders `DELETE ...`.
+	OpDelete Operation = "DELETE"
+	// OpRelate renders `RELATE from->edge->to`.
+	OpRelate Operation = "RELATE"
+)
+
+// OrderField is one `(field, direction)` pair used in `ORDER BY`.
+type OrderField struct {
+	Field     string
+	Direction string
+}
+
+// Query is an immutable SurrealQL query builder.
+//
+// Every method returns a new Query; the receiver is never mutated. The
+// zero value represents an empty query with no operation yet assigned.
+// `ToSurql` renders the accumulated state to a SurrealQL string and
+// returns `ErrValidation` if the query is incomplete.
+type Query struct {
+	// Operation is the statement kind; empty until one of Select/Insert/... is called.
+	Operation Operation
+
+	// TableName is the target table or record id.
+	TableName string
+
+	// Fields lists the projection columns for SELECT.
+	Fields []string
+
+	// Conditions are raw SurrealQL WHERE fragments (already operator-rendered).
+	Conditions []string
+
+	// OrderFields are the ORDER BY pairs in insertion order.
+	OrderFields []OrderField
+
+	// GroupFields are the explicit GROUP BY columns.
+	GroupFields []string
+
+	// GroupAllFlag toggles SurrealQL's `GROUP ALL` aggregation.
+	GroupAllFlag bool
+
+	// LimitValue bounds the number of rows when non-nil.
+	LimitValue *int
+
+	// OffsetValue skips rows when non-nil (rendered as `START n`).
+	OffsetValue *int
+
+	// InsertData carries the body for INSERT statements.
+	InsertData map[string]any
+
+	// UpdateData carries the body for UPDATE / UPSERT statements.
+	UpdateData map[string]any
+
+	// RelateFrom is the source record for RELATE.
+	RelateFrom string
+
+	// RelateTo is the destination record for RELATE.
+	RelateTo string
+
+	// RelateData is the edge body for RELATE.
+	RelateData map[string]any
+
+	// JoinClauses are raw JOIN fragments appended after the FROM.
+	JoinClauses []string
+
+	// GraphTraversal is the `->edge->target` suffix for SELECT.
+	GraphTraversal string
+
+	// ReturnFormat controls the `RETURN ...` clause on mutations.
+	ReturnFormat ReturnFormat
+
+	// Vector search parameters (MTREE-style `<|k,distance|>`).
+	VectorField     string
+	VectorValue     []float64
+	VectorK         *int
+	VectorDistance  VectorDistanceType
+	VectorThreshold *float64
+
+	// Hints accumulates optimization comments rendered by [RenderHints].
+	Hints []QueryHint
+}
+
+// NewQuery returns an empty Query.
+func NewQuery() Query { return Query{} }
+
+// ---------------------------------------------------------------------------
+// Helpers (private) — copy-and-mutate semantics.
+// ---------------------------------------------------------------------------
+
+// clone returns a deep-enough copy so that caller mutations on the
+// returned value cannot leak back into the original slices/maps.
+func (q Query) clone() Query {
+	out := q
+	if q.Fields != nil {
+		out.Fields = append([]string(nil), q.Fields...)
+	}
+	if q.Conditions != nil {
+		out.Conditions = append([]string(nil), q.Conditions...)
+	}
+	if q.OrderFields != nil {
+		out.OrderFields = append([]OrderField(nil), q.OrderFields...)
+	}
+	if q.GroupFields != nil {
+		out.GroupFields = append([]string(nil), q.GroupFields...)
+	}
+	if q.JoinClauses != nil {
+		out.JoinClauses = append([]string(nil), q.JoinClauses...)
+	}
+	if q.VectorValue != nil {
+		out.VectorValue = append([]float64(nil), q.VectorValue...)
+	}
+	if q.Hints != nil {
+		out.Hints = append([]QueryHint(nil), q.Hints...)
+	}
+	if q.InsertData != nil {
+		out.InsertData = copyMap(q.InsertData)
+	}
+	if q.UpdateData != nil {
+		out.UpdateData = copyMap(q.UpdateData)
+	}
+	if q.RelateData != nil {
+		out.RelateData = copyMap(q.RelateData)
+	}
+	return out
+}
+
+func copyMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Fluent API
+// ---------------------------------------------------------------------------
+
+// Select starts a SELECT query. A nil or empty slice selects `*`.
+func (q Query) Select(fields []string) Query {
+	out := q.clone()
+	out.Operation = OpSelect
+	if len(fields) == 0 {
+		out.Fields = []string{"*"}
+	} else {
+		out.Fields = append([]string(nil), fields...)
+	}
+	return out
+}
+
+// FromTable sets the table (or record id) the query targets. Returns
+// ErrValidation when the table portion is not a safe identifier.
+func (q Query) FromTable(table string) (Query, error) {
+	if err := validateIdentifier(splitTablePart(table), "table name"); err != nil {
+		return Query{}, err
+	}
+	out := q.clone()
+	out.TableName = table
+	return out, nil
+}
+
+// Where appends a condition. Accepts either a string (inserted as-is)
+// or a `types.Operator` (rendered via its `ToSurql` method).
+func (q Query) Where(condition any) (Query, error) {
+	var rendered string
+	switch c := condition.(type) {
+	case string:
+		rendered = c
+	case types.Operator:
+		rendered = c.ToSurql()
+	case nil:
+		return Query{}, surqlerrors.New(surqlerrors.ErrValidation, "Where condition cannot be nil")
+	default:
+		return Query{}, surqlerrors.Newf(
+			surqlerrors.ErrValidation,
+			"Where condition must be a string or types.Operator, got %T", condition,
+		)
+	}
+	out := q.clone()
+	out.Conditions = append(out.Conditions, rendered)
+	return out, nil
+}
+
+// OrderBy appends an ORDER BY pair. `direction` must be `ASC` or `DESC`
+// (case-insensitive); any other value returns ErrValidation.
+func (q Query) OrderBy(field, direction string) (Query, error) {
+	dir := strings.ToUpper(direction)
+	if dir != "ASC" && dir != "DESC" {
+		return Query{}, surqlerrors.Newf(
+			surqlerrors.ErrValidation,
+			"Invalid direction: %s. Must be ASC or DESC", direction,
+		)
+	}
+	out := q.clone()
+	out.OrderFields = append(out.OrderFields, OrderField{Field: field, Direction: dir})
+	return out, nil
+}
+
+// GroupBy appends explicit group keys.
+func (q Query) GroupBy(fields ...string) Query {
+	out := q.clone()
+	out.GroupFields = append(out.GroupFields, fields...)
+	return out
+}
+
+// GroupAll sets `GROUP ALL` for whole-result aggregation.
+func (q Query) GroupAll() Query {
+	out := q.clone()
+	out.GroupAllFlag = true
+	return out
+}
+
+// Limit sets the LIMIT clause. Negative values yield ErrValidation.
+func (q Query) Limit(n int) (Query, error) {
+	if n < 0 {
+		return Query{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"Limit must be non-negative, got %d", n)
+	}
+	v := n
+	out := q.clone()
+	out.LimitValue = &v
+	return out, nil
+}
+
+// Offset sets the OFFSET (rendered as `START n`). Negative values yield ErrValidation.
+func (q Query) Offset(n int) (Query, error) {
+	if n < 0 {
+		return Query{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"Offset must be non-negative, got %d", n)
+	}
+	v := n
+	out := q.clone()
+	out.OffsetValue = &v
+	return out, nil
+}
+
+// Insert builds an INSERT (SurrealDB `CREATE ... CONTENT {...}`) query.
+func (q Query) Insert(table string, data map[string]any) (Query, error) {
+	if err := validateIdentifier(table, "table name"); err != nil {
+		return Query{}, err
+	}
+	if err := validateDataKeys(data); err != nil {
+		return Query{}, err
+	}
+	out := q.clone()
+	out.Operation = OpInsert
+	out.TableName = table
+	out.InsertData = copyMap(data)
+	return out, nil
+}
+
+// Update builds an UPDATE query.
+func (q Query) Update(target string, data map[string]any) (Query, error) {
+	if err := validateIdentifier(splitTablePart(target), "table name"); err != nil {
+		return Query{}, err
+	}
+	if err := validateDataKeys(data); err != nil {
+		return Query{}, err
+	}
+	out := q.clone()
+	out.Operation = OpUpdate
+	out.TableName = target
+	out.UpdateData = copyMap(data)
+	return out, nil
+}
+
+// Upsert builds an UPSERT query (insert-or-update).
+func (q Query) Upsert(target string, data map[string]any) (Query, error) {
+	if err := validateIdentifier(splitTablePart(target), "table name"); err != nil {
+		return Query{}, err
+	}
+	if err := validateDataKeys(data); err != nil {
+		return Query{}, err
+	}
+	out := q.clone()
+	out.Operation = OpUpsert
+	out.TableName = target
+	out.UpdateData = copyMap(data)
+	return out, nil
+}
+
+// Delete builds a DELETE query.
+func (q Query) Delete(target string) (Query, error) {
+	if err := validateIdentifier(splitTablePart(target), "table name"); err != nil {
+		return Query{}, err
+	}
+	out := q.clone()
+	out.Operation = OpDelete
+	out.TableName = target
+	return out, nil
+}
+
+// Relate builds a RELATE query. `from` and `to` may be a `string` or
+// `types.RecordID`; any other concrete type returns ErrValidation.
+func (q Query) Relate(edgeTable string, from, to any, data map[string]any) (Query, error) {
+	if err := validateIdentifier(edgeTable, "edge table name"); err != nil {
+		return Query{}, err
+	}
+	fromStr, err := relateEndpoint(from)
+	if err != nil {
+		return Query{}, err
+	}
+	toStr, err := relateEndpoint(to)
+	if err != nil {
+		return Query{}, err
+	}
+	if err := validateIdentifier(splitTablePart(fromStr), "from table name"); err != nil {
+		return Query{}, err
+	}
+	if err := validateIdentifier(splitTablePart(toStr), "to table name"); err != nil {
+		return Query{}, err
+	}
+	if data != nil {
+		if err := validateDataKeys(data); err != nil {
+			return Query{}, err
+		}
+	}
+	out := q.clone()
+	out.Operation = OpRelate
+	out.TableName = edgeTable
+	out.RelateFrom = fromStr
+	out.RelateTo = toStr
+	out.RelateData = copyMap(data)
+	return out, nil
+}
+
+// Traverse sets the graph traversal suffix appended to the FROM clause.
+func (q Query) Traverse(path string) Query {
+	out := q.clone()
+	out.GraphTraversal = path
+	return out
+}
+
+// Join appends a raw JOIN clause.
+func (q Query) Join(clause string) Query {
+	out := q.clone()
+	out.JoinClauses = append(out.JoinClauses, clause)
+	return out
+}
+
+// VectorSearch configures a SurrealDB MTREE k-nearest-neighbour search.
+// Pass a non-nil `threshold` to emit the three-arg operator form.
+func (q Query) VectorSearch(
+	field string,
+	vector []float64,
+	k int,
+	distance VectorDistanceType,
+	threshold *float64,
+) (Query, error) {
+	if k < 1 {
+		return Query{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"k must be at least 1, got %d", k)
+	}
+	if len(vector) == 0 {
+		return Query{}, surqlerrors.New(surqlerrors.ErrValidation, "Vector cannot be empty")
+	}
+	kv := k
+	out := q.clone()
+	out.VectorField = field
+	out.VectorValue = append([]float64(nil), vector...)
+	out.VectorK = &kv
+	out.VectorDistance = distance
+	if threshold != nil {
+		t := *threshold
+		out.VectorThreshold = &t
+	}
+	return out, nil
+}
+
+// SimilarityScore adds `vector::similarity::<metric>(field, vector) AS alias`
+// to the projection.
+func (q Query) SimilarityScore(field string, vector []float64, metric VectorDistanceType, alias string) Query {
+	vec := renderVectorLiteral(vector)
+	metricLower := strings.ToLower(string(metric))
+	if alias == "" {
+		alias = "similarity"
+	}
+	expr := fmt.Sprintf("vector::similarity::%s(%s, %s) AS %s", metricLower, field, vec, alias)
+	out := q.clone()
+	out.Fields = append(out.Fields, expr)
+	return out
+}
+
+// WithReturnFormat sets the RETURN clause to a specific format.
+func (q Query) WithReturnFormat(f ReturnFormat) Query {
+	out := q.clone()
+	out.ReturnFormat = f
+	return out
+}
+
+// ReturnNone shortcut for `RETURN NONE`.
+func (q Query) ReturnNone() Query { return q.WithReturnFormat(ReturnNone) }
+
+// ReturnDiff shortcut for `RETURN DIFF`.
+func (q Query) ReturnDiff() Query { return q.WithReturnFormat(ReturnDiff) }
+
+// ReturnFull shortcut for `RETURN FULL`.
+func (q Query) ReturnFull() Query { return q.WithReturnFormat(ReturnFull) }
+
+// ReturnBefore shortcut for `RETURN BEFORE`.
+func (q Query) ReturnBefore() Query { return q.WithReturnFormat(ReturnBefore) }
+
+// ReturnAfter shortcut for `RETURN AFTER`.
+func (q Query) ReturnAfter() Query { return q.WithReturnFormat(ReturnAfter) }
+
+// Hint appends a query optimization hint.
+func (q Query) Hint(hint QueryHint) Query {
+	out := q.clone()
+	out.Hints = append(out.Hints, hint)
+	return out
+}
+
+// WithHints appends multiple hints in order.
+func (q Query) WithHints(hints ...QueryHint) Query {
+	out := q.clone()
+	out.Hints = append(out.Hints, hints...)
+	return out
+}
+
+// ForceIndex adds an `IndexHint` with the force flag set. Requires the
+// table to have been set first.
+func (q Query) ForceIndex(index string) (Query, error) {
+	if q.TableName == "" {
+		return Query{}, surqlerrors.New(surqlerrors.ErrValidation, "Table name required for index hint")
+	}
+	return q.Hint(IndexHint{Table: q.TableName, Index: index, Force: true}), nil
+}
+
+// UseIndex adds a soft `IndexHint` (non-forcing).
+func (q Query) UseIndex(index string) (Query, error) {
+	if q.TableName == "" {
+		return Query{}, surqlerrors.New(surqlerrors.ErrValidation, "Table name required for index hint")
+	}
+	return q.Hint(IndexHint{Table: q.TableName, Index: index, Force: false}), nil
+}
+
+// WithTimeout adds a TimeoutHint.
+func (q Query) WithTimeout(seconds float64) (Query, error) {
+	hint, err := NewTimeoutHint(seconds)
+	if err != nil {
+		return Query{}, err
+	}
+	return q.Hint(hint), nil
+}
+
+// Parallel adds a ParallelHint. When maxWorkers is nil, enables with
+// the server default worker count.
+func (q Query) Parallel(maxWorkers *uint) (Query, error) {
+	if maxWorkers == nil {
+		return q.Hint(ParallelEnabled()), nil
+	}
+	hint, err := ParallelWithWorkers(*maxWorkers)
+	if err != nil {
+		return Query{}, err
+	}
+	return q.Hint(hint), nil
+}
+
+// WithFetch adds a FetchHint.
+func (q Query) WithFetch(strategy FetchStrategy, batchSize *uint32) (Query, error) {
+	switch strategy {
+	case FetchEager:
+		return q.Hint(FetchEagerHint()), nil
+	case FetchLazy:
+		return q.Hint(FetchLazyHint()), nil
+	case FetchBatch:
+		if batchSize == nil {
+			return Query{}, surqlerrors.New(surqlerrors.ErrValidation,
+				"FetchHint batch_size required when strategy is batch")
+		}
+		hint, err := FetchBatchHint(*batchSize)
+		if err != nil {
+			return Query{}, err
+		}
+		return q.Hint(hint), nil
+	default:
+		return Query{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"unknown fetch strategy: %q", strategy)
+	}
+}
+
+// Explain adds an ExplainHint. `full=true` asks for the full plan.
+func (q Query) Explain(full bool) Query {
+	if full {
+		return q.Hint(ExplainFull())
+	}
+	return q.Hint(ExplainShort())
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+// ToSurql renders the Query to a SurrealQL string. Returns ErrValidation
+// when the query is incomplete or internally inconsistent.
+func (q Query) ToSurql() (string, error) {
+	if q.Operation == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Query operation not specified")
+	}
+	var (
+		base string
+		err  error
+	)
+	switch q.Operation {
+	case OpSelect:
+		base, err = q.buildSelect()
+	case OpInsert:
+		base, err = q.buildInsert()
+	case OpUpdate:
+		base, err = q.buildUpdate()
+	case OpDelete:
+		base, err = q.buildDelete()
+	case OpUpsert:
+		base, err = q.buildUpsert()
+	case OpRelate:
+		base, err = q.buildRelate()
+	default:
+		return "", surqlerrors.Newf(surqlerrors.ErrValidation, "Unsupported operation: %s", q.Operation)
+	}
+	if err != nil {
+		return "", err
+	}
+	if len(q.Hints) > 0 {
+		return RenderHints(q.Hints) + "\n" + base, nil
+	}
+	return base, nil
+}
+
+// MustToSurql is ToSurql that panics on error. Convenient for tests.
+func (q Query) MustToSurql() string {
+	s, err := q.ToSurql()
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func (q Query) buildSelect() (string, error) {
+	if q.TableName == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Table name required for SELECT query")
+	}
+	fieldsStr := "*"
+	if len(q.Fields) > 0 {
+		fieldsStr = strings.Join(q.Fields, ", ")
+	}
+	head := "SELECT " + fieldsStr + " FROM " + q.TableName
+	if q.GraphTraversal != "" {
+		head += q.GraphTraversal
+	}
+	parts := []string{head}
+	parts = append(parts, q.JoinClauses...)
+
+	var whereParts []string
+	if q.VectorField != "" && len(q.VectorValue) > 0 && q.VectorK != nil && q.VectorDistance != "" {
+		vec := renderVectorLiteral(q.VectorValue)
+		var op string
+		if q.VectorThreshold != nil {
+			op = fmt.Sprintf("<|%d,%s,%s|>", *q.VectorK, string(q.VectorDistance), formatFloat(*q.VectorThreshold))
+		} else {
+			op = fmt.Sprintf("<|%d,%s|>", *q.VectorK, string(q.VectorDistance))
+		}
+		whereParts = append(whereParts, fmt.Sprintf("%s %s %s", q.VectorField, op, vec))
+	}
+	for _, c := range q.Conditions {
+		whereParts = append(whereParts, "("+c+")")
+	}
+	if len(whereParts) > 0 {
+		parts = append(parts, "WHERE "+strings.Join(whereParts, " AND "))
+	}
+
+	if q.GroupAllFlag {
+		parts = append(parts, "GROUP ALL")
+	} else if len(q.GroupFields) > 0 {
+		parts = append(parts, "GROUP BY "+strings.Join(q.GroupFields, ", "))
+	}
+
+	if len(q.OrderFields) > 0 {
+		ordered := make([]string, len(q.OrderFields))
+		for i, of := range q.OrderFields {
+			ordered[i] = of.Field + " " + of.Direction
+		}
+		parts = append(parts, "ORDER BY "+strings.Join(ordered, ", "))
+	}
+
+	if q.LimitValue != nil {
+		parts = append(parts, "LIMIT "+strconv.Itoa(*q.LimitValue))
+	}
+	if q.OffsetValue != nil {
+		parts = append(parts, "START "+strconv.Itoa(*q.OffsetValue))
+	}
+	return strings.Join(parts, " "), nil
+}
+
+func (q Query) buildInsert() (string, error) {
+	if q.TableName == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Table name required for INSERT query")
+	}
+	if len(q.InsertData) == 0 {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Insert data required for INSERT query")
+	}
+	body := renderDataObject(q.InsertData)
+	parts := []string{"CREATE " + q.TableName + " CONTENT " + body}
+	if q.ReturnFormat != "" {
+		parts = append(parts, "RETURN "+q.ReturnFormat.ToSurql())
+	}
+	return strings.Join(parts, " "), nil
+}
+
+func (q Query) buildUpdate() (string, error) {
+	if q.TableName == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Table name required for UPDATE query")
+	}
+	if len(q.UpdateData) == 0 {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Update data required for UPDATE query")
+	}
+	keys := sortedKeys(q.UpdateData)
+	setParts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		setParts = append(setParts, k+" = "+quoteValueExpr(q.UpdateData[k]))
+	}
+	parts := []string{"UPDATE " + q.TableName + " SET " + strings.Join(setParts, ", ")}
+	if len(q.Conditions) > 0 {
+		parts = append(parts, "WHERE "+joinConditions(q.Conditions))
+	}
+	if q.ReturnFormat != "" {
+		parts = append(parts, "RETURN "+q.ReturnFormat.ToSurql())
+	}
+	return strings.Join(parts, " "), nil
+}
+
+func (q Query) buildUpsert() (string, error) {
+	if q.TableName == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Table name required for UPSERT query")
+	}
+	if len(q.UpdateData) == 0 {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Data required for UPSERT query")
+	}
+	body := renderDataObject(q.UpdateData)
+	parts := []string{"UPSERT " + q.TableName + " CONTENT " + body}
+	if len(q.Conditions) > 0 {
+		parts = append(parts, "WHERE "+joinConditions(q.Conditions))
+	}
+	if q.ReturnFormat != "" {
+		parts = append(parts, "RETURN "+q.ReturnFormat.ToSurql())
+	}
+	return strings.Join(parts, " "), nil
+}
+
+func (q Query) buildDelete() (string, error) {
+	if q.TableName == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Table name required for DELETE query")
+	}
+	parts := []string{"DELETE " + q.TableName}
+	if len(q.Conditions) > 0 {
+		parts = append(parts, "WHERE "+joinConditions(q.Conditions))
+	}
+	if q.ReturnFormat != "" {
+		parts = append(parts, "RETURN "+q.ReturnFormat.ToSurql())
+	}
+	return strings.Join(parts, " "), nil
+}
+
+func (q Query) buildRelate() (string, error) {
+	if q.TableName == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "Edge table name required for RELATE query")
+	}
+	if q.RelateFrom == "" || q.RelateTo == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "From and to records required for RELATE query")
+	}
+	head := fmt.Sprintf("RELATE %s->%s->%s", q.RelateFrom, q.TableName, q.RelateTo)
+	parts := []string{head}
+	if len(q.RelateData) > 0 {
+		parts = append(parts, "CONTENT "+renderDataObject(q.RelateData))
+	}
+	if q.ReturnFormat != "" {
+		parts = append(parts, "RETURN "+q.ReturnFormat.ToSurql())
+	}
+	return strings.Join(parts, " "), nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared rendering helpers
+// ---------------------------------------------------------------------------
+
+func joinConditions(conds []string) string {
+	wrapped := make([]string, len(conds))
+	for i, c := range conds {
+		wrapped[i] = "(" + c + ")"
+	}
+	return strings.Join(wrapped, " AND ")
+}
+
+// renderDataObject renders a map as `{k: v, ...}` with keys sorted so
+// that the output is deterministic across runs.
+func renderDataObject(m map[string]any) string {
+	keys := sortedKeys(m)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+": "+quoteValueExpr(m[k]))
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func renderVectorLiteral(vec []float64) string {
+	parts := make([]string, len(vec))
+	for i, v := range vec {
+		parts[i] = formatFloat(v)
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+func formatFloat(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}
+
+// validateDataKeys checks every key in a user-supplied map is a safe
+// identifier.
+func validateDataKeys(data map[string]any) error {
+	for k := range data {
+		if err := validateIdentifier(k, "field name"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// relateEndpoint normalizes a from/to endpoint into its string form.
+func relateEndpoint(v any) (string, error) {
+	switch x := v.(type) {
+	case string:
+		if x == "" {
+			return "", surqlerrors.New(surqlerrors.ErrValidation, "relate endpoint cannot be empty")
+		}
+		return x, nil
+	case types.RecordID:
+		return x.String(), nil
+	case fmt.Stringer:
+		s := x.String()
+		if s == "" {
+			return "", surqlerrors.New(surqlerrors.ErrValidation, "relate endpoint cannot be empty")
+		}
+		return s, nil
+	case nil:
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "relate endpoint cannot be nil")
+	default:
+		return "", surqlerrors.Newf(surqlerrors.ErrValidation,
+			"relate endpoint must be string or types.RecordID, got %T", v)
+	}
+}

--- a/pkg/surql/query/builder_test.go
+++ b/pkg/surql/query/builder_test.go
@@ -1,0 +1,514 @@
+package query
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/types"
+)
+
+// mustFrom is a shorthand for `Query{}.Select(fields).FromTable(t)` that
+// returns the Query directly (fatal on error).
+func mustFrom(t *testing.T, fields []string, table string) Query {
+	t.Helper()
+	q, err := Query{}.Select(fields).FromTable(table)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return q
+}
+
+func TestQuery_ZeroValueFailsToRender(t *testing.T) {
+	if _, err := (Query{}).ToSurql(); err == nil {
+		t.Fatal("expected error for empty operation")
+	} else if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestSelect_AllFields(t *testing.T) {
+	q := mustFrom(t, nil, "user")
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "SELECT * FROM user"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestSelect_SpecificFields(t *testing.T) {
+	q := mustFrom(t, []string{"name", "email"}, "user")
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "SELECT name, email FROM user"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSelect_WhereStringAndOperator(t *testing.T) {
+	q, err := Query{}.Select(nil).FromTable("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.Where("age > 18")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.Where(types.EqOp("status", "active"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM user WHERE (age > 18) AND (status = 'active')"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSelect_OrderByAsc(t *testing.T) {
+	q := mustFrom(t, nil, "user")
+	q, err := q.OrderBy("name", "asc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM user ORDER BY name ASC"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestOrderBy_InvalidDirection(t *testing.T) {
+	q := Query{}.Select(nil)
+	if _, err := q.OrderBy("name", "sideways"); err == nil {
+		t.Fatal("expected validation error")
+	} else if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestSelect_GroupBy(t *testing.T) {
+	q := mustFrom(t, []string{"status", "COUNT(*)"}, "user").
+		GroupBy("status")
+	got, _ := q.ToSurql()
+	if want := "SELECT status, COUNT(*) FROM user GROUP BY status"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSelect_GroupAll(t *testing.T) {
+	q := mustFrom(t, []string{"count()"}, "user").GroupAll()
+	got, _ := q.ToSurql()
+	if want := "SELECT count() FROM user GROUP ALL"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSelect_LimitOffset(t *testing.T) {
+	q := mustFrom(t, nil, "user")
+	q, err := q.Limit(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.Offset(20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM user LIMIT 10 START 20"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestLimit_NegativeRejected(t *testing.T) {
+	if _, err := (Query{}).Limit(-1); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestOffset_NegativeRejected(t *testing.T) {
+	if _, err := (Query{}).Offset(-1); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestInsert_Basic(t *testing.T) {
+	q, err := Query{}.Insert("user", map[string]any{"name": "Alice", "age": 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	// Keys are sorted deterministically.
+	if want := "CREATE user CONTENT {age: 30, name: 'Alice'}"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestInsert_InvalidTableRejected(t *testing.T) {
+	if _, err := (Query{}).Insert("1bad", map[string]any{"a": 1}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestInsert_InvalidFieldRejected(t *testing.T) {
+	if _, err := (Query{}).Insert("user", map[string]any{"bad field": 1}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestInsert_ReturnFull(t *testing.T) {
+	q, err := Query{}.Insert("user", map[string]any{"name": "Bob"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ReturnFull().ToSurql()
+	if want := "CREATE user CONTENT {name: 'Bob'} RETURN FULL"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestUpdate_SetAndWhere(t *testing.T) {
+	q, err := Query{}.Update("user", map[string]any{"status": "active"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.Where("last_login > '2024-01-01'")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "UPDATE user SET status = 'active' WHERE (last_login > '2024-01-01')"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestUpdate_ReturnDiff(t *testing.T) {
+	q, err := Query{}.Update("user:alice", map[string]any{"age": 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ReturnDiff().ToSurql()
+	if want := "UPDATE user:alice SET age = 30 RETURN DIFF"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestUpsert_Basic(t *testing.T) {
+	q, err := Query{}.Upsert("user:alice", map[string]any{"name": "Alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "UPSERT user:alice CONTENT {name: 'Alice'}"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestDelete_WithWhere(t *testing.T) {
+	q, err := Query{}.Delete("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.Where("age < 18")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "DELETE user WHERE (age < 18)"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestDelete_ReturnBefore(t *testing.T) {
+	q, err := Query{}.Delete("user:alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ReturnBefore().ToSurql()
+	if want := "DELETE user:alice RETURN BEFORE"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRelate_StringEndpoints(t *testing.T) {
+	q, err := Query{}.Relate("likes", "user:alice", "post:123", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "RELATE user:alice->likes->post:123"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRelate_WithDataAndReturn(t *testing.T) {
+	q, err := Query{}.Relate("likes", "user:a", "post:1", map[string]any{"since": "2024-01-01"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ReturnAfter().ToSurql()
+	if want := "RELATE user:a->likes->post:1 CONTENT {since: '2024-01-01'} RETURN AFTER"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRelate_RecordIDEndpoints(t *testing.T) {
+	from, _ := types.NewStringRecordID("user", "alice")
+	to, _ := types.NewIntRecordID("post", 42)
+	q, err := Query{}.Relate("likes", from, to, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "RELATE user:alice->likes->post:42"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRelate_InvalidEdgeTable(t *testing.T) {
+	if _, err := (Query{}).Relate("1bad", "user:a", "post:1", nil); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestImmutability_ChainingReturnsFreshQuery(t *testing.T) {
+	base := Query{}.Select(nil)
+	a, err := base.FromTable("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := base.FromTable("post")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.TableName == b.TableName {
+		t.Fatalf("expected independent tables, both %q", a.TableName)
+	}
+	if base.TableName != "" {
+		t.Fatalf("base mutated to %q", base.TableName)
+	}
+}
+
+func TestImmutability_FieldsSliceSafety(t *testing.T) {
+	src := []string{"id"}
+	q := Query{}.Select(src)
+	src[0] = "MUTATED"
+	if q.Fields[0] != "id" {
+		t.Fatalf("caller mutation leaked, got %q", q.Fields[0])
+	}
+}
+
+func TestImmutability_DataMapSafety(t *testing.T) {
+	data := map[string]any{"name": "Alice"}
+	q, err := Query{}.Insert("user", data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data["name"] = "Bob"
+	if q.InsertData["name"] != "Alice" {
+		t.Fatalf("caller mutation leaked, got %q", q.InsertData["name"])
+	}
+}
+
+func TestVectorSearch_NoThreshold(t *testing.T) {
+	q, err := Query{}.Select(nil).FromTable("documents")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.VectorSearch("embedding", []float64{0.1, 0.2, 0.3}, 10, DistanceCosine, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM documents WHERE embedding <|10,COSINE|> [0.1, 0.2, 0.3]"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestVectorSearch_WithThreshold(t *testing.T) {
+	thr := 0.7
+	q, err := Query{}.Select(nil).FromTable("docs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.VectorSearch("embedding", []float64{1, 2}, 5, DistanceEuclidean, &thr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, "<|5,EUCLIDEAN,0.7|>") {
+		t.Errorf("missing threshold operator in %q", got)
+	}
+}
+
+func TestVectorSearch_EmptyVectorRejected(t *testing.T) {
+	q := Query{}.Select(nil)
+	if _, err := q.VectorSearch("e", nil, 3, DistanceCosine, nil); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestVectorSearch_KMustBePositive(t *testing.T) {
+	q := Query{}.Select(nil)
+	if _, err := q.VectorSearch("e", []float64{1}, 0, DistanceCosine, nil); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestHint_Composition(t *testing.T) {
+	q := mustFrom(t, nil, "user")
+	timeout, err := NewTimeoutHint(30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := q.WithHints(timeout, ExplainShort()).ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(out, "/* TIMEOUT 30s */ /* EXPLAIN */\nSELECT") {
+		t.Errorf("hint prefix missing in %q", out)
+	}
+}
+
+func TestHint_IndexConvenienceRequiresTable(t *testing.T) {
+	if _, err := (Query{}.Select(nil)).ForceIndex("idx_a"); err == nil {
+		t.Fatal("expected error without table")
+	}
+}
+
+func TestHint_UseIndex(t *testing.T) {
+	q, err := (mustFrom(t, nil, "user")).UseIndex("email_idx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, "/* USE INDEX user.email_idx */") {
+		t.Errorf("hint missing in %q", got)
+	}
+}
+
+func TestFromTable_InvalidRejected(t *testing.T) {
+	if _, err := (Query{}).FromTable("1bad"); err == nil {
+		t.Fatal("expected error")
+	}
+	if _, err := (Query{}).FromTable("a-b"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFromTable_WithRecordID(t *testing.T) {
+	q, err := Query{}.Select(nil).FromTable("user:alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM user:alice"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestTraverse_AppendsToFrom(t *testing.T) {
+	q := mustFrom(t, nil, "user:alice").Traverse("->likes->post")
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM user:alice->likes->post"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSimilarityScore_AddsField(t *testing.T) {
+	q := mustFrom(t, []string{"id"}, "chunk").
+		SimilarityScore("embedding", []float64{0.1, 0.2}, DistanceCosine, "score")
+	got, _ := q.ToSurql()
+	want := "SELECT id, vector::similarity::cosine(embedding, [0.1, 0.2]) AS score FROM chunk"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestUnsupportedOperation_Rendered(t *testing.T) {
+	q := Query{Operation: Operation("BOGUS")}
+	if _, err := q.ToSurql(); err == nil {
+		t.Fatal("expected error for unsupported op")
+	}
+}
+
+func TestUpdate_WithoutDataFails(t *testing.T) {
+	q := Query{Operation: OpUpdate, TableName: "user"}
+	if _, err := q.ToSurql(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestInsert_WithoutDataFails(t *testing.T) {
+	q := Query{Operation: OpInsert, TableName: "user"}
+	if _, err := q.ToSurql(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRelate_MissingEndpointsFails(t *testing.T) {
+	q := Query{Operation: OpRelate, TableName: "likes"}
+	if _, err := q.ToSurql(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestJoin_AppendsRawClause(t *testing.T) {
+	q := mustFrom(t, nil, "user").
+		Join("JOIN post ON user.id = post.author")
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, "JOIN post ON user.id = post.author") {
+		t.Errorf("join missing: %q", got)
+	}
+}
+
+func TestReturnFormat_ToSurql(t *testing.T) {
+	cases := map[ReturnFormat]string{
+		ReturnNone:   "NONE",
+		ReturnDiff:   "DIFF",
+		ReturnFull:   "FULL",
+		ReturnBefore: "BEFORE",
+		ReturnAfter:  "AFTER",
+	}
+	for f, want := range cases {
+		if got := f.ToSurql(); got != want {
+			t.Errorf("%v: got %q want %q", f, got, want)
+		}
+	}
+}
+
+func TestWhere_NilRejected(t *testing.T) {
+	q := Query{}.Select(nil)
+	if _, err := q.Where(nil); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestWhere_UnsupportedTypeRejected(t *testing.T) {
+	q := Query{}.Select(nil)
+	if _, err := q.Where(123); err == nil {
+		t.Fatal("expected error for int condition")
+	}
+}
+
+func TestQuoteValue_EscapesSpecialChars(t *testing.T) {
+	q, err := Query{}.Insert("user", map[string]any{"name": "O'Brien"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, `O\'Brien`) {
+		t.Errorf("escape missing: %q", got)
+	}
+}
+
+func TestExplain_Hint(t *testing.T) {
+	q := mustFrom(t, nil, "user").Explain(true)
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, "/* EXPLAIN FULL */") {
+		t.Errorf("explain full missing: %q", got)
+	}
+}

--- a/pkg/surql/query/doc.go
+++ b/pkg/surql/query/doc.go
@@ -1,0 +1,12 @@
+// Package query provides query construction and result handling for the
+// surql-go library. It is a 1:1 port of surql-py/src/surql/query/.
+//
+// This increment exposes the hints API (IndexHint, ParallelHint, TimeoutHint,
+// FetchHint, ExplainHint) and the result wrappers (QueryResult, RecordResult,
+// ListResult, CountResult, AggregateResult, PageInfo, PaginatedResult) plus
+// the raw-response extraction helpers (ExtractResult, ExtractOne,
+// ExtractScalar, HasResults).
+//
+// Subsequent increments add the immutable Query builder, expressions,
+// typed/batch/graph CRUD, and the async executor.
+package query

--- a/pkg/surql/query/doc.go
+++ b/pkg/surql/query/doc.go
@@ -1,12 +1,19 @@
 // Package query provides query construction and result handling for the
 // surql-go library. It is a 1:1 port of surql-py/src/surql/query/.
 //
-// This increment exposes the hints API (IndexHint, ParallelHint, TimeoutHint,
-// FetchHint, ExplainHint) and the result wrappers (QueryResult, RecordResult,
-// ListResult, CountResult, AggregateResult, PageInfo, PaginatedResult) plus
-// the raw-response extraction helpers (ExtractResult, ExtractOne,
-// ExtractScalar, HasResults).
+// This increment exposes:
+//   - the hints API (IndexHint, ParallelHint, TimeoutHint, FetchHint, ExplainHint)
+//   - the result wrappers (QueryResult, RecordResult, ListResult, CountResult,
+//     AggregateResult, PageInfo, PaginatedResult) plus the raw-response
+//     extraction helpers (ExtractResult, ExtractOne, ExtractScalar, HasResults)
+//   - typed SurrealQL expression helpers (Field, Value, Raw, Func, and function
+//     builders such as Count, MathMean, ArrayContains, Concat, ...)
+//   - the immutable fluent Query builder with SELECT / INSERT / UPDATE /
+//     UPSERT / DELETE / RELATE operations, graph traversal, vector search,
+//     return-format, and optimization hints
+//   - standalone helper constructors (Select, FromTable, Insert, Update,
+//     Upsert, Delete, Relate, VectorSearchQuery, SimilaritySearchQuery).
 //
-// Subsequent increments add the immutable Query builder, expressions,
-// typed/batch/graph CRUD, and the async executor.
+// Subsequent increments add typed/batch/graph CRUD helpers and the async
+// executor.
 package query

--- a/pkg/surql/query/expressions.go
+++ b/pkg/surql/query/expressions.go
@@ -1,0 +1,235 @@
+package query
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/albedosehen/surql-go/pkg/surql/types"
+)
+
+// ExpressionKind tags an Expression by category (field / value / function /
+// raw). Consumers can introspect without re-parsing the SurrealQL string.
+type ExpressionKind string
+
+const (
+	// ExprRaw is the default / aliased / raw category.
+	ExprRaw ExpressionKind = "raw"
+	// ExprField is a field reference.
+	ExprField ExpressionKind = "field"
+	// ExprValue is a quoted literal.
+	ExprValue ExpressionKind = "value"
+	// ExprFunction is a function-call expression.
+	ExprFunction ExpressionKind = "function"
+)
+
+// Expression is a typed SurrealQL fragment: a rendered string plus a kind tag.
+type Expression struct {
+	SQL  string         `json:"sql"`
+	Kind ExpressionKind `json:"kind,omitempty"`
+}
+
+// ToSurql renders as SurrealQL.
+func (e Expression) ToSurql() string { return e.SQL }
+
+// String implements fmt.Stringer.
+func (e Expression) String() string { return e.SQL }
+
+// NewRaw builds a raw-kind Expression.
+func NewRaw(sql string) Expression { return Expression{SQL: sql, Kind: ExprRaw} }
+
+// NewField builds a field-kind Expression.
+func NewField(name string) Expression { return Expression{SQL: name, Kind: ExprField} }
+
+// NewValue builds a value-kind Expression, quoted with SurrealQL rules.
+func NewValue(v any) Expression {
+	return Expression{SQL: quoteValueExpr(v), Kind: ExprValue}
+}
+
+// NewFunction builds a function-kind Expression from a pre-rendered `FN(...)`.
+func NewFunction(sql string) Expression { return Expression{SQL: sql, Kind: ExprFunction} }
+
+// Field is the free-function alias for [NewField].
+func Field(name string) Expression { return NewField(name) }
+
+// Value is the free-function alias for [NewValue].
+func Value(v any) Expression { return NewValue(v) }
+
+// Raw is the free-function alias for [NewRaw].
+func Raw(sql string) Expression { return NewRaw(sql) }
+
+// ExprArg is the union type accepted by Func / Concat: either a built
+// Expression or a raw string fragment.
+type ExprArg struct {
+	expr *Expression
+	str  *string
+}
+
+// E wraps an Expression for Func / Concat.
+func E(e Expression) ExprArg { return ExprArg{expr: &e} }
+
+// S wraps a raw string for Func / Concat.
+func S(s string) ExprArg { return ExprArg{str: &s} }
+
+func (a ExprArg) render() string {
+	if a.expr != nil {
+		return a.expr.ToSurql()
+	}
+	if a.str != nil {
+		return *a.str
+	}
+	return ""
+}
+
+// Func builds a function-call Expression: `Func("UPPER", E(Field("name")))`.
+func Func(name string, args ...ExprArg) Expression {
+	parts := make([]string, len(args))
+	for i, a := range args {
+		parts[i] = a.render()
+	}
+	return NewFunction(fmt.Sprintf("%s(%s)", name, strings.Join(parts, ", ")))
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate functions
+// ---------------------------------------------------------------------------
+
+// Count builds `COUNT(*)` or `COUNT(field)` when fieldName is non-empty.
+func Count(fieldName string) Expression {
+	if fieldName == "" {
+		return NewFunction("COUNT(*)")
+	}
+	return NewFunction(fmt.Sprintf("COUNT(%s)", fieldName))
+}
+
+// Sum builds `SUM(field)`.
+func Sum(fieldName string) Expression { return NewFunction(fmt.Sprintf("SUM(%s)", fieldName)) }
+
+// Avg builds `AVG(field)`.
+func Avg(fieldName string) Expression { return NewFunction(fmt.Sprintf("AVG(%s)", fieldName)) }
+
+// MinFn builds `MIN(field)`.
+func MinFn(fieldName string) Expression { return NewFunction(fmt.Sprintf("MIN(%s)", fieldName)) }
+
+// MaxFn builds `MAX(field)`.
+func MaxFn(fieldName string) Expression { return NewFunction(fmt.Sprintf("MAX(%s)", fieldName)) }
+
+// ---------------------------------------------------------------------------
+// String functions
+// ---------------------------------------------------------------------------
+
+// Upper builds `string::uppercase(field)`.
+func Upper(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("string::uppercase(%s)", fieldName))
+}
+
+// Lower builds `string::lowercase(field)`.
+func Lower(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("string::lowercase(%s)", fieldName))
+}
+
+// Concat builds `string::concat(a, b, c, ...)`.
+func Concat(parts ...ExprArg) Expression {
+	rendered := make([]string, len(parts))
+	for i, p := range parts {
+		rendered[i] = p.render()
+	}
+	return NewFunction(fmt.Sprintf("string::concat(%s)", strings.Join(rendered, ", ")))
+}
+
+// ---------------------------------------------------------------------------
+// Array functions
+// ---------------------------------------------------------------------------
+
+// ArrayLength builds `array::len(field)`.
+func ArrayLength(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("array::len(%s)", fieldName))
+}
+
+// ArrayContains builds `array::includes(field, value)`.
+func ArrayContains(fieldName string, v any) Expression {
+	return NewFunction(fmt.Sprintf("array::includes(%s, %s)", fieldName, quoteValueExpr(v)))
+}
+
+// ---------------------------------------------------------------------------
+// Math functions
+// ---------------------------------------------------------------------------
+
+// Abs builds `math::abs(field)`.
+func Abs(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("math::abs(%s)", fieldName))
+}
+
+// Ceil builds `math::ceil(field)`.
+func Ceil(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("math::ceil(%s)", fieldName))
+}
+
+// Floor builds `math::floor(field)`.
+func Floor(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("math::floor(%s)", fieldName))
+}
+
+// Round builds `math::round(field, precision)`. Pass 0 for integer rounding.
+func Round(fieldName string, precision int) Expression {
+	return NewFunction(fmt.Sprintf("math::round(%s, %d)", fieldName, precision))
+}
+
+// MathMean builds `math::mean(field)`.
+func MathMean(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("math::mean(%s)", fieldName))
+}
+
+// MathSum builds `math::sum(field)`.
+func MathSum(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("math::sum(%s)", fieldName))
+}
+
+// MathMax builds `math::max(field)`.
+func MathMax(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("math::max(%s)", fieldName))
+}
+
+// MathMin builds `math::min(field)`.
+func MathMin(fieldName string) Expression {
+	return NewFunction(fmt.Sprintf("math::min(%s)", fieldName))
+}
+
+// ---------------------------------------------------------------------------
+// Time, type, composition
+// ---------------------------------------------------------------------------
+
+// TimeNow builds `time::now()`.
+func TimeNow() Expression { return NewFunction("time::now()") }
+
+// TimeFormat builds `time::format(field, 'fmt')`.
+func TimeFormat(fieldName, format string) Expression {
+	return NewFunction(fmt.Sprintf("time::format(%s, %s)", fieldName, quoteValueExpr(format)))
+}
+
+// TypeIs builds `type::is::<type_name>(field)`.
+func TypeIs(fieldName, typeName string) Expression {
+	return NewFunction(fmt.Sprintf("type::is::%s(%s)", typeName, fieldName))
+}
+
+// Cast builds `<target_type>field` — SurrealQL cast syntax.
+func Cast(fieldName, targetType string) Expression {
+	return NewRaw(fmt.Sprintf("<%s>%s", targetType, fieldName))
+}
+
+// As aliases an expression: `As(Count(""), "total")` -> `COUNT(*) AS total`.
+func As(expr Expression, alias string) Expression {
+	return NewRaw(fmt.Sprintf("%s AS %s", expr.ToSurql(), alias))
+}
+
+// ---------------------------------------------------------------------------
+// quoteValueExpr: SurrealQL literal renderer used by expression helpers.
+// Delegates to the types package's operator rendering to stay consistent.
+// ---------------------------------------------------------------------------
+
+func quoteValueExpr(v any) string {
+	// Reuse the rendering path via a scratch Eq operator. This keeps quoting
+	// logic DRY with the types/operators package.
+	rendered := types.EqOp("__x__", v).ToSurql()
+	const prefix = "__x__ = "
+	return strings.TrimPrefix(rendered, prefix)
+}

--- a/pkg/surql/query/expressions_test.go
+++ b/pkg/surql/query/expressions_test.go
@@ -1,0 +1,145 @@
+package query
+
+import "testing"
+
+func TestFieldAndValue(t *testing.T) {
+	if got := Field("user.name").ToSurql(); got != "user.name" {
+		t.Errorf("got %q", got)
+	}
+	if got := Value("Alice").ToSurql(); got != `'Alice'` {
+		t.Errorf("got %q", got)
+	}
+	if got := Value(42).ToSurql(); got != "42" {
+		t.Errorf("got %q", got)
+	}
+	if got := Value(true).ToSurql(); got != "true" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestCount_Renders(t *testing.T) {
+	if got := Count("").ToSurql(); got != "COUNT(*)" {
+		t.Errorf("got %q", got)
+	}
+	if got := Count("id").ToSurql(); got != "COUNT(id)" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestAggregateFunctions(t *testing.T) {
+	if Sum("price").ToSurql() != "SUM(price)" ||
+		Avg("age").ToSurql() != "AVG(age)" ||
+		MinFn("price").ToSurql() != "MIN(price)" ||
+		MaxFn("price").ToSurql() != "MAX(price)" {
+		t.Error("aggregate mismatch")
+	}
+}
+
+func TestMathNativeAggregates(t *testing.T) {
+	if MathMean("score").ToSurql() != "math::mean(score)" ||
+		MathSum("price").ToSurql() != "math::sum(price)" ||
+		MathMax("score").ToSurql() != "math::max(score)" ||
+		MathMin("price").ToSurql() != "math::min(price)" {
+		t.Error("math aggregate mismatch")
+	}
+}
+
+func TestStringFunctions(t *testing.T) {
+	if Upper("name").ToSurql() != "string::uppercase(name)" {
+		t.Error("upper")
+	}
+	if Lower("email").ToSurql() != "string::lowercase(email)" {
+		t.Error("lower")
+	}
+	c := Concat(E(Field("first_name")), E(Value(" ")), E(Field("last_name")))
+	if c.ToSurql() != "string::concat(first_name, ' ', last_name)" {
+		t.Errorf("concat: %q", c.ToSurql())
+	}
+}
+
+func TestArrayFunctions(t *testing.T) {
+	if ArrayLength("tags").ToSurql() != "array::len(tags)" {
+		t.Error("array_length")
+	}
+	if got := ArrayContains("tags", "python").ToSurql(); got != "array::includes(tags, 'python')" {
+		t.Errorf("array_contains: %q", got)
+	}
+}
+
+func TestMathFunctions(t *testing.T) {
+	if Abs("temperature").ToSurql() != "math::abs(temperature)" {
+		t.Error("abs")
+	}
+	if Ceil("price").ToSurql() != "math::ceil(price)" {
+		t.Error("ceil")
+	}
+	if Floor("price").ToSurql() != "math::floor(price)" {
+		t.Error("floor")
+	}
+	if Round("price", 2).ToSurql() != "math::round(price, 2)" {
+		t.Error("round")
+	}
+}
+
+func TestTimeFunctions(t *testing.T) {
+	if TimeNow().ToSurql() != "time::now()" {
+		t.Error("time_now")
+	}
+	if got := TimeFormat("created_at", "%Y-%m-%d").ToSurql(); got != "time::format(created_at, '%Y-%m-%d')" {
+		t.Errorf("time_format: %q", got)
+	}
+}
+
+func TestTypeFunctions(t *testing.T) {
+	if TypeIs("value", "string").ToSurql() != "type::is::string(value)" {
+		t.Error("type_is")
+	}
+	if Cast("id", "string").ToSurql() != "<string>id" {
+		t.Error("cast")
+	}
+}
+
+func TestFunc_AcceptsMixedArgs(t *testing.T) {
+	c := Func("CONCAT", E(Field("first")), S("' '"), E(Field("last")))
+	if c.ToSurql() != "CONCAT(first, ' ', last)" {
+		t.Errorf("got %q", c.ToSurql())
+	}
+}
+
+func TestAs_AliasesExpressions(t *testing.T) {
+	if got := As(Count(""), "total").ToSurql(); got != "COUNT(*) AS total" {
+		t.Errorf("got %q", got)
+	}
+	inner := Concat(E(Field("first")), E(Field("last")))
+	if got := As(inner, "full_name").ToSurql(); got != "string::concat(first, last) AS full_name" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRaw_PassesThrough(t *testing.T) {
+	if Raw("time::now()").ToSurql() != "time::now()" {
+		t.Error("raw")
+	}
+}
+
+func TestKindTag_ReflectsConstructor(t *testing.T) {
+	if Field("x").Kind != ExprField {
+		t.Error("field kind")
+	}
+	if Value(1).Kind != ExprValue {
+		t.Error("value kind")
+	}
+	if Count("").Kind != ExprFunction {
+		t.Error("count kind")
+	}
+	if Raw("x").Kind != ExprRaw {
+		t.Error("raw kind")
+	}
+}
+
+func TestString_MatchesToSurql(t *testing.T) {
+	e := Count("")
+	if e.String() != e.ToSurql() {
+		t.Error("String / ToSurql mismatch")
+	}
+}

--- a/pkg/surql/query/helpers.go
+++ b/pkg/surql/query/helpers.go
@@ -1,0 +1,202 @@
+package query
+
+import (
+	"regexp"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// ReturnFormat selects the data returned by a mutation.
+//
+// Mirrors the Python `ReturnFormat` enum: NONE returns nothing, DIFF
+// returns only changed fields, FULL returns the entire record, and
+// BEFORE / AFTER capture state around the write.
+type ReturnFormat string
+
+const (
+	// ReturnNone omits the record body from the response.
+	ReturnNone ReturnFormat = "NONE"
+	// ReturnDiff emits just the fields that changed.
+	ReturnDiff ReturnFormat = "DIFF"
+	// ReturnFull emits the full record.
+	ReturnFull ReturnFormat = "FULL"
+	// ReturnBefore emits the record state before the write.
+	ReturnBefore ReturnFormat = "BEFORE"
+	// ReturnAfter emits the record state after the write (SurrealDB default).
+	ReturnAfter ReturnFormat = "AFTER"
+)
+
+// ToSurql renders the format as its SurrealQL keyword.
+func (f ReturnFormat) ToSurql() string { return string(f) }
+
+// String implements fmt.Stringer.
+func (f ReturnFormat) String() string { return string(f) }
+
+// VectorDistanceType names a vector-similarity metric.
+//
+// Mirrors the Python `VectorDistanceType` literal. MAHALANOBIS is
+// included for parity even though the surql-py public surface only
+// lists 8 metrics — the generator and SurrealDB both accept it.
+type VectorDistanceType string
+
+const (
+	// DistanceCosine is cosine similarity.
+	DistanceCosine VectorDistanceType = "COSINE"
+	// DistanceEuclidean is L2 distance.
+	DistanceEuclidean VectorDistanceType = "EUCLIDEAN"
+	// DistanceManhattan is L1 distance.
+	DistanceManhattan VectorDistanceType = "MANHATTAN"
+	// DistanceChebyshev is L-infinity distance.
+	DistanceChebyshev VectorDistanceType = "CHEBYSHEV"
+	// DistanceMinkowski is generalized Lp distance.
+	DistanceMinkowski VectorDistanceType = "MINKOWSKI"
+	// DistanceHamming is hamming distance.
+	DistanceHamming VectorDistanceType = "HAMMING"
+	// DistanceJaccard is jaccard distance.
+	DistanceJaccard VectorDistanceType = "JACCARD"
+	// DistancePearson is pearson correlation distance.
+	DistancePearson VectorDistanceType = "PEARSON"
+	// DistanceMahalanobis is mahalanobis distance (parity extension).
+	DistanceMahalanobis VectorDistanceType = "MAHALANOBIS"
+)
+
+// identifierPattern matches a safe SurrealDB identifier.
+var identifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// validateIdentifier checks that a table / field / edge name is safe to
+// splice into a generated SurrealQL string.
+func validateIdentifier(name, context string) error {
+	if name == "" {
+		return surqlerrors.Newf(surqlerrors.ErrValidation, "%s cannot be empty", capitalize(context))
+	}
+	if !identifierPattern.MatchString(name) {
+		return surqlerrors.Newf(
+			surqlerrors.ErrValidation,
+			"Invalid %s: %q. Must contain only alphanumeric characters and underscores, and cannot start with a digit",
+			context, name,
+		)
+	}
+	return nil
+}
+
+// splitTablePart peels off the `table:id` prefix so we can validate just
+// the table portion of a target string.
+func splitTablePart(target string) string {
+	if idx := strings.Index(target, ":"); idx >= 0 {
+		return target[:idx]
+	}
+	return target
+}
+
+// capitalize upper-cases the first rune of s.
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// ---------------------------------------------------------------------------
+// Standalone helper constructors — mirror the free functions in helpers.py.
+// Each produces a fresh Query with the relevant state set.
+// ---------------------------------------------------------------------------
+
+// Select starts a SELECT query with the given fields. Pass nil for `SELECT *`.
+func Select(fields []string) Query {
+	return Query{}.Select(fields)
+}
+
+// FromTable builds a Query whose target is the given table.
+func FromTable(table string) (Query, error) {
+	return Query{}.FromTable(table)
+}
+
+// Where adds a WHERE condition to an existing query. The condition can
+// be a raw string or any value implementing `types.Operator`.
+func Where(q Query, condition any) (Query, error) {
+	return q.Where(condition)
+}
+
+// OrderBy adds an ORDER BY clause to an existing query.
+func OrderBy(q Query, field, direction string) (Query, error) {
+	return q.OrderBy(field, direction)
+}
+
+// Limit adds a LIMIT clause to an existing query.
+func Limit(q Query, n int) (Query, error) {
+	return q.Limit(n)
+}
+
+// Offset adds an OFFSET clause to an existing query.
+func Offset(q Query, n int) (Query, error) {
+	return q.Offset(n)
+}
+
+// Insert creates an INSERT query.
+func Insert(table string, data map[string]any) (Query, error) {
+	return Query{}.Insert(table, data)
+}
+
+// Update creates an UPDATE query.
+func Update(target string, data map[string]any) (Query, error) {
+	return Query{}.Update(target, data)
+}
+
+// Upsert creates an UPSERT query.
+func Upsert(target string, data map[string]any) (Query, error) {
+	return Query{}.Upsert(target, data)
+}
+
+// Delete creates a DELETE query.
+func Delete(target string) (Query, error) {
+	return Query{}.Delete(target)
+}
+
+// Relate creates a RELATE query for the given edge + endpoints.
+//
+// `from` and `to` may be `string` or `types.RecordID`.
+func Relate(edgeTable string, from, to any, data map[string]any) (Query, error) {
+	return Query{}.Relate(edgeTable, from, to, data)
+}
+
+// VectorSearchQuery is the convenience builder: `SELECT ... FROM table
+// WHERE field <|k,distance|> vector`.
+func VectorSearchQuery(
+	table, field string,
+	vector []float64,
+	k int,
+	distance VectorDistanceType,
+	fields []string,
+	threshold *float64,
+) (Query, error) {
+	q := Select(fields)
+	q, err := q.FromTable(table)
+	if err != nil {
+		return Query{}, err
+	}
+	return q.VectorSearch(field, vector, k, distance, threshold)
+}
+
+// SimilaritySearchQuery mirrors `similarity_search_query`: combines a
+// vector search clause with a similarity score field in the projection.
+func SimilaritySearchQuery(
+	table, field string,
+	vector []float64,
+	k int,
+	distance VectorDistanceType,
+	threshold *float64,
+	fields []string,
+	alias string,
+) (Query, error) {
+	q := Select(fields)
+	q, err := q.FromTable(table)
+	if err != nil {
+		return Query{}, err
+	}
+	if alias == "" {
+		alias = "similarity"
+	}
+	q = q.SimilarityScore(field, vector, distance, alias)
+	return q.VectorSearch(field, vector, k, distance, threshold)
+}

--- a/pkg/surql/query/helpers_test.go
+++ b/pkg/surql/query/helpers_test.go
@@ -1,0 +1,246 @@
+package query
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestHelper_Select(t *testing.T) {
+	q := Select(nil)
+	if q.Operation != OpSelect {
+		t.Errorf("got %v", q.Operation)
+	}
+	if len(q.Fields) != 1 || q.Fields[0] != "*" {
+		t.Errorf("fields: %v", q.Fields)
+	}
+}
+
+func TestHelper_SelectWithFields(t *testing.T) {
+	q := Select([]string{"a", "b"})
+	if len(q.Fields) != 2 || q.Fields[0] != "a" || q.Fields[1] != "b" {
+		t.Errorf("fields: %v", q.Fields)
+	}
+}
+
+func TestHelper_FromTable(t *testing.T) {
+	q, err := FromTable("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q.TableName != "user" {
+		t.Errorf("got %q", q.TableName)
+	}
+}
+
+func TestHelper_FromTable_Invalid(t *testing.T) {
+	if _, err := FromTable(""); err == nil {
+		t.Fatal("expected empty-table error")
+	} else if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+	if _, err := FromTable("1bad"); err == nil {
+		t.Fatal("expected syntax error")
+	}
+}
+
+func TestHelper_Where(t *testing.T) {
+	q, err := FromTable("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q = q.Select(nil)
+	q, err = Where(q, "age > 18")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM user WHERE (age > 18)"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestHelper_OrderBy(t *testing.T) {
+	q, _ := Select(nil).FromTable("user")
+	q, err := OrderBy(q, "name", "DESC")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM user ORDER BY name DESC"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestHelper_Limit(t *testing.T) {
+	q, _ := Select(nil).FromTable("user")
+	q, err := Limit(q, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q.LimitValue == nil || *q.LimitValue != 5 {
+		t.Errorf("limit: %v", q.LimitValue)
+	}
+}
+
+func TestHelper_Offset(t *testing.T) {
+	q, _ := Select(nil).FromTable("user")
+	q, err := Offset(q, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q.OffsetValue == nil || *q.OffsetValue != 3 {
+		t.Errorf("offset: %v", q.OffsetValue)
+	}
+}
+
+func TestHelper_Insert(t *testing.T) {
+	q, err := Insert("user", map[string]any{"name": "Alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q.Operation != OpInsert {
+		t.Errorf("op: %v", q.Operation)
+	}
+	if q.TableName != "user" {
+		t.Errorf("table: %q", q.TableName)
+	}
+}
+
+func TestHelper_Update(t *testing.T) {
+	q, err := Update("user:alice", map[string]any{"age": 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "UPDATE user:alice SET age = 30"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestHelper_Upsert(t *testing.T) {
+	q, err := Upsert("user:alice", map[string]any{"status": "active"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "UPSERT user:alice CONTENT {status: 'active'}"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestHelper_Delete(t *testing.T) {
+	q, err := Delete("user:alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "DELETE user:alice"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestHelper_Relate(t *testing.T) {
+	q, err := Relate("likes", "user:a", "post:1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "RELATE user:a->likes->post:1"; got != want {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestHelper_VectorSearchQuery(t *testing.T) {
+	q, err := VectorSearchQuery(
+		"documents", "embedding", []float64{0.1, 0.2, 0.3}, 10,
+		DistanceCosine, nil, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, "<|10,COSINE|>") {
+		t.Errorf("missing vector op: %q", got)
+	}
+}
+
+func TestHelper_VectorSearchQuery_WithThreshold(t *testing.T) {
+	thr := 0.5
+	q, err := VectorSearchQuery(
+		"documents", "embedding", []float64{0.1, 0.2, 0.3}, 10,
+		DistanceCosine, []string{"id", "text"}, &thr,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, "<|10,COSINE,0.5|>") || !strings.Contains(got, "SELECT id, text") {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestHelper_SimilaritySearchQuery(t *testing.T) {
+	q, err := SimilaritySearchQuery(
+		"chunk", "embedding", []float64{0.1, 0.2}, 5,
+		DistanceCosine, nil, []string{"id"}, "score",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, "vector::similarity::cosine(embedding, [0.1, 0.2]) AS score") {
+		t.Errorf("missing similarity projection: %q", got)
+	}
+	if !strings.Contains(got, "<|5,COSINE|>") {
+		t.Errorf("missing vector operator: %q", got)
+	}
+}
+
+func TestReturnFormat_Values(t *testing.T) {
+	if ReturnNone.String() != "NONE" {
+		t.Error("none")
+	}
+	if ReturnAfter.ToSurql() != "AFTER" {
+		t.Error("after")
+	}
+}
+
+func TestVectorDistance_Constants(t *testing.T) {
+	cases := []VectorDistanceType{
+		DistanceCosine, DistanceEuclidean, DistanceManhattan, DistanceChebyshev,
+		DistanceMinkowski, DistanceHamming, DistanceJaccard, DistancePearson,
+		DistanceMahalanobis,
+	}
+	for _, c := range cases {
+		if string(c) == "" {
+			t.Errorf("empty distance constant")
+		}
+	}
+}
+
+func TestValidateIdentifier_Cases(t *testing.T) {
+	valid := []string{"user", "_hidden", "a1", "user_table"}
+	for _, v := range valid {
+		if err := validateIdentifier(v, "test"); err != nil {
+			t.Errorf("valid %q rejected: %v", v, err)
+		}
+	}
+	invalid := []string{"", "1user", "user-table", "user.name", "user table"}
+	for _, v := range invalid {
+		if err := validateIdentifier(v, "test"); err == nil {
+			t.Errorf("invalid %q accepted", v)
+		}
+	}
+}
+
+func TestSplitTablePart(t *testing.T) {
+	if splitTablePart("user") != "user" {
+		t.Error("plain")
+	}
+	if splitTablePart("user:alice") != "user" {
+		t.Error("record id")
+	}
+}

--- a/pkg/surql/query/hints.go
+++ b/pkg/surql/query/hints.go
@@ -1,0 +1,263 @@
+package query
+
+import (
+	"fmt"
+	"strconv"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// HintType is the category of a query hint, used to dedupe when MergeHints
+// collapses overlapping hints.
+type HintType string
+
+const (
+	// HintIndex is the index-selection hint category.
+	HintIndex HintType = "index"
+	// HintParallel is the parallel-execution hint category.
+	HintParallel HintType = "parallel"
+	// HintTimeout is the timeout-override hint category.
+	HintTimeout HintType = "timeout"
+	// HintFetch is the fetch-strategy hint category.
+	HintFetch HintType = "fetch"
+	// HintExplain is the execution-plan hint category.
+	HintExplain HintType = "explain"
+)
+
+// QueryHint renders a SurrealQL comment that the query planner interprets.
+type QueryHint interface {
+	ToSurql() string
+	Type() HintType
+}
+
+// FetchStrategy controls how records are retrieved for a query.
+type FetchStrategy string
+
+const (
+	// FetchEager fetches all records up front.
+	FetchEager FetchStrategy = "eager"
+	// FetchLazy fetches records on demand.
+	FetchLazy FetchStrategy = "lazy"
+	// FetchBatch fetches records in fixed-size batches.
+	FetchBatch FetchStrategy = "batch"
+)
+
+// IndexHint forces or suggests use of a particular index.
+type IndexHint struct {
+	Table string `json:"table"`
+	Index string `json:"index"`
+	Force bool   `json:"force,omitempty"`
+}
+
+// NewIndexHint builds an IndexHint that suggests (does not force) the index.
+func NewIndexHint(table, index string) IndexHint {
+	return IndexHint{Table: table, Index: index}
+}
+
+// WithForce returns a copy with the FORCE flag set.
+func (h IndexHint) WithForce(force bool) IndexHint {
+	h.Force = force
+	return h
+}
+
+// ToSurql implements QueryHint.
+func (h IndexHint) ToSurql() string {
+	prefix := "USE"
+	if h.Force {
+		prefix = "FORCE"
+	}
+	return fmt.Sprintf("/* %s INDEX %s.%s */", prefix, h.Table, h.Index)
+}
+
+// Type implements QueryHint.
+func (IndexHint) Type() HintType { return HintIndex }
+
+// ParallelHint toggles parallel query execution and bounds worker count.
+type ParallelHint struct {
+	Enabled    bool  `json:"enabled"`
+	MaxWorkers *uint `json:"max_workers,omitempty"`
+}
+
+// ParallelEnabled enables parallel execution with the server-picked worker count.
+func ParallelEnabled() ParallelHint { return ParallelHint{Enabled: true} }
+
+// ParallelDisabled disables parallel execution.
+func ParallelDisabled() ParallelHint { return ParallelHint{Enabled: false} }
+
+// ParallelWithWorkers enables parallel execution capped at n workers.
+// Returns ErrValidation when n is outside 1..=32.
+func ParallelWithWorkers(n uint) (ParallelHint, error) {
+	if n < 1 || n > 32 {
+		return ParallelHint{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"ParallelHint max_workers must be in 1..=32, got %d", n)
+	}
+	return ParallelHint{Enabled: true, MaxWorkers: &n}, nil
+}
+
+// ToSurql implements QueryHint.
+func (h ParallelHint) ToSurql() string {
+	if !h.Enabled {
+		return "/* PARALLEL OFF */"
+	}
+	if h.MaxWorkers != nil {
+		return fmt.Sprintf("/* PARALLEL %d */", *h.MaxWorkers)
+	}
+	return "/* PARALLEL ON */"
+}
+
+// Type implements QueryHint.
+func (ParallelHint) Type() HintType { return HintParallel }
+
+// TimeoutHint overrides the query timeout.
+type TimeoutHint struct {
+	Seconds float64 `json:"seconds"`
+}
+
+// NewTimeoutHint builds a TimeoutHint. Returns ErrValidation on non-positive seconds.
+func NewTimeoutHint(seconds float64) (TimeoutHint, error) {
+	if seconds != seconds /* NaN */ || seconds <= 0 {
+		return TimeoutHint{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"TimeoutHint seconds must be > 0, got %v", seconds)
+	}
+	return TimeoutHint{Seconds: seconds}, nil
+}
+
+// ToSurql implements QueryHint.
+func (h TimeoutHint) ToSurql() string {
+	return "/* TIMEOUT " + trimFloat(h.Seconds) + "s */"
+}
+
+// Type implements QueryHint.
+func (TimeoutHint) Type() HintType { return HintTimeout }
+
+// FetchHint controls how records are fetched.
+type FetchHint struct {
+	Strategy  FetchStrategy `json:"strategy"`
+	BatchSize *uint32       `json:"batch_size,omitempty"`
+}
+
+// FetchEagerHint builds an eager-fetch FetchHint.
+func FetchEagerHint() FetchHint { return FetchHint{Strategy: FetchEager} }
+
+// FetchLazyHint builds a lazy-fetch FetchHint.
+func FetchLazyHint() FetchHint { return FetchHint{Strategy: FetchLazy} }
+
+// FetchBatchHint builds a batch-fetch FetchHint (size must be in 1..=10000).
+func FetchBatchHint(batchSize uint32) (FetchHint, error) {
+	if batchSize < 1 || batchSize > 10_000 {
+		return FetchHint{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"FetchHint batch_size must be in 1..=10000, got %d", batchSize)
+	}
+	bs := batchSize
+	return FetchHint{Strategy: FetchBatch, BatchSize: &bs}, nil
+}
+
+// Validate reports missing-batch-size errors (mirrors surql-py).
+func (h FetchHint) Validate() error {
+	if h.Strategy == FetchBatch && h.BatchSize == nil {
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"FetchHint batch_size required when strategy is batch")
+	}
+	return nil
+}
+
+// ToSurql implements QueryHint.
+func (h FetchHint) ToSurql() string {
+	if h.Strategy == FetchBatch && h.BatchSize != nil {
+		return fmt.Sprintf("/* FETCH BATCH %d */", *h.BatchSize)
+	}
+	switch h.Strategy {
+	case FetchEager:
+		return "/* FETCH EAGER */"
+	case FetchLazy:
+		return "/* FETCH LAZY */"
+	case FetchBatch:
+		return "/* FETCH BATCH */"
+	default:
+		return "/* FETCH */"
+	}
+}
+
+// Type implements QueryHint.
+func (FetchHint) Type() HintType { return HintFetch }
+
+// ExplainHint requests the query execution plan.
+type ExplainHint struct {
+	Full bool `json:"full,omitempty"`
+}
+
+// ExplainShort builds a short-form ExplainHint.
+func ExplainShort() ExplainHint { return ExplainHint{Full: false} }
+
+// ExplainFull builds a full-form ExplainHint.
+func ExplainFull() ExplainHint { return ExplainHint{Full: true} }
+
+// ToSurql implements QueryHint.
+func (h ExplainHint) ToSurql() string {
+	if h.Full {
+		return "/* EXPLAIN FULL */"
+	}
+	return "/* EXPLAIN */"
+}
+
+// Type implements QueryHint.
+func (ExplainHint) Type() HintType { return HintExplain }
+
+// ValidateHint checks a hint against the query's target table.
+//
+// Returns human-readable problems; an empty slice means the hint is OK.
+// `table` is the query's target table, or "" if not known.
+func ValidateHint(hint QueryHint, table string) []string {
+	var errors []string
+	if idx, ok := hint.(IndexHint); ok && table != "" && idx.Table != table {
+		errors = append(errors, fmt.Sprintf(
+			"Index hint table %q does not match query table %q", idx.Table, table))
+	}
+	return errors
+}
+
+// MergeHints collapses duplicate hints by HintType, keeping the last one
+// of each type and preserving the insertion order of unique types.
+func MergeHints(hints []QueryHint) []QueryHint {
+	idx := map[HintType]int{}
+	var out []QueryHint
+	for _, h := range hints {
+		t := h.Type()
+		if i, ok := idx[t]; ok {
+			out[i] = h
+		} else {
+			idx[t] = len(out)
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+// RenderHints joins a slice of hints into a single SurrealQL comment string.
+func RenderHints(hints []QueryHint) string {
+	if len(hints) == 0 {
+		return ""
+	}
+	merged := MergeHints(hints)
+	parts := make([]string, 0, len(merged))
+	for _, h := range merged {
+		parts = append(parts, h.ToSurql())
+	}
+	// manual join avoids extra allocation and mirrors the Python " ".join()
+	out := parts[0]
+	for i := 1; i < len(parts); i++ {
+		out += " " + parts[i]
+	}
+	return out
+}
+
+// HintRenderer is kept for API symmetry with surql-py.
+type HintRenderer struct{}
+
+// RenderHints is the stateful wrapper for RenderHints.
+func (HintRenderer) RenderHints(hints []QueryHint) string { return RenderHints(hints) }
+
+// trimFloat prints f without unnecessary trailing zeros (30.0 -> "30").
+func trimFloat(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}

--- a/pkg/surql/query/hints_test.go
+++ b/pkg/surql/query/hints_test.go
@@ -1,0 +1,167 @@
+package query
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestIndexHint_RendersUseAndForce(t *testing.T) {
+	if got := NewIndexHint("user", "email_idx").ToSurql(); got != "/* USE INDEX user.email_idx */" {
+		t.Errorf("got %q", got)
+	}
+	if got := NewIndexHint("user", "email_idx").WithForce(true).ToSurql(); got != "/* FORCE INDEX user.email_idx */" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestParallelHint_Renders(t *testing.T) {
+	if got := ParallelEnabled().ToSurql(); got != "/* PARALLEL ON */" {
+		t.Errorf("got %q", got)
+	}
+	if got := ParallelDisabled().ToSurql(); got != "/* PARALLEL OFF */" {
+		t.Errorf("got %q", got)
+	}
+	h, err := ParallelWithWorkers(4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := h.ToSurql(); got != "/* PARALLEL 4 */" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestParallelHint_RejectsBadWorkerCount(t *testing.T) {
+	if _, err := ParallelWithWorkers(0); err == nil {
+		t.Error("expected error for 0 workers")
+	}
+	if _, err := ParallelWithWorkers(33); err == nil {
+		t.Error("expected error for 33 workers")
+	}
+}
+
+func TestTimeoutHint_Renders(t *testing.T) {
+	h, err := NewTimeoutHint(30.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := h.ToSurql(); got != "/* TIMEOUT 30s */" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestTimeoutHint_RejectsNonPositive(t *testing.T) {
+	if _, err := NewTimeoutHint(0); err == nil {
+		t.Error("expected error for 0")
+	}
+	if _, err := NewTimeoutHint(-1.0); err == nil {
+		t.Error("expected error for negative")
+	}
+}
+
+func TestFetchHint_Renders(t *testing.T) {
+	if got := FetchEagerHint().ToSurql(); got != "/* FETCH EAGER */" {
+		t.Errorf("got %q", got)
+	}
+	if got := FetchLazyHint().ToSurql(); got != "/* FETCH LAZY */" {
+		t.Errorf("got %q", got)
+	}
+	h, err := FetchBatchHint(100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := h.ToSurql(); got != "/* FETCH BATCH 100 */" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestFetchHint_BatchValidatesSize(t *testing.T) {
+	if _, err := FetchBatchHint(0); err == nil {
+		t.Error("expected error for 0")
+	}
+	if _, err := FetchBatchHint(10_001); err == nil {
+		t.Error("expected error for 10001")
+	}
+	bad := FetchHint{Strategy: FetchBatch}
+	if err := bad.Validate(); err == nil {
+		t.Error("expected validation error")
+	}
+}
+
+func TestExplainHint_Renders(t *testing.T) {
+	if got := ExplainShort().ToSurql(); got != "/* EXPLAIN */" {
+		t.Errorf("got %q", got)
+	}
+	if got := ExplainFull().ToSurql(); got != "/* EXPLAIN FULL */" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestValidateHint_ChecksTable(t *testing.T) {
+	idx := NewIndexHint("user", "email_idx")
+	if errs := ValidateHint(idx, "user"); len(errs) != 0 {
+		t.Errorf("matching table should be valid: %v", errs)
+	}
+	errs := ValidateHint(idx, "post")
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %v", errs)
+	}
+	if !strings.Contains(errs[0], "user") || !strings.Contains(errs[0], "post") {
+		t.Errorf("unexpected message: %q", errs[0])
+	}
+}
+
+func TestMergeHints_ReplacesDuplicates(t *testing.T) {
+	h1, _ := NewTimeoutHint(10.0)
+	h2, _ := NewTimeoutHint(20.0)
+	merged := MergeHints([]QueryHint{h1, h2})
+	if len(merged) != 1 {
+		t.Fatalf("expected 1, got %d", len(merged))
+	}
+	if got := merged[0].(TimeoutHint).Seconds; got != 20.0 {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestMergeHints_KeepsDistinctTypes(t *testing.T) {
+	t1, _ := NewTimeoutHint(30.0)
+	t2, _ := NewTimeoutHint(60.0)
+	merged := MergeHints([]QueryHint{t1, ParallelEnabled(), t2})
+	if len(merged) != 2 {
+		t.Fatalf("expected 2, got %d", len(merged))
+	}
+}
+
+func TestRenderHints_Empty(t *testing.T) {
+	if got := RenderHints(nil); got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRenderHints_JoinsAll(t *testing.T) {
+	t1, _ := NewTimeoutHint(30.0)
+	out := RenderHints([]QueryHint{t1, ParallelEnabled()})
+	if !strings.Contains(out, "/* TIMEOUT 30s */") {
+		t.Errorf("missing timeout: %q", out)
+	}
+	if !strings.Contains(out, "/* PARALLEL ON */") {
+		t.Errorf("missing parallel: %q", out)
+	}
+}
+
+func TestRenderer_MatchesFreeFunction(t *testing.T) {
+	hints := []QueryHint{ExplainFull()}
+	renderer := HintRenderer{}
+	if renderer.RenderHints(hints) != RenderHints(hints) {
+		t.Error("renderer and free function should match")
+	}
+}
+
+func TestValidationErrorsAreClassified(t *testing.T) {
+	_, err := NewTimeoutHint(-1)
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}

--- a/pkg/surql/query/results.go
+++ b/pkg/surql/query/results.go
@@ -1,0 +1,261 @@
+package query
+
+import (
+	"encoding/json"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// QueryResult is the generic query execution wrapper.
+type QueryResult[T any] struct {
+	Data   T      `json:"data"`
+	Time   string `json:"time,omitempty"`
+	Status string `json:"status"`
+}
+
+// Success builds a QueryResult with status="OK".
+func Success[T any](data T, execTime string) QueryResult[T] {
+	return QueryResult[T]{Data: data, Time: execTime, Status: "OK"}
+}
+
+// RecordResult wraps a single (possibly-missing) record.
+type RecordResult[T any] struct {
+	Record *T   `json:"record"`
+	Exists bool `json:"exists"`
+}
+
+// Record builds a RecordResult.
+func Record[T any](rec *T, exists bool) RecordResult[T] {
+	return RecordResult[T]{Record: rec, Exists: exists}
+}
+
+// Unwrap returns the record or panics if nil.
+func (r RecordResult[T]) Unwrap() T {
+	if r.Record == nil {
+		panic("RecordResult.Unwrap called on a nil record")
+	}
+	return *r.Record
+}
+
+// TryUnwrap returns the record or ErrValidation when nil.
+func (r RecordResult[T]) TryUnwrap() (T, error) {
+	var zero T
+	if r.Record == nil {
+		return zero, surqlerrors.New(surqlerrors.ErrValidation, "Cannot unwrap nil record")
+	}
+	return *r.Record, nil
+}
+
+// UnwrapOr returns the record or the given default when nil.
+func (r RecordResult[T]) UnwrapOr(def T) T {
+	if r.Record == nil {
+		return def
+	}
+	return *r.Record
+}
+
+// ListResult wraps a slice of records with optional pagination hints.
+type ListResult[T any] struct {
+	Records []T     `json:"records"`
+	Total   *uint64 `json:"total,omitempty"`
+	Limit   *uint64 `json:"limit,omitempty"`
+	Offset  *uint64 `json:"offset,omitempty"`
+	HasMore bool    `json:"has_more"`
+}
+
+// Records builds a ListResult with has_more inferred from the pagination
+// inputs (mirrors surql-py's heuristic).
+func Records[T any](items []T, total, limit, offset *uint64) ListResult[T] {
+	hasMore := false
+	switch {
+	case total != nil && limit != nil && offset != nil:
+		hasMore = (*offset)+(*limit) < *total
+	case total == nil && limit != nil:
+		hasMore = uint64(len(items)) == *limit
+	}
+	return ListResult[T]{
+		Records: items, Total: total, Limit: limit, Offset: offset, HasMore: hasMore,
+	}
+}
+
+// Len returns the number of records.
+func (r ListResult[T]) Len() int { return len(r.Records) }
+
+// IsEmpty reports whether the list is empty.
+func (r ListResult[T]) IsEmpty() bool { return len(r.Records) == 0 }
+
+// First returns the first record or nil.
+func (r ListResult[T]) First() *T {
+	if len(r.Records) == 0 {
+		return nil
+	}
+	return &r.Records[0]
+}
+
+// Last returns the last record or nil.
+func (r ListResult[T]) Last() *T {
+	if len(r.Records) == 0 {
+		return nil
+	}
+	return &r.Records[len(r.Records)-1]
+}
+
+// CountResult holds a COUNT aggregation.
+type CountResult struct {
+	Count int64 `json:"count"`
+}
+
+// NewCountResult builds a CountResult.
+func NewCountResult(n int64) CountResult { return CountResult{Count: n} }
+
+// AggregateResult is the generic aggregation wrapper.
+type AggregateResult struct {
+	Value     json.RawMessage `json:"value"`
+	Operation string          `json:"operation,omitempty"`
+	Field     string          `json:"field,omitempty"`
+}
+
+// Aggregate builds an AggregateResult. The value can be any JSON-serialisable
+// value; it is re-encoded into json.RawMessage for opaque round-tripping.
+func Aggregate(value any, operation, field string) (AggregateResult, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return AggregateResult{}, surqlerrors.Wrap(surqlerrors.ErrSerialization, "aggregate value", err)
+	}
+	return AggregateResult{Value: raw, Operation: operation, Field: field}, nil
+}
+
+// PageInfo carries pagination metadata.
+type PageInfo struct {
+	CurrentPage uint64 `json:"current_page"`
+	PageSize    uint64 `json:"page_size"`
+	TotalPages  uint64 `json:"total_pages"`
+	TotalItems  uint64 `json:"total_items"`
+	HasPrevious bool   `json:"has_previous"`
+	HasNext     bool   `json:"has_next"`
+}
+
+// PaginatedResult wraps a page of items with metadata.
+type PaginatedResult[T any] struct {
+	Items    []T      `json:"items"`
+	PageInfo PageInfo `json:"page_info"`
+}
+
+// Paginated builds a PaginatedResult. `page` is 1-indexed.
+func Paginated[T any](items []T, page, pageSize, total uint64) PaginatedResult[T] {
+	var totalPages uint64
+	if pageSize > 0 {
+		totalPages = (total + pageSize - 1) / pageSize
+	}
+	return PaginatedResult[T]{
+		Items: items,
+		PageInfo: PageInfo{
+			CurrentPage: page,
+			PageSize:    pageSize,
+			TotalPages:  totalPages,
+			TotalItems:  total,
+			HasPrevious: page > 1,
+			HasNext:     page < totalPages,
+		},
+	}
+}
+
+// Len returns the number of items on the current page.
+func (p PaginatedResult[T]) Len() int { return len(p.Items) }
+
+// IsEmpty reports whether the current page is empty.
+func (p PaginatedResult[T]) IsEmpty() bool { return len(p.Items) == 0 }
+
+// ExtractResult pulls the array of records from a raw SurrealDB response,
+// handling both nested (`[{"result": [...]}]` from db.query) and flat
+// (`[{...}, ...]` from db.select) formats.
+func ExtractResult(result any) []map[string]any {
+	if result == nil {
+		return nil
+	}
+	// []any top-level
+	if arr, ok := result.([]any); ok {
+		if len(arr) == 0 {
+			return nil
+		}
+		// Nested?
+		if first, ok := arr[0].(map[string]any); ok {
+			if _, hasResult := first["result"]; hasResult {
+				var out []map[string]any
+				for _, item := range arr {
+					m, ok := item.(map[string]any)
+					if !ok {
+						continue
+					}
+					inner, has := m["result"]
+					if !has {
+						continue
+					}
+					pushValue(&out, inner)
+				}
+				return out
+			}
+		}
+		// Flat: collect map[string]any elements only
+		var out []map[string]any
+		for _, item := range arr {
+			if m, ok := item.(map[string]any); ok {
+				out = append(out, m)
+			}
+		}
+		return out
+	}
+	// Single object with "result"
+	if m, ok := result.(map[string]any); ok {
+		if inner, has := m["result"]; has {
+			var out []map[string]any
+			pushValue(&out, inner)
+			return out
+		}
+	}
+	return nil
+}
+
+func pushValue(out *[]map[string]any, v any) {
+	switch vv := v.(type) {
+	case []any:
+		for _, x := range vv {
+			if m, ok := x.(map[string]any); ok {
+				*out = append(*out, m)
+			}
+		}
+	case map[string]any:
+		*out = append(*out, vv)
+	case nil:
+		// no-op
+	default:
+		*out = append(*out, map[string]any{"value": vv})
+	}
+}
+
+// ExtractOne returns the first record from a raw response, or nil.
+func ExtractOne(result any) map[string]any {
+	records := ExtractResult(result)
+	if len(records) == 0 {
+		return nil
+	}
+	return records[0]
+}
+
+// ExtractScalar pulls a scalar value from an aggregate response. Returns
+// `def` when the result is empty or the key is missing.
+func ExtractScalar(result any, key string, def any) any {
+	one := ExtractOne(result)
+	if one == nil {
+		return def
+	}
+	if v, ok := one[key]; ok {
+		return v
+	}
+	return def
+}
+
+// HasResults reports whether the response contains at least one record.
+func HasResults(result any) bool {
+	return len(ExtractResult(result)) > 0
+}

--- a/pkg/surql/query/results_test.go
+++ b/pkg/surql/query/results_test.go
@@ -1,0 +1,214 @@
+package query
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRecordResult_Unwrap(t *testing.T) {
+	v := 42
+	r := Record(&v, true)
+	if got := r.Unwrap(); got != 42 {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestRecordResult_UnwrapOr(t *testing.T) {
+	var r RecordResult[int]
+	if got := r.UnwrapOr(5); got != 5 {
+		t.Errorf("got %v", got)
+	}
+	v := 1
+	if got := Record(&v, true).UnwrapOr(5); got != 1 {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestRecordResult_TryUnwrapNil(t *testing.T) {
+	var r RecordResult[int]
+	if _, err := r.TryUnwrap(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestListResult_Helpers(t *testing.T) {
+	three := uint64(3)
+	ten := uint64(10)
+	zero := uint64(0)
+	lr := Records([]int{1, 2, 3}, &three, &ten, &zero)
+	if lr.Len() != 3 || lr.IsEmpty() {
+		t.Errorf("len=%d empty=%v", lr.Len(), lr.IsEmpty())
+	}
+	if *lr.First() != 1 || *lr.Last() != 3 {
+		t.Errorf("first/last")
+	}
+}
+
+func TestRecords_HasMoreFromTotal(t *testing.T) {
+	twenty := uint64(20)
+	three := uint64(3)
+	zero := uint64(0)
+	lr := Records([]int{1, 2, 3}, &twenty, &three, &zero)
+	if !lr.HasMore {
+		t.Error("expected has_more")
+	}
+	threeAgain := uint64(3)
+	done := Records([]int{1, 2, 3}, &threeAgain, &three, &zero)
+	if done.HasMore {
+		t.Error("expected no has_more")
+	}
+}
+
+func TestRecords_HasMoreFromLimitOnly(t *testing.T) {
+	three := uint64(3)
+	lr := Records([]int{1, 2, 3}, nil, &three, nil)
+	if !lr.HasMore {
+		t.Error("expected has_more")
+	}
+	lr2 := Records([]int{1, 2}, nil, &three, nil)
+	if lr2.HasMore {
+		t.Error("expected no has_more")
+	}
+}
+
+func TestPaginated_ComputesPages(t *testing.T) {
+	p := Paginated([]int{1, 2, 3}, 1, 10, 100)
+	if p.PageInfo.TotalPages != 10 {
+		t.Errorf("total_pages: %d", p.PageInfo.TotalPages)
+	}
+	if p.PageInfo.HasPrevious || !p.PageInfo.HasNext {
+		t.Errorf("has_prev=%v has_next=%v", p.PageInfo.HasPrevious, p.PageInfo.HasNext)
+	}
+}
+
+func TestPaginated_LastPageRounding(t *testing.T) {
+	p := Paginated[int](nil, 10, 10, 95)
+	if p.PageInfo.TotalPages != 10 {
+		t.Errorf("got %d", p.PageInfo.TotalPages)
+	}
+	if p.PageInfo.HasNext || !p.PageInfo.HasPrevious {
+		t.Errorf("has_prev=%v has_next=%v", p.PageInfo.HasPrevious, p.PageInfo.HasNext)
+	}
+}
+
+func TestPaginated_ZeroPageSize(t *testing.T) {
+	p := Paginated[int](nil, 1, 0, 100)
+	if p.PageInfo.TotalPages != 0 {
+		t.Errorf("got %d", p.PageInfo.TotalPages)
+	}
+}
+
+func TestExtract_Flat(t *testing.T) {
+	raw := []any{map[string]any{"id": "user:123", "name": "Alice"}}
+	out := ExtractResult(raw)
+	if len(out) != 1 || out[0]["name"] != "Alice" {
+		t.Errorf("got %+v", out)
+	}
+}
+
+func TestExtract_Nested(t *testing.T) {
+	raw := []any{
+		map[string]any{"result": []any{map[string]any{"id": "user:123", "name": "Alice"}}},
+	}
+	out := ExtractResult(raw)
+	if len(out) != 1 || out[0]["name"] != "Alice" {
+		t.Errorf("got %+v", out)
+	}
+}
+
+func TestExtract_NestedMultiple(t *testing.T) {
+	raw := []any{
+		map[string]any{"result": []any{
+			map[string]any{"id": "user:1"},
+			map[string]any{"id": "user:2"},
+		}},
+		map[string]any{"result": []any{map[string]any{"id": "user:3"}}},
+	}
+	out := ExtractResult(raw)
+	if len(out) != 3 {
+		t.Errorf("got %d records", len(out))
+	}
+}
+
+func TestExtract_Empty(t *testing.T) {
+	if out := ExtractResult([]any{}); len(out) != 0 {
+		t.Errorf("got %+v", out)
+	}
+}
+
+func TestExtract_Nil(t *testing.T) {
+	if out := ExtractResult(nil); out != nil && len(out) != 0 {
+		t.Errorf("got %+v", out)
+	}
+}
+
+func TestExtract_ObjectWithResult(t *testing.T) {
+	raw := map[string]any{"result": []any{map[string]any{"id": "u:1"}}}
+	if out := ExtractResult(raw); len(out) != 1 {
+		t.Errorf("got %d", len(out))
+	}
+}
+
+func TestExtractOne(t *testing.T) {
+	raw := []any{map[string]any{"result": []any{map[string]any{"id": "user:123", "name": "Alice"}}}}
+	one := ExtractOne(raw)
+	if one == nil || one["name"] != "Alice" {
+		t.Errorf("got %+v", one)
+	}
+	if ExtractOne([]any{}) != nil {
+		t.Error("expected nil")
+	}
+}
+
+func TestExtractScalar(t *testing.T) {
+	raw := []any{map[string]any{"result": []any{map[string]any{"count": 42}}}}
+	if got := ExtractScalar(raw, "count", 0); got != 42 {
+		t.Errorf("got %v", got)
+	}
+	if got := ExtractScalar([]any{}, "count", 0); got != 0 {
+		t.Errorf("got %v", got)
+	}
+	rawMissing := []any{map[string]any{"id": "u:1"}}
+	if got := ExtractScalar(rawMissing, "total", 0); got != 0 {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestHasResults(t *testing.T) {
+	if !HasResults([]any{map[string]any{"result": []any{map[string]any{"id": "u:1"}}}}) {
+		t.Error("expected true")
+	}
+	if HasResults([]any{}) {
+		t.Error("expected false")
+	}
+	if !HasResults([]any{map[string]any{"id": "u:1"}}) {
+		t.Error("expected true on flat")
+	}
+	if HasResults([]any{map[string]any{"result": []any{}}}) {
+		t.Error("expected false on empty nested")
+	}
+}
+
+func TestSuccess(t *testing.T) {
+	r := Success([]int{1, 2, 3}, "12ms")
+	if r.Status != "OK" || r.Time != "12ms" || len(r.Data) != 3 {
+		t.Errorf("got %+v", r)
+	}
+}
+
+func TestCountAndAggregate(t *testing.T) {
+	if NewCountResult(42).Count != 42 {
+		t.Error("count mismatch")
+	}
+	a, err := Aggregate(25.5, "AVG", "age")
+	if err != nil {
+		t.Fatalf("aggregate: %v", err)
+	}
+	var got float64
+	if err := json.Unmarshal(a.Value, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got != 25.5 {
+		t.Errorf("got %v", got)
+	}
+}

--- a/pkg/surql/schema/access.go
+++ b/pkg/surql/schema/access.go
@@ -1,0 +1,191 @@
+package schema
+
+import (
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// AccessType enumerates the access control types supported by DEFINE ACCESS.
+type AccessType string
+
+// AccessType values.
+const (
+	AccessTypeJWT    AccessType = "JWT"
+	AccessTypeRecord AccessType = "RECORD"
+)
+
+// IsValid reports whether the AccessType is recognised.
+func (a AccessType) IsValid() bool {
+	switch a {
+	case AccessTypeJWT, AccessTypeRecord:
+		return true
+	}
+	return false
+}
+
+// JwtConfig describes the JWT-specific configuration of a DEFINE ACCESS
+// statement. The Algorithm field defaults to "HS256" when unset.
+type JwtConfig struct {
+	Algorithm string
+	Key       string
+	URL       string
+	Issuer    string
+}
+
+// RecordAccessConfig describes the RECORD-specific configuration of a DEFINE
+// ACCESS statement.
+type RecordAccessConfig struct {
+	Signup string
+	Signin string
+}
+
+// AccessDefinition captures a DEFINE ACCESS statement.
+type AccessDefinition struct {
+	Name            string
+	Type            AccessType
+	JWT             *JwtConfig
+	Record          *RecordAccessConfig
+	DurationSession string
+	DurationToken   string
+}
+
+// AccessOption customises an AccessDefinition created via NewAccess.
+type AccessOption func(*AccessDefinition)
+
+// WithJWT attaches a JwtConfig (and implicitly sets Type to AccessTypeJWT if
+// not already set by the caller).
+func WithJWT(cfg JwtConfig) AccessOption {
+	return func(a *AccessDefinition) {
+		cp := cfg
+		a.JWT = &cp
+	}
+}
+
+// WithRecord attaches a RecordAccessConfig.
+func WithRecord(cfg RecordAccessConfig) AccessOption {
+	return func(a *AccessDefinition) {
+		cp := cfg
+		a.Record = &cp
+	}
+}
+
+// WithDurationSession sets the FOR SESSION clause.
+func WithDurationSession(dur string) AccessOption {
+	return func(a *AccessDefinition) { a.DurationSession = dur }
+}
+
+// WithDurationToken sets the FOR TOKEN clause.
+func WithDurationToken(dur string) AccessOption {
+	return func(a *AccessDefinition) { a.DurationToken = dur }
+}
+
+// NewAccess constructs an AccessDefinition of the given type.
+func NewAccess(name string, accessType AccessType, opts ...AccessOption) AccessDefinition {
+	a := AccessDefinition{Name: name, Type: accessType}
+	for _, opt := range opts {
+		opt(&a)
+	}
+	return a
+}
+
+// JwtAccess constructs a JWT-type AccessDefinition. Algorithm defaults to
+// HS256 when left blank.
+func JwtAccess(name string, cfg JwtConfig, opts ...AccessOption) AccessDefinition {
+	if cfg.Algorithm == "" {
+		cfg.Algorithm = "HS256"
+	}
+	merged := append([]AccessOption{WithJWT(cfg)}, opts...)
+	return NewAccess(name, AccessTypeJWT, merged...)
+}
+
+// RecordAccess constructs a RECORD-type AccessDefinition.
+func RecordAccess(name string, cfg RecordAccessConfig, opts ...AccessOption) AccessDefinition {
+	merged := append([]AccessOption{WithRecord(cfg)}, opts...)
+	return NewAccess(name, AccessTypeRecord, merged...)
+}
+
+// Validate checks structural invariants for the access definition.
+func (a AccessDefinition) Validate() error {
+	if a.Name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "access name cannot be empty")
+	}
+	if !a.Type.IsValid() {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"invalid access type %q for access %q", string(a.Type), a.Name)
+	}
+	switch a.Type {
+	case AccessTypeJWT:
+		if a.JWT == nil {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"JWT access %q requires a JWT config", a.Name)
+		}
+	case AccessTypeRecord:
+		if a.Record == nil {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"RECORD access %q requires a record config", a.Name)
+		}
+	}
+	return nil
+}
+
+// ToSurql emits the DEFINE ACCESS statement.
+func (a AccessDefinition) ToSurql() string {
+	var b strings.Builder
+	b.WriteString("DEFINE ACCESS ")
+	b.WriteString(a.Name)
+	b.WriteString(" ON DATABASE TYPE ")
+	b.WriteString(string(a.Type))
+
+	if a.Type == AccessTypeJWT && a.JWT != nil {
+		algo := a.JWT.Algorithm
+		if algo == "" {
+			algo = "HS256"
+		}
+		b.WriteString(" ALGORITHM ")
+		b.WriteString(algo)
+		if a.JWT.Key != "" {
+			b.WriteString(" KEY '")
+			b.WriteString(a.JWT.Key)
+			b.WriteString("'")
+		}
+		if a.JWT.URL != "" {
+			b.WriteString(" URL '")
+			b.WriteString(a.JWT.URL)
+			b.WriteString("'")
+		}
+		if a.JWT.Issuer != "" {
+			b.WriteString(" WITH ISSUER '")
+			b.WriteString(a.JWT.Issuer)
+			b.WriteString("'")
+		}
+	}
+
+	if a.Type == AccessTypeRecord && a.Record != nil {
+		if a.Record.Signup != "" {
+			b.WriteString(" SIGNUP (")
+			b.WriteString(a.Record.Signup)
+			b.WriteString(")")
+		}
+		if a.Record.Signin != "" {
+			b.WriteString(" SIGNIN (")
+			b.WriteString(a.Record.Signin)
+			b.WriteString(")")
+		}
+	}
+
+	if a.DurationSession != "" || a.DurationToken != "" {
+		parts := make([]string, 0, 2)
+		if a.DurationSession != "" {
+			parts = append(parts, "FOR SESSION "+a.DurationSession)
+		}
+		if a.DurationToken != "" {
+			parts = append(parts, "FOR TOKEN "+a.DurationToken)
+		}
+		b.WriteString(" DURATION ")
+		b.WriteString(strings.Join(parts, ", "))
+	}
+
+	b.WriteString(";")
+	return b.String()
+}

--- a/pkg/surql/schema/access_test.go
+++ b/pkg/surql/schema/access_test.go
@@ -1,0 +1,187 @@
+package schema
+
+import (
+	stdErrors "errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestAccessType_IsValid(t *testing.T) {
+	if !AccessTypeJWT.IsValid() {
+		t.Error("JWT should be valid")
+	}
+	if !AccessTypeRecord.IsValid() {
+		t.Error("RECORD should be valid")
+	}
+	if AccessType("bogus").IsValid() {
+		t.Error("bogus should not be valid")
+	}
+}
+
+func TestJwtAccess_ToSurql_KeyOnly(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{Algorithm: "HS256", Key: "secret"})
+	got := a.ToSurql()
+	want := "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'secret';"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestJwtAccess_ToSurql_DefaultsAlgorithm(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{Key: "secret"})
+	got := a.ToSurql()
+	if !strings.Contains(got, "ALGORITHM HS256") {
+		t.Errorf("default algorithm missing: %q", got)
+	}
+}
+
+func TestJwtAccess_ToSurql_WithURL(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{
+		Algorithm: "RS256",
+		URL:       "https://example.com/.well-known/jwks.json",
+	})
+	got := a.ToSurql()
+	if !strings.Contains(got, "ALGORITHM RS256") {
+		t.Errorf("ToSurql = %q", got)
+	}
+	if !strings.Contains(got, "URL 'https://example.com/.well-known/jwks.json'") {
+		t.Errorf("URL clause missing: %q", got)
+	}
+}
+
+func TestJwtAccess_ToSurql_WithIssuer(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{Algorithm: "HS256", Key: "s", Issuer: "me"})
+	got := a.ToSurql()
+	if !strings.Contains(got, "WITH ISSUER 'me'") {
+		t.Errorf("issuer missing: %q", got)
+	}
+}
+
+func TestRecordAccess_ToSurql_SignupOnly(t *testing.T) {
+	a := RecordAccess("user_auth", RecordAccessConfig{Signup: "CREATE user SET email = $email"})
+	got := a.ToSurql()
+	if !strings.HasPrefix(got, "DEFINE ACCESS user_auth ON DATABASE TYPE RECORD") {
+		t.Errorf("prefix wrong: %q", got)
+	}
+	if !strings.Contains(got, "SIGNUP (CREATE user SET email = $email)") {
+		t.Errorf("signup missing: %q", got)
+	}
+}
+
+func TestRecordAccess_ToSurql_SigninOnly(t *testing.T) {
+	a := RecordAccess("user_auth", RecordAccessConfig{Signin: "SELECT * FROM user"})
+	got := a.ToSurql()
+	if !strings.Contains(got, "SIGNIN (SELECT * FROM user)") {
+		t.Errorf("signin missing: %q", got)
+	}
+}
+
+func TestRecordAccess_ToSurql_Both(t *testing.T) {
+	a := RecordAccess("user_auth", RecordAccessConfig{
+		Signup: "CREATE user",
+		Signin: "SELECT * FROM user",
+	})
+	got := a.ToSurql()
+	if !strings.Contains(got, "SIGNUP (CREATE user)") {
+		t.Errorf("signup missing: %q", got)
+	}
+	if !strings.Contains(got, "SIGNIN (SELECT * FROM user)") {
+		t.Errorf("signin missing: %q", got)
+	}
+}
+
+func TestAccess_ToSurql_DurationSession(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{Key: "s"}, WithDurationSession("24h"))
+	got := a.ToSurql()
+	if !strings.Contains(got, "DURATION FOR SESSION 24h") {
+		t.Errorf("session duration missing: %q", got)
+	}
+}
+
+func TestAccess_ToSurql_DurationToken(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{Key: "s"}, WithDurationToken("15m"))
+	got := a.ToSurql()
+	if !strings.Contains(got, "DURATION FOR TOKEN 15m") {
+		t.Errorf("token duration missing: %q", got)
+	}
+}
+
+func TestAccess_ToSurql_DurationBoth(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{Key: "s"},
+		WithDurationSession("24h"), WithDurationToken("15m"))
+	got := a.ToSurql()
+	if !strings.Contains(got, "FOR SESSION 24h") || !strings.Contains(got, "FOR TOKEN 15m") {
+		t.Errorf("durations missing: %q", got)
+	}
+	// Both should appear after DURATION keyword (single occurrence).
+	if strings.Count(got, "DURATION ") != 1 {
+		t.Errorf("expected single DURATION keyword: %q", got)
+	}
+}
+
+func TestAccess_Validate_EmptyName(t *testing.T) {
+	a := AccessDefinition{Type: AccessTypeJWT, JWT: &JwtConfig{}}
+	if err := a.Validate(); err == nil {
+		t.Error("empty name should fail")
+	}
+}
+
+func TestAccess_Validate_InvalidType(t *testing.T) {
+	a := AccessDefinition{Name: "x", Type: AccessType("bogus")}
+	err := a.Validate()
+	if err == nil {
+		t.Fatal("invalid type should fail")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestAccess_Validate_JwtRequiresConfig(t *testing.T) {
+	a := AccessDefinition{Name: "api", Type: AccessTypeJWT}
+	if err := a.Validate(); err == nil {
+		t.Error("JWT without config should fail")
+	}
+}
+
+func TestAccess_Validate_RecordRequiresConfig(t *testing.T) {
+	a := AccessDefinition{Name: "api", Type: AccessTypeRecord}
+	if err := a.Validate(); err == nil {
+		t.Error("RECORD without config should fail")
+	}
+}
+
+func TestAccess_Validate_ValidJwt(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{Key: "s"})
+	if err := a.Validate(); err != nil {
+		t.Errorf("valid JWT errored: %v", err)
+	}
+}
+
+func TestAccess_Validate_ValidRecord(t *testing.T) {
+	a := RecordAccess("u", RecordAccessConfig{Signin: "SELECT * FROM user"})
+	if err := a.Validate(); err != nil {
+		t.Errorf("valid RECORD errored: %v", err)
+	}
+}
+
+func TestNewAccess_Explicit(t *testing.T) {
+	a := NewAccess("x", AccessTypeJWT, WithJWT(JwtConfig{Algorithm: "HS512", Key: "k"}))
+	if a.Type != AccessTypeJWT {
+		t.Errorf("type = %q", string(a.Type))
+	}
+	if a.JWT == nil || a.JWT.Algorithm != "HS512" {
+		t.Errorf("JWT config wrong: %+v", a.JWT)
+	}
+}
+
+func TestAccessConfigIsolation(t *testing.T) {
+	cfg := JwtConfig{Algorithm: "HS256", Key: "k"}
+	a := JwtAccess("api", cfg)
+	cfg.Key = "MUTATED"
+	if a.JWT.Key != "k" {
+		t.Errorf("expected isolated JWT config; got %q", a.JWT.Key)
+	}
+}

--- a/pkg/surql/schema/doc.go
+++ b/pkg/surql/schema/doc.go
@@ -1,0 +1,26 @@
+// Package schema provides typed builders for SurrealDB schema definitions.
+//
+// It is a Go port of surql-py/src/surql/schema/ (fields, table, edge, access
+// modules only). Each definition is an immutable value-type struct with:
+//
+//   - A ToSurql() method that renders the DEFINE statement as SurrealQL.
+//   - A Validate() method returning a wrapped surqlerrors.ErrValidation
+//     when the definition is malformed.
+//
+// Typical usage:
+//
+//	t := schema.NewTable("user",
+//	    schema.WithMode(schema.TableModeSchemafull),
+//	    schema.WithFields(
+//	        schema.StringField("email"),
+//	        schema.IntField("age"),
+//	    ),
+//	    schema.WithIndexes(
+//	        schema.UniqueIndex("email_idx", []string{"email"}),
+//	    ),
+//	)
+//	stmts := t.ToSurqlStatements()
+//
+// The package does NOT include the registry, validator, parser, visualizer,
+// or diff tooling; those will be added in later increments.
+package schema

--- a/pkg/surql/schema/edge.go
+++ b/pkg/surql/schema/edge.go
@@ -1,0 +1,234 @@
+package schema
+
+import (
+	"sort"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// EdgeMode enumerates edge table modes.
+type EdgeMode string
+
+// EdgeMode values.
+const (
+	EdgeModeRelation   EdgeMode = "RELATION"
+	EdgeModeSchemafull EdgeMode = "SCHEMAFULL"
+	EdgeModeSchemaless EdgeMode = "SCHEMALESS"
+)
+
+// IsValid reports whether the EdgeMode is recognised.
+func (m EdgeMode) IsValid() bool {
+	switch m {
+	case EdgeModeRelation, EdgeModeSchemafull, EdgeModeSchemaless:
+		return true
+	}
+	return false
+}
+
+// EdgeDefinition captures the fields required to emit a DEFINE TABLE ... TYPE
+// RELATION statement (or a SCHEMAFULL / SCHEMALESS edge) plus its attendant
+// DEFINE FIELD / INDEX / EVENT children.
+type EdgeDefinition struct {
+	Name        string
+	Mode        EdgeMode
+	FromTable   string
+	ToTable     string
+	Fields      []FieldDefinition
+	Indexes     []IndexDefinition
+	Events      []EventDefinition
+	Permissions map[string]string
+}
+
+// EdgeOption customises an EdgeDefinition created via NewEdge.
+type EdgeOption func(*EdgeDefinition)
+
+// WithEdgeMode sets the edge table mode.
+func WithEdgeMode(mode EdgeMode) EdgeOption {
+	return func(e *EdgeDefinition) { e.Mode = mode }
+}
+
+// WithFromTable sets the source table constraint.
+func WithFromTable(table string) EdgeOption {
+	return func(e *EdgeDefinition) { e.FromTable = table }
+}
+
+// WithToTable sets the destination table constraint.
+func WithToTable(table string) EdgeOption {
+	return func(e *EdgeDefinition) { e.ToTable = table }
+}
+
+// WithEdgeFields appends fields.
+func WithEdgeFields(fields ...FieldDefinition) EdgeOption {
+	return func(e *EdgeDefinition) { e.Fields = append(e.Fields, fields...) }
+}
+
+// WithEdgeIndexes appends indexes.
+func WithEdgeIndexes(indexes ...IndexDefinition) EdgeOption {
+	return func(e *EdgeDefinition) { e.Indexes = append(e.Indexes, indexes...) }
+}
+
+// WithEdgeEvents appends events.
+func WithEdgeEvents(events ...EventDefinition) EdgeOption {
+	return func(e *EdgeDefinition) { e.Events = append(e.Events, events...) }
+}
+
+// WithEdgePermissions sets permissions for the edge table.
+func WithEdgePermissions(perms map[string]string) EdgeOption {
+	return func(e *EdgeDefinition) {
+		if perms == nil {
+			e.Permissions = nil
+			return
+		}
+		copied := make(map[string]string, len(perms))
+		for k, v := range perms {
+			copied[k] = v
+		}
+		e.Permissions = copied
+	}
+}
+
+// NewEdge constructs an EdgeDefinition with EdgeModeRelation as default.
+func NewEdge(name string, opts ...EdgeOption) EdgeDefinition {
+	e := EdgeDefinition{Name: name, Mode: EdgeModeRelation}
+	for _, opt := range opts {
+		opt(&e)
+	}
+	return e
+}
+
+// BidirectionalEdge builds an edge whose from and to constraints reference the
+// same table (e.g. user->user follows).
+func BidirectionalEdge(name, table string, opts ...EdgeOption) EdgeDefinition {
+	merged := append([]EdgeOption{WithFromTable(table), WithToTable(table)}, opts...)
+	return NewEdge(name, merged...)
+}
+
+// TypedEdge builds an edge with specific from/to table constraints.
+func TypedEdge(name, fromTable, toTable string, opts ...EdgeOption) EdgeDefinition {
+	merged := append([]EdgeOption{WithFromTable(fromTable), WithToTable(toTable)}, opts...)
+	return NewEdge(name, merged...)
+}
+
+// Validate checks edge-level invariants plus each child definition.
+func (e EdgeDefinition) Validate() error {
+	if e.Name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "edge name cannot be empty")
+	}
+	if !e.Mode.IsValid() {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"invalid edge mode %q for edge %q", string(e.Mode), e.Name)
+	}
+	if e.Mode == EdgeModeRelation {
+		if e.FromTable == "" || e.ToTable == "" {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"edge %q with RELATION mode requires both from_table and to_table",
+				e.Name)
+		}
+	}
+	for _, f := range e.Fields {
+		if err := f.Validate(); err != nil {
+			return err
+		}
+	}
+	for _, i := range e.Indexes {
+		if err := i.Validate(); err != nil {
+			return err
+		}
+	}
+	for _, ev := range e.Events {
+		if err := ev.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ToSurql emits only the DEFINE TABLE line for this edge (no children).
+func (e EdgeDefinition) ToSurql() string {
+	return e.toSurqlTable(false)
+}
+
+// ToSurqlIfNotExists emits the DEFINE TABLE line with IF NOT EXISTS.
+func (e EdgeDefinition) ToSurqlIfNotExists() string {
+	return e.toSurqlTable(true)
+}
+
+func (e EdgeDefinition) toSurqlTable(ifNotExists bool) string {
+	var b strings.Builder
+	b.WriteString("DEFINE TABLE")
+	if ifNotExists {
+		b.WriteString(" IF NOT EXISTS")
+	}
+	b.WriteString(" ")
+	b.WriteString(e.Name)
+
+	switch e.Mode {
+	case EdgeModeRelation:
+		b.WriteString(" TYPE RELATION")
+		if e.FromTable != "" {
+			b.WriteString(" FROM ")
+			b.WriteString(e.FromTable)
+		}
+		if e.ToTable != "" {
+			b.WriteString(" TO ")
+			b.WriteString(e.ToTable)
+		}
+	case EdgeModeSchemafull:
+		b.WriteString(" SCHEMAFULL")
+	case EdgeModeSchemaless:
+		b.WriteString(" SCHEMALESS")
+	}
+
+	b.WriteString(";")
+	return b.String()
+}
+
+// ToSurqlStatements returns the DEFINE TABLE line followed by each DEFINE
+// FIELD / INDEX / EVENT / PERMISSIONS for this edge. It returns an error when
+// the edge violates structural invariants (e.g. RELATION mode without
+// from/to tables).
+func (e EdgeDefinition) ToSurqlStatements() ([]string, error) {
+	return e.toSurqlStatements(false)
+}
+
+// ToSurqlStatementsIfNotExists is like ToSurqlStatements with IF NOT EXISTS.
+func (e EdgeDefinition) ToSurqlStatementsIfNotExists() ([]string, error) {
+	return e.toSurqlStatements(true)
+}
+
+func (e EdgeDefinition) toSurqlStatements(ifNotExists bool) ([]string, error) {
+	if e.Mode == EdgeModeRelation && (e.FromTable == "" || e.ToTable == "") {
+		return nil, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"edge %q with RELATION mode requires both from_table and to_table",
+			e.Name)
+	}
+
+	stmts := make([]string, 0, 1+len(e.Fields)+len(e.Indexes)+len(e.Events))
+	stmts = append(stmts, e.toSurqlTable(ifNotExists))
+
+	for _, f := range e.Fields {
+		stmts = append(stmts, f.toSurql(e.Name, ifNotExists))
+	}
+	for _, i := range e.Indexes {
+		stmts = append(stmts, i.toSurql(e.Name, ifNotExists))
+	}
+	for _, ev := range e.Events {
+		stmts = append(stmts, ev.toSurql(e.Name, ifNotExists))
+	}
+
+	if len(e.Permissions) > 0 {
+		keys := make([]string, 0, len(e.Permissions))
+		for k := range e.Permissions {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			stmts = append(stmts,
+				"DEFINE FIELD PERMISSIONS FOR "+strings.ToUpper(k)+
+					" ON TABLE "+e.Name+" WHERE "+e.Permissions[k]+";")
+		}
+	}
+
+	return stmts, nil
+}

--- a/pkg/surql/schema/edge_test.go
+++ b/pkg/surql/schema/edge_test.go
@@ -1,0 +1,262 @@
+package schema
+
+import (
+	stdErrors "errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestEdgeMode_IsValid(t *testing.T) {
+	for _, m := range []EdgeMode{EdgeModeRelation, EdgeModeSchemafull, EdgeModeSchemaless} {
+		if !m.IsValid() {
+			t.Errorf("%q should be valid", string(m))
+		}
+	}
+	if EdgeMode("bogus").IsValid() {
+		t.Error("bogus edge mode")
+	}
+}
+
+func TestNewEdge_DefaultMode(t *testing.T) {
+	e := NewEdge("likes")
+	if e.Mode != EdgeModeRelation {
+		t.Errorf("default mode = %q", string(e.Mode))
+	}
+}
+
+func TestEdgeToSurql_Relation(t *testing.T) {
+	e := NewEdge("likes", WithFromTable("user"), WithToTable("post"))
+	got := e.ToSurql()
+	want := "DEFINE TABLE likes TYPE RELATION FROM user TO post;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestEdgeToSurql_Schemafull(t *testing.T) {
+	e := NewEdge("entity_rel", WithEdgeMode(EdgeModeSchemafull))
+	got := e.ToSurql()
+	want := "DEFINE TABLE entity_rel SCHEMAFULL;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestEdgeToSurql_Schemaless(t *testing.T) {
+	e := NewEdge("loose_rel", WithEdgeMode(EdgeModeSchemaless))
+	got := e.ToSurql()
+	want := "DEFINE TABLE loose_rel SCHEMALESS;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestEdgeToSurqlIfNotExists(t *testing.T) {
+	e := NewEdge("likes", WithFromTable("user"), WithToTable("post"))
+	got := e.ToSurqlIfNotExists()
+	want := "DEFINE TABLE IF NOT EXISTS likes TYPE RELATION FROM user TO post;"
+	if got != want {
+		t.Errorf("ToSurqlIfNotExists() = %q, want %q", got, want)
+	}
+}
+
+func TestEdgeStatements_MissingFromTable(t *testing.T) {
+	e := NewEdge("likes", WithToTable("post"))
+	_, err := e.ToSurqlStatements()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "requires both from_table and to_table") {
+		t.Errorf("err message = %q", err.Error())
+	}
+}
+
+func TestEdgeStatements_MissingToTable(t *testing.T) {
+	e := NewEdge("likes", WithFromTable("user"))
+	_, err := e.ToSurqlStatements()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestEdgeStatements_MissingBoth(t *testing.T) {
+	e := NewEdge("likes")
+	_, err := e.ToSurqlStatements()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestEdgeStatements_SchemafullNoTablesRequired(t *testing.T) {
+	e := NewEdge("entity_rel", WithEdgeMode(EdgeModeSchemafull))
+	stmts, err := e.ToSurqlStatements()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stmts) != 1 {
+		t.Errorf("len = %d, want 1", len(stmts))
+	}
+}
+
+func TestEdgeStatements_WithFields(t *testing.T) {
+	e := NewEdge("likes",
+		WithFromTable("user"),
+		WithToTable("post"),
+		WithEdgeFields(DatetimeField("created_at", WithDefault("time::now()"))),
+	)
+	stmts, err := e.ToSurqlStatements()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "DEFINE FIELD created_at ON TABLE likes TYPE datetime") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected field stmt: %v", stmts)
+	}
+}
+
+func TestEdgeStatements_StartsWithDefineTable(t *testing.T) {
+	e := NewEdge("follows", WithFromTable("user"), WithToTable("user"))
+	stmts, err := e.ToSurqlStatements()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.HasPrefix(stmts[0], "DEFINE TABLE") {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+}
+
+func TestEdgeStatements_IfNotExists(t *testing.T) {
+	e := NewEdge("likes",
+		WithFromTable("user"),
+		WithToTable("post"),
+		WithEdgeFields(DatetimeField("created_at", WithDefault("time::now()"))),
+	)
+	stmts, err := e.ToSurqlStatementsIfNotExists()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if stmts[0] != "DEFINE TABLE IF NOT EXISTS likes TYPE RELATION FROM user TO post;" {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "DEFINE FIELD IF NOT EXISTS created_at ON TABLE likes") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected IF NOT EXISTS field stmt: %v", stmts)
+	}
+}
+
+func TestEdgeStatements_SchemafullIfNotExists(t *testing.T) {
+	e := NewEdge("entity_rel", WithEdgeMode(EdgeModeSchemafull))
+	stmts, err := e.ToSurqlStatementsIfNotExists()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if stmts[0] != "DEFINE TABLE IF NOT EXISTS entity_rel SCHEMAFULL;" {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+}
+
+func TestEdgeStatements_SchemalessIfNotExists(t *testing.T) {
+	e := NewEdge("loose_rel", WithEdgeMode(EdgeModeSchemaless))
+	stmts, err := e.ToSurqlStatementsIfNotExists()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if stmts[0] != "DEFINE TABLE IF NOT EXISTS loose_rel SCHEMALESS;" {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+}
+
+func TestBidirectionalEdge(t *testing.T) {
+	e := BidirectionalEdge("follows", "user")
+	if e.FromTable != "user" || e.ToTable != "user" {
+		t.Errorf("from=%q to=%q", e.FromTable, e.ToTable)
+	}
+	if e.Mode != EdgeModeRelation {
+		t.Errorf("mode = %q", string(e.Mode))
+	}
+}
+
+func TestTypedEdge(t *testing.T) {
+	e := TypedEdge("authored", "user", "post")
+	if e.FromTable != "user" || e.ToTable != "post" {
+		t.Errorf("from=%q to=%q", e.FromTable, e.ToTable)
+	}
+}
+
+func TestEdgeValidate_EmptyName(t *testing.T) {
+	e := EdgeDefinition{Mode: EdgeModeSchemafull}
+	if err := e.Validate(); err == nil {
+		t.Error("empty name should fail")
+	}
+}
+
+func TestEdgeValidate_InvalidMode(t *testing.T) {
+	e := EdgeDefinition{Name: "x", Mode: EdgeMode("bogus")}
+	if err := e.Validate(); err == nil {
+		t.Error("bogus mode should fail")
+	}
+}
+
+func TestEdgeValidate_RelationRequiresTables(t *testing.T) {
+	e := NewEdge("likes")
+	if err := e.Validate(); err == nil {
+		t.Error("RELATION without tables should fail validation")
+	}
+}
+
+func TestEdgeValidate_PropagatesField(t *testing.T) {
+	e := NewEdge("likes",
+		WithFromTable("user"), WithToTable("post"),
+		WithEdgeFields(NewField("1bad", FieldTypeString)),
+	)
+	if err := e.Validate(); err == nil {
+		t.Error("expected error from invalid field")
+	}
+}
+
+func TestEdgePermissions_MapCopyIsolation(t *testing.T) {
+	perms := map[string]string{"create": "$auth.id = in"}
+	e := NewEdge("likes",
+		WithFromTable("u"), WithToTable("p"),
+		WithEdgePermissions(perms),
+	)
+	perms["create"] = "MUTATED"
+	if e.Permissions["create"] != "$auth.id = in" {
+		t.Errorf("expected copied map; got %q", e.Permissions["create"])
+	}
+}
+
+func TestEdgeStatements_WithPermissions(t *testing.T) {
+	e := NewEdge("follows",
+		WithFromTable("user"), WithToTable("user"),
+		WithEdgePermissions(map[string]string{"create": "$auth.id = in"}),
+	)
+	stmts, err := e.ToSurqlStatements()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "FOR CREATE") && strings.Contains(s, "$auth.id = in") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected permissions stmt: %v", stmts)
+	}
+}

--- a/pkg/surql/schema/fields.go
+++ b/pkg/surql/schema/fields.go
@@ -1,0 +1,269 @@
+package schema
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/types"
+)
+
+// FieldType enumerates the SurrealDB field types supported in DEFINE FIELD.
+type FieldType string
+
+// FieldType values mirrored from surql-py FieldType enum.
+const (
+	FieldTypeString   FieldType = "string"
+	FieldTypeInt      FieldType = "int"
+	FieldTypeFloat    FieldType = "float"
+	FieldTypeBool     FieldType = "bool"
+	FieldTypeDatetime FieldType = "datetime"
+	FieldTypeDuration FieldType = "duration"
+	FieldTypeDecimal  FieldType = "decimal"
+	FieldTypeNumber   FieldType = "number"
+	FieldTypeObject   FieldType = "object"
+	FieldTypeArray    FieldType = "array"
+	FieldTypeRecord   FieldType = "record"
+	FieldTypeGeometry FieldType = "geometry"
+	FieldTypeAny      FieldType = "any"
+)
+
+// IsValid reports whether the receiver is one of the defined FieldType constants.
+func (f FieldType) IsValid() bool {
+	switch f {
+	case FieldTypeString, FieldTypeInt, FieldTypeFloat, FieldTypeBool,
+		FieldTypeDatetime, FieldTypeDuration, FieldTypeDecimal, FieldTypeNumber,
+		FieldTypeObject, FieldTypeArray, FieldTypeRecord, FieldTypeGeometry,
+		FieldTypeAny:
+		return true
+	}
+	return false
+}
+
+// String returns the SurrealQL-ready string form of the type.
+func (f FieldType) String() string { return string(f) }
+
+var fieldNamePartRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// FieldDefinition is an immutable description of a single column in a DEFINE
+// FIELD statement.
+type FieldDefinition struct {
+	Name        string
+	Type        FieldType
+	Assertion   string
+	Default     string
+	Value       string // computed fields
+	Permissions map[string]string
+	ReadOnly    bool
+	Flexible    bool
+}
+
+// FieldOption customises a FieldDefinition created via NewField.
+type FieldOption func(*FieldDefinition)
+
+// WithAssertion attaches a SurrealQL ASSERT clause.
+func WithAssertion(expr string) FieldOption {
+	return func(f *FieldDefinition) { f.Assertion = expr }
+}
+
+// WithDefault attaches a DEFAULT expression.
+func WithDefault(expr string) FieldOption {
+	return func(f *FieldDefinition) { f.Default = expr }
+}
+
+// WithValue attaches a VALUE expression (computed field).
+func WithValue(expr string) FieldOption {
+	return func(f *FieldDefinition) { f.Value = expr }
+}
+
+// WithFieldPermissions attaches a PERMISSIONS map keyed by action.
+func WithFieldPermissions(perms map[string]string) FieldOption {
+	return func(f *FieldDefinition) {
+		if perms == nil {
+			f.Permissions = nil
+			return
+		}
+		copied := make(map[string]string, len(perms))
+		for k, v := range perms {
+			copied[k] = v
+		}
+		f.Permissions = copied
+	}
+}
+
+// WithReadOnly marks the field READONLY.
+func WithReadOnly(readonly bool) FieldOption {
+	return func(f *FieldDefinition) { f.ReadOnly = readonly }
+}
+
+// WithFlexible marks the field FLEXIBLE (used for object fields).
+func WithFlexible(flex bool) FieldOption {
+	return func(f *FieldDefinition) { f.Flexible = flex }
+}
+
+// NewField constructs a FieldDefinition. It does not fail; use Validate to
+// surface name/type problems before emitting SurrealQL.
+func NewField(name string, ft FieldType, opts ...FieldOption) FieldDefinition {
+	fd := FieldDefinition{Name: name, Type: ft}
+	for _, opt := range opts {
+		opt(&fd)
+	}
+	return fd
+}
+
+// Validate checks the field name (alphanumeric / underscore, dot-notation
+// allowed) and that the field type is recognised.
+func (f FieldDefinition) Validate() error {
+	if err := validateFieldName(f.Name); err != nil {
+		return err
+	}
+	if !f.Type.IsValid() {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"invalid field type %q for field %q", string(f.Type), f.Name)
+	}
+	return nil
+}
+
+// ReservedWarning returns a human-readable warning when the field name
+// collides with a SurrealDB reserved word, or an empty string.
+//
+// allowEdgeFields should be true when the field belongs to an edge table
+// (permitting "in" and "out" identifiers).
+func (f FieldDefinition) ReservedWarning(allowEdgeFields bool) string {
+	return types.CheckReservedWord(f.Name, allowEdgeFields)
+}
+
+// ToSurql renders the standalone DEFINE FIELD statement for this field on
+// the given table. It does not validate; call Validate separately.
+func (f FieldDefinition) ToSurql(tableName string) string {
+	return f.toSurql(tableName, false)
+}
+
+// ToSurqlIfNotExists renders the DEFINE FIELD statement with IF NOT EXISTS.
+func (f FieldDefinition) ToSurqlIfNotExists(tableName string) string {
+	return f.toSurql(tableName, true)
+}
+
+func (f FieldDefinition) toSurql(tableName string, ifNotExists bool) string {
+	var b strings.Builder
+	b.WriteString("DEFINE FIELD")
+	if ifNotExists {
+		b.WriteString(" IF NOT EXISTS")
+	}
+	b.WriteString(" ")
+	b.WriteString(f.Name)
+	b.WriteString(" ON TABLE ")
+	b.WriteString(tableName)
+	b.WriteString(" TYPE ")
+	b.WriteString(string(f.Type))
+
+	if f.Assertion != "" {
+		b.WriteString(" ASSERT ")
+		b.WriteString(f.Assertion)
+	}
+	if f.Default != "" {
+		b.WriteString(" DEFAULT ")
+		b.WriteString(f.Default)
+	}
+	if f.Value != "" {
+		b.WriteString(" VALUE ")
+		b.WriteString(f.Value)
+	}
+	if f.ReadOnly {
+		b.WriteString(" READONLY")
+	}
+	if f.Flexible {
+		b.WriteString(" FLEXIBLE")
+	}
+	b.WriteString(";")
+	return b.String()
+}
+
+// validateFieldName mirrors the Python _validate_field_name helper, supporting
+// dot-notation for nested fields.
+func validateFieldName(name string) error {
+	if name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "field name cannot be empty")
+	}
+	for _, part := range strings.Split(name, ".") {
+		if part == "" {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"invalid field name %q: empty segment", name)
+		}
+		if !fieldNamePartRe.MatchString(part) {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"invalid field name %q: segment %q must contain only alphanumeric characters and underscores, and cannot start with a digit",
+				name, part)
+		}
+	}
+	return nil
+}
+
+// Convenience constructors that mirror surql-py helper functions.
+
+// StringField builds a string-typed FieldDefinition.
+func StringField(name string, opts ...FieldOption) FieldDefinition {
+	return NewField(name, FieldTypeString, opts...)
+}
+
+// IntField builds an int-typed FieldDefinition.
+func IntField(name string, opts ...FieldOption) FieldDefinition {
+	return NewField(name, FieldTypeInt, opts...)
+}
+
+// FloatField builds a float-typed FieldDefinition.
+func FloatField(name string, opts ...FieldOption) FieldDefinition {
+	return NewField(name, FieldTypeFloat, opts...)
+}
+
+// BoolField builds a bool-typed FieldDefinition.
+func BoolField(name string, opts ...FieldOption) FieldDefinition {
+	return NewField(name, FieldTypeBool, opts...)
+}
+
+// DatetimeField builds a datetime-typed FieldDefinition.
+func DatetimeField(name string, opts ...FieldOption) FieldDefinition {
+	return NewField(name, FieldTypeDatetime, opts...)
+}
+
+// RecordField builds a record-typed FieldDefinition. When targetTable is
+// non-empty, an assertion constraining $value.table is pre-populated and any
+// user-provided assertion is combined with it.
+func RecordField(name, targetTable string, opts ...FieldOption) FieldDefinition {
+	fd := NewField(name, FieldTypeRecord, opts...)
+	if targetTable == "" {
+		return fd
+	}
+	tableAssert := fmt.Sprintf("$value.table = %q", targetTable)
+	if fd.Assertion == "" {
+		fd.Assertion = tableAssert
+	} else {
+		fd.Assertion = "(" + tableAssert + ") AND (" + fd.Assertion + ")"
+	}
+	return fd
+}
+
+// ArrayField builds an array-typed FieldDefinition.
+func ArrayField(name string, opts ...FieldOption) FieldDefinition {
+	return NewField(name, FieldTypeArray, opts...)
+}
+
+// ObjectField builds an object-typed FieldDefinition, defaulting the
+// FLEXIBLE flag to true (matching the Python helper). Pass WithFlexible(false)
+// to opt out.
+func ObjectField(name string, opts ...FieldOption) FieldDefinition {
+	fd := FieldDefinition{Name: name, Type: FieldTypeObject, Flexible: true}
+	for _, opt := range opts {
+		opt(&fd)
+	}
+	return fd
+}
+
+// ComputedField builds a computed field (VALUE expression, READONLY).
+func ComputedField(name, valueExpr string, ft FieldType, opts ...FieldOption) FieldDefinition {
+	fd := NewField(name, ft, opts...)
+	fd.Value = valueExpr
+	fd.ReadOnly = true
+	return fd
+}

--- a/pkg/surql/schema/fields_test.go
+++ b/pkg/surql/schema/fields_test.go
@@ -1,0 +1,319 @@
+package schema
+
+import (
+	stdErrors "errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestFieldType_IsValid(t *testing.T) {
+	cases := []struct {
+		in   FieldType
+		want bool
+	}{
+		{FieldTypeString, true},
+		{FieldTypeInt, true},
+		{FieldTypeFloat, true},
+		{FieldTypeBool, true},
+		{FieldTypeDatetime, true},
+		{FieldTypeDuration, true},
+		{FieldTypeDecimal, true},
+		{FieldTypeNumber, true},
+		{FieldTypeObject, true},
+		{FieldTypeArray, true},
+		{FieldTypeRecord, true},
+		{FieldTypeGeometry, true},
+		{FieldTypeAny, true},
+		{FieldType("bogus"), false},
+		{FieldType(""), false},
+	}
+	for _, tc := range cases {
+		if got := tc.in.IsValid(); got != tc.want {
+			t.Errorf("FieldType(%q).IsValid() = %v, want %v", string(tc.in), got, tc.want)
+		}
+	}
+}
+
+func TestFieldType_StringValues(t *testing.T) {
+	pairs := map[FieldType]string{
+		FieldTypeString:   "string",
+		FieldTypeInt:      "int",
+		FieldTypeFloat:    "float",
+		FieldTypeBool:     "bool",
+		FieldTypeDatetime: "datetime",
+		FieldTypeDuration: "duration",
+		FieldTypeDecimal:  "decimal",
+		FieldTypeNumber:   "number",
+		FieldTypeObject:   "object",
+		FieldTypeArray:    "array",
+		FieldTypeRecord:   "record",
+		FieldTypeGeometry: "geometry",
+		FieldTypeAny:      "any",
+	}
+	for ft, want := range pairs {
+		if ft.String() != want {
+			t.Errorf("FieldType(%q).String() = %q, want %q", string(ft), ft.String(), want)
+		}
+	}
+}
+
+func TestNewField_Minimal(t *testing.T) {
+	f := NewField("name", FieldTypeString)
+	if f.Name != "name" || f.Type != FieldTypeString {
+		t.Fatalf("unexpected field: %+v", f)
+	}
+	if f.Assertion != "" || f.Default != "" || f.Value != "" || f.ReadOnly || f.Flexible {
+		t.Fatalf("unexpected non-zero defaults: %+v", f)
+	}
+}
+
+func TestNewField_WithAllOptions(t *testing.T) {
+	f := NewField("age", FieldTypeInt,
+		WithAssertion("$value >= 0"),
+		WithDefault("0"),
+		WithReadOnly(true),
+		WithFieldPermissions(map[string]string{"select": "$auth.id = id"}),
+	)
+	if f.Assertion != "$value >= 0" {
+		t.Errorf("assertion = %q", f.Assertion)
+	}
+	if f.Default != "0" {
+		t.Errorf("default = %q", f.Default)
+	}
+	if !f.ReadOnly {
+		t.Errorf("readonly = false")
+	}
+	if v := f.Permissions["select"]; v != "$auth.id = id" {
+		t.Errorf("permissions[select] = %q", v)
+	}
+}
+
+func TestFieldToSurql_Basic(t *testing.T) {
+	f := StringField("name")
+	got := f.ToSurql("user")
+	want := "DEFINE FIELD name ON TABLE user TYPE string;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestFieldToSurql_WithAssertion(t *testing.T) {
+	f := StringField("email", WithAssertion("string::is::email($value)"))
+	got := f.ToSurql("user")
+	want := "DEFINE FIELD email ON TABLE user TYPE string ASSERT string::is::email($value);"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestFieldToSurql_WithDefault(t *testing.T) {
+	f := DatetimeField("created_at", WithDefault("time::now()"))
+	got := f.ToSurql("event")
+	want := "DEFINE FIELD created_at ON TABLE event TYPE datetime DEFAULT time::now();"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestFieldToSurql_WithValue(t *testing.T) {
+	f := ComputedField("full_name", "string::concat(first, ' ', last)", FieldTypeString)
+	got := f.ToSurql("user")
+	if !strings.Contains(got, "VALUE string::concat(first, ' ', last)") {
+		t.Errorf("ToSurql() missing VALUE clause: %q", got)
+	}
+	if !strings.Contains(got, "READONLY") {
+		t.Errorf("computed field should include READONLY: %q", got)
+	}
+}
+
+func TestFieldToSurql_Readonly(t *testing.T) {
+	f := DatetimeField("created_at", WithDefault("time::now()"), WithReadOnly(true))
+	got := f.ToSurql("event")
+	want := "DEFINE FIELD created_at ON TABLE event TYPE datetime DEFAULT time::now() READONLY;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestFieldToSurql_ObjectFlexible(t *testing.T) {
+	f := ObjectField("metadata")
+	if !f.Flexible {
+		t.Fatalf("ObjectField should default flexible=true")
+	}
+	got := f.ToSurql("user")
+	if !strings.Contains(got, "FLEXIBLE") {
+		t.Errorf("ObjectField ToSurql should include FLEXIBLE: %q", got)
+	}
+	if !strings.Contains(got, "TYPE object") {
+		t.Errorf("ObjectField ToSurql should include TYPE object: %q", got)
+	}
+}
+
+func TestFieldToSurql_ObjectFlexibleOptOut(t *testing.T) {
+	f := ObjectField("metadata", WithFlexible(false))
+	if f.Flexible {
+		t.Fatalf("ObjectField(WithFlexible(false)) should disable flexible")
+	}
+	got := f.ToSurql("user")
+	if strings.Contains(got, "FLEXIBLE") {
+		t.Errorf("ToSurql should not include FLEXIBLE: %q", got)
+	}
+}
+
+func TestFieldToSurql_AllClauses(t *testing.T) {
+	f := NewField("status", FieldTypeString,
+		WithAssertion("$value IN ['a','b']"),
+		WithDefault("'a'"),
+		WithReadOnly(true),
+		WithFlexible(true),
+	)
+	got := f.ToSurql("t")
+	want := "DEFINE FIELD status ON TABLE t TYPE string ASSERT $value IN ['a','b'] DEFAULT 'a' READONLY FLEXIBLE;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestFieldToSurqlIfNotExists(t *testing.T) {
+	f := StringField("name")
+	got := f.ToSurqlIfNotExists("user")
+	want := "DEFINE FIELD IF NOT EXISTS name ON TABLE user TYPE string;"
+	if got != want {
+		t.Errorf("ToSurqlIfNotExists() = %q, want %q", got, want)
+	}
+}
+
+func TestFieldValidate_EmptyName(t *testing.T) {
+	f := NewField("", FieldTypeString)
+	err := f.Validate()
+	if err == nil {
+		t.Fatal("Validate() returned nil for empty name")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("err = %v, want ErrValidation chain", err)
+	}
+}
+
+func TestFieldValidate_InvalidType(t *testing.T) {
+	f := NewField("x", FieldType("bogus"))
+	err := f.Validate()
+	if err == nil {
+		t.Fatal("Validate() returned nil for invalid type")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("err = %v, want ErrValidation chain", err)
+	}
+}
+
+func TestFieldValidate_SimpleNameValid(t *testing.T) {
+	for _, name := range []string{"name", "_field", "n1", "foo_bar"} {
+		f := NewField(name, FieldTypeString)
+		if err := f.Validate(); err != nil {
+			t.Errorf("Validate(%q) = %v, want nil", name, err)
+		}
+	}
+}
+
+func TestFieldValidate_DotNotationValid(t *testing.T) {
+	for _, name := range []string{"address.city", "a.b.c", "user_1.email"} {
+		f := NewField(name, FieldTypeString)
+		if err := f.Validate(); err != nil {
+			t.Errorf("Validate(%q) = %v, want nil", name, err)
+		}
+	}
+}
+
+func TestFieldValidate_InvalidNames(t *testing.T) {
+	cases := []string{
+		"1digit",
+		"name-hyphen",
+		"name space",
+		".leading",
+		"trailing.",
+		"empty..segment",
+		"1digit.b",
+	}
+	for _, name := range cases {
+		f := NewField(name, FieldTypeString)
+		err := f.Validate()
+		if err == nil {
+			t.Errorf("Validate(%q) = nil, want error", name)
+			continue
+		}
+		if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+			t.Errorf("Validate(%q) err = %v, want ErrValidation chain", name, err)
+		}
+	}
+}
+
+func TestRecordField_WithTargetTable(t *testing.T) {
+	f := RecordField("author", "user")
+	if f.Type != FieldTypeRecord {
+		t.Fatalf("type = %q", string(f.Type))
+	}
+	if f.Assertion != `$value.table = "user"` {
+		t.Errorf("assertion = %q", f.Assertion)
+	}
+}
+
+func TestRecordField_WithCustomAssertion(t *testing.T) {
+	f := RecordField("author", "user", WithAssertion("$value.active = true"))
+	if !strings.Contains(f.Assertion, `$value.table = "user"`) {
+		t.Errorf("assertion missing table clause: %q", f.Assertion)
+	}
+	if !strings.Contains(f.Assertion, "$value.active = true") {
+		t.Errorf("assertion missing custom clause: %q", f.Assertion)
+	}
+}
+
+func TestRecordField_WithoutTable(t *testing.T) {
+	f := RecordField("author", "")
+	if f.Assertion != "" {
+		t.Errorf("assertion = %q, want empty", f.Assertion)
+	}
+}
+
+func TestReservedWarning(t *testing.T) {
+	f := StringField("in")
+	if f.ReservedWarning(false) == "" {
+		t.Errorf("expected warning for reserved word 'in'")
+	}
+	if f.ReservedWarning(true) != "" {
+		t.Errorf("expected no warning for 'in' with allowEdgeFields=true")
+	}
+}
+
+func TestConvenienceBuilders(t *testing.T) {
+	if StringField("a").Type != FieldTypeString {
+		t.Error("StringField type mismatch")
+	}
+	if IntField("a").Type != FieldTypeInt {
+		t.Error("IntField type mismatch")
+	}
+	if FloatField("a").Type != FieldTypeFloat {
+		t.Error("FloatField type mismatch")
+	}
+	if BoolField("a").Type != FieldTypeBool {
+		t.Error("BoolField type mismatch")
+	}
+	if DatetimeField("a").Type != FieldTypeDatetime {
+		t.Error("DatetimeField type mismatch")
+	}
+	if ArrayField("a").Type != FieldTypeArray {
+		t.Error("ArrayField type mismatch")
+	}
+	if ObjectField("a").Type != FieldTypeObject {
+		t.Error("ObjectField type mismatch")
+	}
+}
+
+func TestFieldPermissions_MapCopyIsolation(t *testing.T) {
+	perms := map[string]string{"select": "$auth.id = id"}
+	f := NewField("x", FieldTypeString, WithFieldPermissions(perms))
+	perms["select"] = "MUTATED"
+	if f.Permissions["select"] != "$auth.id = id" {
+		t.Errorf("permissions should be copied; got %q", f.Permissions["select"])
+	}
+}

--- a/pkg/surql/schema/parser.go
+++ b/pkg/surql/schema/parser.go
@@ -1,0 +1,754 @@
+package schema
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// DatabaseInfo is the parsed shape of an INFO FOR DB response. Tables, Edges,
+// and Accesses are keyed by definition name. Edges are tables whose tb
+// definition includes TYPE RELATION; everything else is a regular table.
+type DatabaseInfo struct {
+	Tables   map[string]TableDefinition
+	Edges    map[string]EdgeDefinition
+	Accesses map[string]AccessDefinition
+}
+
+// ParseDBInfo parses a SurrealDB INFO FOR DB response into a DatabaseInfo.
+//
+// The accepted shape is the object map returned by SurrealDB (e.g. {"tb": {
+// "user": "DEFINE TABLE user SCHEMAFULL;", ... }, "ac": {...}}). Each value in
+// the inner maps is the DEFINE statement string for that object. Unparseable
+// entries are skipped silently, matching the Python behaviour which logs and
+// moves on.
+//
+// The returned DatabaseInfo always has non-nil maps, even when the input is
+// empty.
+func ParseDBInfo(info map[string]any) (DatabaseInfo, error) {
+	if info == nil {
+		return DatabaseInfo{
+			Tables:   map[string]TableDefinition{},
+			Edges:    map[string]EdgeDefinition{},
+			Accesses: map[string]AccessDefinition{},
+		}, nil
+	}
+
+	tables := map[string]TableDefinition{}
+	edges := map[string]EdgeDefinition{}
+	accesses := map[string]AccessDefinition{}
+
+	tbDict := extractStringMap(info, "tables", "tb")
+	for name, def := range tbDict {
+		if name == "" {
+			continue
+		}
+		if isEdgeDefinitionSource(def) {
+			if edge, err := parseEdgeFromDefinition(name, def); err == nil {
+				edges[name] = edge
+			}
+			continue
+		}
+		tables[name] = TableDefinition{
+			Name: name,
+			Mode: parseTableMode(def),
+		}
+	}
+
+	acDict := extractStringMap(info, "accesses", "ac")
+	for name, def := range acDict {
+		if name == "" {
+			continue
+		}
+		access, err := ParseAccess(name, def)
+		if err != nil {
+			continue
+		}
+		accesses[name] = access
+	}
+
+	return DatabaseInfo{
+		Tables:   tables,
+		Edges:    edges,
+		Accesses: accesses,
+	}, nil
+}
+
+// ParseTableInfo parses a SurrealDB INFO FOR TABLE response into a
+// TableDefinition. The tableName identifies the table (the INFO payload itself
+// does not carry it). Unknown or malformed fields/indexes/events are skipped.
+//
+// Returns an error wrapping ErrSchemaParse only for catastrophic failures
+// (currently: an empty name). Individual child parse failures are silent.
+func ParseTableInfo(tableName string, info map[string]any) (TableDefinition, error) {
+	if tableName == "" {
+		return TableDefinition{}, surqlerrors.New(surqlerrors.ErrSchemaParse,
+			"table name cannot be empty")
+	}
+
+	tb := stringAt(info, "tb")
+	mode := parseTableMode(tb)
+
+	fieldsDict := extractStringMap(info, "fields", "fd")
+	fields := parseFields(fieldsDict)
+
+	indexesDict := extractStringMap(info, "indexes", "ix")
+	indexes := parseIndexes(indexesDict)
+
+	eventsDict := extractStringMap(info, "events", "ev")
+	events := parseEvents(eventsDict)
+
+	return TableDefinition{
+		Name:    tableName,
+		Mode:    mode,
+		Fields:  fields,
+		Indexes: indexes,
+		Events:  events,
+	}, nil
+}
+
+// ParseEdgeInfo parses a SurrealDB INFO FOR TABLE response into an
+// EdgeDefinition. The edgeName identifies the edge. The tb definition (when
+// present) is consulted to extract RELATION / FROM / TO clauses.
+func ParseEdgeInfo(edgeName string, info map[string]any) (EdgeDefinition, error) {
+	if edgeName == "" {
+		return EdgeDefinition{}, surqlerrors.New(surqlerrors.ErrSchemaParse,
+			"edge name cannot be empty")
+	}
+
+	tb := stringAt(info, "tb")
+	edge, _ := parseEdgeFromDefinition(edgeName, tb)
+
+	fieldsDict := extractStringMap(info, "fields", "fd")
+	edge.Fields = parseFields(fieldsDict)
+
+	indexesDict := extractStringMap(info, "indexes", "ix")
+	edge.Indexes = parseIndexes(indexesDict)
+
+	eventsDict := extractStringMap(info, "events", "ev")
+	edge.Events = parseEvents(eventsDict)
+
+	return edge, nil
+}
+
+// ParseField parses a single DEFINE FIELD statement into a FieldDefinition.
+// Returns an error wrapping ErrSchemaParse when the definition string is empty.
+func ParseField(fieldName, definition string) (FieldDefinition, error) {
+	if fieldName == "" {
+		return FieldDefinition{}, surqlerrors.New(surqlerrors.ErrSchemaParse,
+			"field name cannot be empty")
+	}
+	if strings.TrimSpace(definition) == "" {
+		return FieldDefinition{}, surqlerrors.Newf(surqlerrors.ErrSchemaParse,
+			"field %q has empty definition", fieldName)
+	}
+	return FieldDefinition{
+		Name:      fieldName,
+		Type:      extractFieldType(definition),
+		Assertion: extractAssertion(definition),
+		Default:   extractDefault(definition),
+		Value:     extractValue(definition),
+		ReadOnly:  extractReadOnly(definition),
+		Flexible:  extractFlexible(definition),
+	}, nil
+}
+
+// ParseIndex parses a single DEFINE INDEX statement into an IndexDefinition.
+// Returns an error wrapping ErrSchemaParse when the definition string is empty.
+func ParseIndex(indexName, definition string) (IndexDefinition, error) {
+	if indexName == "" {
+		return IndexDefinition{}, surqlerrors.New(surqlerrors.ErrSchemaParse,
+			"index name cannot be empty")
+	}
+	if strings.TrimSpace(definition) == "" {
+		return IndexDefinition{}, surqlerrors.Newf(surqlerrors.ErrSchemaParse,
+			"index %q has empty definition", indexName)
+	}
+
+	columns := extractIndexColumns(definition)
+	if len(columns) == 0 {
+		columns = extractIndexFields(definition)
+	}
+
+	indexType := extractIndexType(definition)
+
+	idx := IndexDefinition{
+		Name:    indexName,
+		Columns: columns,
+		Type:    indexType,
+	}
+
+	switch indexType {
+	case IndexTypeMTree:
+		idx.Dimension = extractMtreeDimension(definition)
+		idx.Distance = extractMtreeDistance(definition)
+		idx.VectorType = extractVectorType(definition)
+	case IndexTypeHNSW:
+		idx.Dimension = extractMtreeDimension(definition)
+		idx.VectorType = extractVectorType(definition)
+		idx.HnswDistance = extractHnswDistance(definition)
+		idx.EFC = extractHnswEFC(definition)
+		idx.M = extractHnswM(definition)
+	}
+
+	return idx, nil
+}
+
+// ParseEvent parses a single DEFINE EVENT statement into an EventDefinition.
+// Returns an error wrapping ErrSchemaParse when the definition is empty or
+// when neither a WHEN clause nor a THEN clause can be located.
+func ParseEvent(eventName, definition string) (EventDefinition, error) {
+	if eventName == "" {
+		return EventDefinition{}, surqlerrors.New(surqlerrors.ErrSchemaParse,
+			"event name cannot be empty")
+	}
+	if strings.TrimSpace(definition) == "" {
+		return EventDefinition{}, surqlerrors.Newf(surqlerrors.ErrSchemaParse,
+			"event %q has empty definition", eventName)
+	}
+
+	condition := extractEventCondition(definition)
+	action := extractEventAction(definition)
+	if condition == "" || action == "" {
+		return EventDefinition{}, surqlerrors.Newf(surqlerrors.ErrSchemaParse,
+			"event %q missing WHEN or THEN clause", eventName)
+	}
+
+	return EventDefinition{
+		Name:      eventName,
+		Condition: condition,
+		Action:    action,
+	}, nil
+}
+
+// ParseAccess parses a single DEFINE ACCESS statement into an AccessDefinition.
+// Returns an error wrapping ErrSchemaParse when the definition is empty or
+// when the access type cannot be determined.
+func ParseAccess(accessName, definition string) (AccessDefinition, error) {
+	if accessName == "" {
+		return AccessDefinition{}, surqlerrors.New(surqlerrors.ErrSchemaParse,
+			"access name cannot be empty")
+	}
+	if strings.TrimSpace(definition) == "" {
+		return AccessDefinition{}, surqlerrors.Newf(surqlerrors.ErrSchemaParse,
+			"access %q has empty definition", accessName)
+	}
+
+	accessType := extractAccessType(definition)
+	if !accessType.IsValid() {
+		return AccessDefinition{}, surqlerrors.Newf(surqlerrors.ErrSchemaParse,
+			"access %q has unknown type", accessName)
+	}
+
+	ad := AccessDefinition{
+		Name:            accessName,
+		Type:            accessType,
+		DurationSession: extractAccessDuration(definition, "SESSION"),
+		DurationToken:   extractAccessDuration(definition, "TOKEN"),
+	}
+
+	switch accessType {
+	case AccessTypeJWT:
+		ad.JWT = &JwtConfig{
+			Algorithm: extractJwtAlgorithm(definition),
+			Key:       extractQuoted(definition, "KEY"),
+			URL:       extractQuoted(definition, "URL"),
+			Issuer:    extractJwtIssuer(definition),
+		}
+	case AccessTypeRecord:
+		ad.Record = &RecordAccessConfig{
+			Signup: extractParenClause(definition, "SIGNUP"),
+			Signin: extractParenClause(definition, "SIGNIN"),
+		}
+	}
+
+	return ad, nil
+}
+
+// -----------------------------------------------------------------------------
+// Internal helpers
+// -----------------------------------------------------------------------------
+
+func stringAt(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// extractStringMap returns the first map[string]string-shaped value found
+// under any of keys. The underlying value may be map[string]any or
+// map[string]string; each entry that is not a string is dropped.
+func extractStringMap(info map[string]any, keys ...string) map[string]string {
+	if info == nil {
+		return nil
+	}
+	for _, k := range keys {
+		raw, ok := info[k]
+		if !ok {
+			continue
+		}
+		switch typed := raw.(type) {
+		case map[string]string:
+			if len(typed) == 0 {
+				continue
+			}
+			out := make(map[string]string, len(typed))
+			for k2, v2 := range typed {
+				out[k2] = v2
+			}
+			return out
+		case map[string]any:
+			if len(typed) == 0 {
+				continue
+			}
+			out := make(map[string]string, len(typed))
+			for k2, v2 := range typed {
+				if s, ok := v2.(string); ok {
+					out[k2] = s
+				}
+			}
+			if len(out) > 0 {
+				return out
+			}
+		}
+	}
+	return nil
+}
+
+// parseTableMode recovers the TableMode from a DEFINE TABLE statement. The
+// default (matching surql-py) is SCHEMALESS.
+func parseTableMode(def string) TableMode {
+	if def == "" {
+		return TableModeSchemaless
+	}
+	up := strings.ToUpper(def)
+	switch {
+	case strings.Contains(up, "SCHEMAFULL"):
+		return TableModeSchemafull
+	case strings.Contains(up, "SCHEMALESS"):
+		return TableModeSchemaless
+	case strings.Contains(up, "DROP"):
+		return TableModeDrop
+	default:
+		return TableModeSchemaless
+	}
+}
+
+var reRelationFrom = regexp.MustCompile(`(?i)FROM\s+([A-Za-z_][A-Za-z0-9_]*)`)
+var reRelationTo = regexp.MustCompile(`(?i)\bTO\s+([A-Za-z_][A-Za-z0-9_]*)`)
+
+func isEdgeDefinitionSource(def string) bool {
+	return strings.Contains(strings.ToUpper(def), "TYPE RELATION")
+}
+
+func parseEdgeFromDefinition(name, def string) (EdgeDefinition, error) {
+	edge := EdgeDefinition{Name: name, Mode: EdgeModeRelation}
+	up := strings.ToUpper(def)
+
+	switch {
+	case strings.Contains(up, "TYPE RELATION"):
+		edge.Mode = EdgeModeRelation
+		if m := reRelationFrom.FindStringSubmatch(def); len(m) == 2 {
+			edge.FromTable = m[1]
+		}
+		if m := reRelationTo.FindStringSubmatch(def); len(m) == 2 {
+			edge.ToTable = m[1]
+		}
+	case strings.Contains(up, "SCHEMAFULL"):
+		edge.Mode = EdgeModeSchemafull
+	case strings.Contains(up, "SCHEMALESS"):
+		edge.Mode = EdgeModeSchemaless
+	}
+
+	return edge, nil
+}
+
+func parseFields(dict map[string]string) []FieldDefinition {
+	if len(dict) == 0 {
+		return nil
+	}
+	out := make([]FieldDefinition, 0, len(dict))
+	for name, def := range dict {
+		fd, err := ParseField(name, def)
+		if err != nil {
+			continue
+		}
+		out = append(out, fd)
+	}
+	return out
+}
+
+func parseIndexes(dict map[string]string) []IndexDefinition {
+	if len(dict) == 0 {
+		return nil
+	}
+	out := make([]IndexDefinition, 0, len(dict))
+	for name, def := range dict {
+		idx, err := ParseIndex(name, def)
+		if err != nil {
+			continue
+		}
+		out = append(out, idx)
+	}
+	return out
+}
+
+func parseEvents(dict map[string]string) []EventDefinition {
+	if len(dict) == 0 {
+		return nil
+	}
+	out := make([]EventDefinition, 0, len(dict))
+	for name, def := range dict {
+		ev, err := ParseEvent(name, def)
+		if err != nil {
+			continue
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+// -----------------------------------------------------------------------------
+// Field extraction helpers
+// -----------------------------------------------------------------------------
+
+var (
+	reFieldType      = regexp.MustCompile(`(?i)TYPE\s+([A-Za-z_]\w*)`)
+	reFieldAssert    = regexp.MustCompile(`(?is)ASSERT\s+(.+?)(?:\s+DEFAULT\b|\s+VALUE\b|\s+READONLY\b|\s+FLEXIBLE\b|\s+PERMISSIONS\b|\s*;|\s*$)`)
+	reFieldDefault   = regexp.MustCompile(`(?is)DEFAULT\s+(.+?)(?:\s+VALUE\b|\s+READONLY\b|\s+FLEXIBLE\b|\s+PERMISSIONS\b|\s+ASSERT\b|\s*;|\s*$)`)
+	reFieldValueExpr = regexp.MustCompile(`(?is)\bVALUE\s+(.+?)(?:\s+DEFAULT\b|\s+READONLY\b|\s+FLEXIBLE\b|\s+PERMISSIONS\b|\s+ASSERT\b|\s*;|\s*$)`)
+	reFieldReadOnly  = regexp.MustCompile(`(?i)\bREADONLY\b`)
+	reFieldFlexible  = regexp.MustCompile(`(?i)\bFLEXIBLE\b`)
+)
+
+var fieldTypeMap = map[string]FieldType{
+	"string":   FieldTypeString,
+	"int":      FieldTypeInt,
+	"float":    FieldTypeFloat,
+	"bool":     FieldTypeBool,
+	"datetime": FieldTypeDatetime,
+	"duration": FieldTypeDuration,
+	"decimal":  FieldTypeDecimal,
+	"number":   FieldTypeNumber,
+	"object":   FieldTypeObject,
+	"array":    FieldTypeArray,
+	"record":   FieldTypeRecord,
+	"geometry": FieldTypeGeometry,
+	"any":      FieldTypeAny,
+}
+
+func extractFieldType(def string) FieldType {
+	m := reFieldType.FindStringSubmatch(def)
+	if len(m) != 2 {
+		return FieldTypeAny
+	}
+	if ft, ok := fieldTypeMap[strings.ToLower(m[1])]; ok {
+		return ft
+	}
+	return FieldTypeAny
+}
+
+func extractAssertion(def string) string {
+	if m := reFieldAssert.FindStringSubmatch(def); len(m) == 2 {
+		return strings.TrimSpace(strings.TrimSuffix(m[1], ";"))
+	}
+	return ""
+}
+
+func extractDefault(def string) string {
+	if m := reFieldDefault.FindStringSubmatch(def); len(m) == 2 {
+		return strings.TrimSpace(strings.TrimSuffix(m[1], ";"))
+	}
+	return ""
+}
+
+func extractValue(def string) string {
+	if m := reFieldValueExpr.FindStringSubmatch(def); len(m) == 2 {
+		return strings.TrimSpace(strings.TrimSuffix(m[1], ";"))
+	}
+	return ""
+}
+
+func extractReadOnly(def string) bool {
+	return reFieldReadOnly.MatchString(def)
+}
+
+func extractFlexible(def string) bool {
+	return reFieldFlexible.MatchString(def)
+}
+
+// -----------------------------------------------------------------------------
+// Index extraction helpers
+// -----------------------------------------------------------------------------
+
+var (
+	reIndexColumns = regexp.MustCompile(`(?i)COLUMNS\s+([^;]+?)(?:\s+UNIQUE\b|\s+SEARCH\b|\s+HNSW\b|\s+MTREE\b|\s*;|\s*$)`)
+	reIndexFields  = regexp.MustCompile(`(?i)FIELDS\s+([^;]+?)(?:\s+UNIQUE\b|\s+SEARCH\b|\s+HNSW\b|\s+MTREE\b|\s*;|\s*$)`)
+	reIndexDim     = regexp.MustCompile(`(?i)DIMENSION\s+(\d+)`)
+	reIndexDist    = regexp.MustCompile(`(?i)(?:DIST|DISTANCE)\s+([A-Za-z_]\w*)`)
+	reVectorType   = regexp.MustCompile(`(?i)TYPE\s+([A-Za-z_]\w*)`)
+	reIndexEFC     = regexp.MustCompile(`(?i)\bEFC\s+(\d+)`)
+	reIndexM       = regexp.MustCompile(`(?i)\bM\s+(\d+)`)
+)
+
+func splitColumns(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func extractIndexColumns(def string) []string {
+	if m := reIndexColumns.FindStringSubmatch(def); len(m) == 2 {
+		return splitColumns(m[1])
+	}
+	return nil
+}
+
+func extractIndexFields(def string) []string {
+	if m := reIndexFields.FindStringSubmatch(def); len(m) == 2 {
+		return splitColumns(m[1])
+	}
+	return nil
+}
+
+func extractIndexType(def string) IndexType {
+	up := strings.ToUpper(def)
+	switch {
+	case strings.Contains(up, "UNIQUE"):
+		return IndexTypeUnique
+	case strings.Contains(up, "HNSW"):
+		return IndexTypeHNSW
+	case strings.Contains(up, "MTREE"):
+		return IndexTypeMTree
+	case strings.Contains(up, "SEARCH"):
+		return IndexTypeSearch
+	default:
+		return IndexTypeStandard
+	}
+}
+
+func extractMtreeDimension(def string) int {
+	if m := reIndexDim.FindStringSubmatch(def); len(m) == 2 {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+var mtreeDistanceMap = map[string]MTreeDistanceType{
+	"COSINE":    MTreeDistanceCosine,
+	"EUCLIDEAN": MTreeDistanceEuclidean,
+	"MANHATTAN": MTreeDistanceManhattan,
+	"MINKOWSKI": MTreeDistanceMinkowski,
+}
+
+func extractMtreeDistance(def string) MTreeDistanceType {
+	if m := reIndexDist.FindStringSubmatch(def); len(m) == 2 {
+		if d, ok := mtreeDistanceMap[strings.ToUpper(m[1])]; ok {
+			return d
+		}
+	}
+	return ""
+}
+
+var hnswDistanceMap = map[string]HnswDistanceType{
+	"CHEBYSHEV": HnswDistanceChebyshev,
+	"COSINE":    HnswDistanceCosine,
+	"EUCLIDEAN": HnswDistanceEuclidean,
+	"HAMMING":   HnswDistanceHamming,
+	"JACCARD":   HnswDistanceJaccard,
+	"MANHATTAN": HnswDistanceManhattan,
+	"MINKOWSKI": HnswDistanceMinkowski,
+	"PEARSON":   HnswDistancePearson,
+}
+
+func extractHnswDistance(def string) HnswDistanceType {
+	if m := reIndexDist.FindStringSubmatch(def); len(m) == 2 {
+		if d, ok := hnswDistanceMap[strings.ToUpper(m[1])]; ok {
+			return d
+		}
+	}
+	return ""
+}
+
+var vectorTypeMap = map[string]MTreeVectorType{
+	"F64": MTreeVectorF64,
+	"F32": MTreeVectorF32,
+	"I64": MTreeVectorI64,
+	"I32": MTreeVectorI32,
+	"I16": MTreeVectorI16,
+}
+
+func extractVectorType(def string) MTreeVectorType {
+	if m := reVectorType.FindStringSubmatch(def); len(m) == 2 {
+		if v, ok := vectorTypeMap[strings.ToUpper(m[1])]; ok {
+			return v
+		}
+	}
+	return ""
+}
+
+func extractHnswEFC(def string) int {
+	if m := reIndexEFC.FindStringSubmatch(def); len(m) == 2 {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+func extractHnswM(def string) int {
+	if m := reIndexM.FindStringSubmatch(def); len(m) == 2 {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+// -----------------------------------------------------------------------------
+// Event extraction helpers
+// -----------------------------------------------------------------------------
+
+var (
+	reEventWhen = regexp.MustCompile(`(?is)WHEN\s+(.+?)\s+THEN\b`)
+	reEventThen = regexp.MustCompile(`(?is)THEN\s+(?:\{\s*(.+?)\s*\}|(.+?))(?:\s*;|\s*$)`)
+)
+
+func extractEventCondition(def string) string {
+	if m := reEventWhen.FindStringSubmatch(def); len(m) == 2 {
+		return strings.TrimSpace(m[1])
+	}
+	return ""
+}
+
+func extractEventAction(def string) string {
+	m := reEventThen.FindStringSubmatch(def)
+	if len(m) < 3 {
+		return ""
+	}
+	action := m[1]
+	if action == "" {
+		action = m[2]
+	}
+	return strings.TrimSpace(action)
+}
+
+// -----------------------------------------------------------------------------
+// Access extraction helpers
+// -----------------------------------------------------------------------------
+
+var (
+	reAccessType    = regexp.MustCompile(`(?i)TYPE\s+(JWT|RECORD)\b`)
+	reJwtAlgorithm  = regexp.MustCompile(`(?i)ALGORITHM\s+([A-Za-z0-9]+)`)
+	reJwtIssuer     = regexp.MustCompile(`(?i)WITH\s+ISSUER\s+'([^']*)'`)
+	reDurationBlock = regexp.MustCompile(`(?is)DURATION\s+(.+?)(?:\s*;|\s*$)`)
+	rePerSession    = regexp.MustCompile(`(?i)FOR\s+SESSION\s+([^,;]+?)(?:\s*,|\s*$)`)
+	rePerToken      = regexp.MustCompile(`(?i)FOR\s+TOKEN\s+([^,;]+?)(?:\s*,|\s*$)`)
+)
+
+func extractAccessType(def string) AccessType {
+	if m := reAccessType.FindStringSubmatch(def); len(m) == 2 {
+		switch strings.ToUpper(m[1]) {
+		case "JWT":
+			return AccessTypeJWT
+		case "RECORD":
+			return AccessTypeRecord
+		}
+	}
+	return ""
+}
+
+func extractJwtAlgorithm(def string) string {
+	if m := reJwtAlgorithm.FindStringSubmatch(def); len(m) == 2 {
+		return strings.ToUpper(m[1])
+	}
+	return ""
+}
+
+func extractJwtIssuer(def string) string {
+	if m := reJwtIssuer.FindStringSubmatch(def); len(m) == 2 {
+		return m[1]
+	}
+	return ""
+}
+
+// extractQuoted pulls KEYWORD 'value' out of a DEFINE ACCESS body.
+func extractQuoted(def, keyword string) string {
+	re := regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(keyword) + `\s+'([^']*)'`)
+	if m := re.FindStringSubmatch(def); len(m) == 2 {
+		return m[1]
+	}
+	return ""
+}
+
+// extractParenClause pulls KEYWORD (expression) out of a DEFINE ACCESS body
+// handling nested parentheses.
+func extractParenClause(def, keyword string) string {
+	up := strings.ToUpper(def)
+	kw := strings.ToUpper(keyword)
+	idx := strings.Index(up, kw)
+	if idx < 0 {
+		return ""
+	}
+	rest := def[idx+len(kw):]
+	// skip whitespace
+	i := 0
+	for i < len(rest) && (rest[i] == ' ' || rest[i] == '\t' || rest[i] == '\n' || rest[i] == '\r') {
+		i++
+	}
+	if i >= len(rest) || rest[i] != '(' {
+		return ""
+	}
+	depth := 0
+	start := i + 1
+	for j := i; j < len(rest); j++ {
+		switch rest[j] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return strings.TrimSpace(rest[start:j])
+			}
+		}
+	}
+	return ""
+}
+
+func extractAccessDuration(def, clause string) string {
+	block := reDurationBlock.FindStringSubmatch(def)
+	if len(block) != 2 {
+		return ""
+	}
+	body := block[1]
+	var re *regexp.Regexp
+	switch strings.ToUpper(clause) {
+	case "SESSION":
+		re = rePerSession
+	case "TOKEN":
+		re = rePerToken
+	default:
+		return ""
+	}
+	// Append trailing comma so the regex's "," terminator matches a lone clause.
+	if m := re.FindStringSubmatch(body + ","); len(m) == 2 {
+		return strings.TrimSpace(m[1])
+	}
+	return ""
+}

--- a/pkg/surql/schema/parser_test.go
+++ b/pkg/surql/schema/parser_test.go
@@ -1,0 +1,852 @@
+package schema
+
+import (
+	stdErrors "errors"
+	"reflect"
+	"sort"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// ---------------------------------------------------------------------------
+// parseTableMode / ParseTableInfo
+// ---------------------------------------------------------------------------
+
+func TestParseTableMode_Schemafull(t *testing.T) {
+	if got := parseTableMode("DEFINE TABLE user SCHEMAFULL;"); got != TableModeSchemafull {
+		t.Errorf("parseTableMode(SCHEMAFULL) = %q, want %q", got, TableModeSchemafull)
+	}
+}
+
+func TestParseTableMode_Schemaless(t *testing.T) {
+	if got := parseTableMode("DEFINE TABLE user SCHEMALESS;"); got != TableModeSchemaless {
+		t.Errorf("parseTableMode(SCHEMALESS) = %q, want %q", got, TableModeSchemaless)
+	}
+}
+
+func TestParseTableMode_Drop(t *testing.T) {
+	if got := parseTableMode("DEFINE TABLE tmp DROP;"); got != TableModeDrop {
+		t.Errorf("parseTableMode(DROP) = %q, want %q", got, TableModeDrop)
+	}
+}
+
+func TestParseTableMode_EmptyDefaultsSchemaless(t *testing.T) {
+	if got := parseTableMode(""); got != TableModeSchemaless {
+		t.Errorf("parseTableMode(\"\") = %q, want %q", got, TableModeSchemaless)
+	}
+}
+
+func TestParseTableInfo_EmptyName(t *testing.T) {
+	_, err := ParseTableInfo("", nil)
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrSchemaParse) {
+		t.Errorf("expected ErrSchemaParse, got %v", err)
+	}
+}
+
+func TestParseTableInfo_MinimalSchemafull(t *testing.T) {
+	info := map[string]any{
+		"tb": "DEFINE TABLE user SCHEMAFULL;",
+	}
+	got, err := ParseTableInfo("user", info)
+	if err != nil {
+		t.Fatalf("ParseTableInfo: %v", err)
+	}
+	if got.Name != "user" {
+		t.Errorf("Name = %q, want user", got.Name)
+	}
+	if got.Mode != TableModeSchemafull {
+		t.Errorf("Mode = %q, want SCHEMAFULL", got.Mode)
+	}
+	if len(got.Fields) != 0 || len(got.Indexes) != 0 || len(got.Events) != 0 {
+		t.Errorf("expected empty children, got %+v", got)
+	}
+}
+
+func TestParseTableInfo_FullRoundTrip(t *testing.T) {
+	table := TableDefinition{
+		Name: "user",
+		Mode: TableModeSchemafull,
+		Fields: []FieldDefinition{
+			StringField("email", WithAssertion("string::is::email($value)")),
+			IntField("age", WithDefault("0")),
+			BoolField("admin", WithReadOnly(true)),
+		},
+		Indexes: []IndexDefinition{
+			UniqueIndex("email_idx", []string{"email"}),
+		},
+		Events: []EventDefinition{
+			NewEvent("on_create", "$event = 'CREATE'", "(CREATE log SET t = time::now())"),
+		},
+	}
+
+	// Build synthetic INFO response.
+	fd := map[string]any{}
+	for _, f := range table.Fields {
+		fd[f.Name] = f.ToSurql(table.Name)
+	}
+	ix := map[string]any{}
+	for _, i := range table.Indexes {
+		ix[i.Name] = i.ToSurql(table.Name)
+	}
+	ev := map[string]any{}
+	for _, e := range table.Events {
+		ev[e.Name] = e.ToSurql(table.Name)
+	}
+
+	info := map[string]any{
+		"tb":      table.ToSurql(),
+		"fields":  fd,
+		"indexes": ix,
+		"events":  ev,
+	}
+
+	parsed, err := ParseTableInfo("user", info)
+	if err != nil {
+		t.Fatalf("ParseTableInfo: %v", err)
+	}
+	if parsed.Mode != table.Mode {
+		t.Errorf("Mode = %q, want %q", parsed.Mode, table.Mode)
+	}
+	if len(parsed.Fields) != len(table.Fields) {
+		t.Errorf("expected %d fields, got %d", len(table.Fields), len(parsed.Fields))
+	}
+	if len(parsed.Indexes) != len(table.Indexes) {
+		t.Errorf("expected %d indexes, got %d", len(table.Indexes), len(parsed.Indexes))
+	}
+	if len(parsed.Events) != len(table.Events) {
+		t.Errorf("expected %d events, got %d", len(table.Events), len(parsed.Events))
+	}
+}
+
+func TestParseTableInfo_AliasKeys(t *testing.T) {
+	info := map[string]any{
+		"tb": "DEFINE TABLE user SCHEMAFULL;",
+		"fd": map[string]any{
+			"email": "DEFINE FIELD email ON TABLE user TYPE string;",
+		},
+		"ix": map[string]any{
+			"email_idx": "DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE;",
+		},
+		"ev": map[string]any{
+			"on_x": "DEFINE EVENT on_x ON TABLE user WHEN $event = 'CREATE' THEN (SELECT 1);",
+		},
+	}
+	got, err := ParseTableInfo("user", info)
+	if err != nil {
+		t.Fatalf("ParseTableInfo: %v", err)
+	}
+	if len(got.Fields) != 1 || got.Fields[0].Name != "email" {
+		t.Errorf("fields = %+v", got.Fields)
+	}
+	if len(got.Indexes) != 1 || got.Indexes[0].Name != "email_idx" {
+		t.Errorf("indexes = %+v", got.Indexes)
+	}
+	if len(got.Events) != 1 || got.Events[0].Name != "on_x" {
+		t.Errorf("events = %+v", got.Events)
+	}
+}
+
+func TestParseTableInfo_MapStringStringAccepted(t *testing.T) {
+	info := map[string]any{
+		"tb": "DEFINE TABLE user SCHEMAFULL;",
+		"fields": map[string]string{
+			"email": "DEFINE FIELD email ON TABLE user TYPE string;",
+		},
+	}
+	got, err := ParseTableInfo("user", info)
+	if err != nil {
+		t.Fatalf("ParseTableInfo: %v", err)
+	}
+	if len(got.Fields) != 1 {
+		t.Errorf("expected 1 field, got %d", len(got.Fields))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseField
+// ---------------------------------------------------------------------------
+
+func TestParseField_String(t *testing.T) {
+	fd, err := ParseField("email", "DEFINE FIELD email ON TABLE user TYPE string;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fd.Type != FieldTypeString {
+		t.Errorf("Type = %q, want string", fd.Type)
+	}
+}
+
+func TestParseField_AllTypes(t *testing.T) {
+	cases := map[string]FieldType{
+		"string":   FieldTypeString,
+		"int":      FieldTypeInt,
+		"float":    FieldTypeFloat,
+		"bool":     FieldTypeBool,
+		"datetime": FieldTypeDatetime,
+		"duration": FieldTypeDuration,
+		"decimal":  FieldTypeDecimal,
+		"number":   FieldTypeNumber,
+		"object":   FieldTypeObject,
+		"array":    FieldTypeArray,
+		"record":   FieldTypeRecord,
+		"geometry": FieldTypeGeometry,
+		"any":      FieldTypeAny,
+	}
+	for typeStr, want := range cases {
+		def := "DEFINE FIELD x ON TABLE user TYPE " + typeStr + ";"
+		fd, err := ParseField("x", def)
+		if err != nil {
+			t.Fatalf("ParseField(%s): %v", typeStr, err)
+		}
+		if fd.Type != want {
+			t.Errorf("Type for %q = %q, want %q", typeStr, fd.Type, want)
+		}
+	}
+}
+
+func TestParseField_UnknownTypeFallsBackToAny(t *testing.T) {
+	fd, err := ParseField("x", "DEFINE FIELD x ON TABLE user TYPE weirdthing;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fd.Type != FieldTypeAny {
+		t.Errorf("Type = %q, want any", fd.Type)
+	}
+}
+
+func TestParseField_WithAssertion(t *testing.T) {
+	fd, err := ParseField("email",
+		"DEFINE FIELD email ON TABLE user TYPE string ASSERT string::is::email($value);")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fd.Assertion != "string::is::email($value)" {
+		t.Errorf("Assertion = %q", fd.Assertion)
+	}
+}
+
+func TestParseField_WithDefault(t *testing.T) {
+	fd, err := ParseField("age",
+		"DEFINE FIELD age ON TABLE user TYPE int DEFAULT 18;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fd.Default != "18" {
+		t.Errorf("Default = %q, want 18", fd.Default)
+	}
+}
+
+func TestParseField_WithValue(t *testing.T) {
+	fd, err := ParseField("full",
+		"DEFINE FIELD full ON TABLE user TYPE string VALUE string::concat(first, last);")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fd.Value != "string::concat(first, last)" {
+		t.Errorf("Value = %q", fd.Value)
+	}
+}
+
+func TestParseField_ReadOnlyFlag(t *testing.T) {
+	fd, err := ParseField("id",
+		"DEFINE FIELD id ON TABLE user TYPE string READONLY;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fd.ReadOnly {
+		t.Error("ReadOnly should be true")
+	}
+}
+
+func TestParseField_FlexibleFlag(t *testing.T) {
+	fd, err := ParseField("meta",
+		"DEFINE FIELD meta ON TABLE user TYPE object FLEXIBLE;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fd.Flexible {
+		t.Error("Flexible should be true")
+	}
+}
+
+func TestParseField_EmptyDefinitionErrors(t *testing.T) {
+	_, err := ParseField("x", "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrSchemaParse) {
+		t.Errorf("expected ErrSchemaParse, got %v", err)
+	}
+}
+
+func TestParseField_EmptyNameErrors(t *testing.T) {
+	_, err := ParseField("", "DEFINE FIELD x ON TABLE user TYPE string;")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseField_RoundTrip(t *testing.T) {
+	orig := NewField("email", FieldTypeString,
+		WithAssertion("$value != NONE"),
+		WithDefault("'a@b.com'"),
+	)
+	def := orig.ToSurql("user")
+	parsed, err := ParseField("email", def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Type != orig.Type {
+		t.Errorf("Type: got %q, want %q", parsed.Type, orig.Type)
+	}
+	if parsed.Assertion != orig.Assertion {
+		t.Errorf("Assertion: got %q, want %q", parsed.Assertion, orig.Assertion)
+	}
+	if parsed.Default != orig.Default {
+		t.Errorf("Default: got %q, want %q", parsed.Default, orig.Default)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseIndex
+// ---------------------------------------------------------------------------
+
+func TestParseIndex_Standard(t *testing.T) {
+	idx, err := ParseIndex("ix1",
+		"DEFINE INDEX ix1 ON TABLE user COLUMNS email;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx.Type != IndexTypeStandard {
+		t.Errorf("Type = %q, want INDEX", idx.Type)
+	}
+	if !reflect.DeepEqual(idx.Columns, []string{"email"}) {
+		t.Errorf("Columns = %v", idx.Columns)
+	}
+}
+
+func TestParseIndex_Unique(t *testing.T) {
+	idx, err := ParseIndex("email_idx",
+		"DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx.Type != IndexTypeUnique {
+		t.Errorf("Type = %q, want UNIQUE", idx.Type)
+	}
+}
+
+func TestParseIndex_MultipleColumns(t *testing.T) {
+	idx, err := ParseIndex("composite",
+		"DEFINE INDEX composite ON TABLE user COLUMNS a, b, c UNIQUE;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"a", "b", "c"}
+	if !reflect.DeepEqual(idx.Columns, want) {
+		t.Errorf("Columns = %v, want %v", idx.Columns, want)
+	}
+}
+
+func TestParseIndex_FieldsAlias(t *testing.T) {
+	idx, err := ParseIndex("ix",
+		"DEFINE INDEX ix ON TABLE user FIELDS a, b;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(idx.Columns, []string{"a", "b"}) {
+		t.Errorf("Columns = %v", idx.Columns)
+	}
+}
+
+func TestParseIndex_MTree(t *testing.T) {
+	idx, err := ParseIndex("emb_idx",
+		"DEFINE INDEX emb_idx ON TABLE doc COLUMNS embedding MTREE DIMENSION 128 DIST COSINE TYPE F32;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx.Type != IndexTypeMTree {
+		t.Errorf("Type = %q, want MTREE", idx.Type)
+	}
+	if idx.Dimension != 128 {
+		t.Errorf("Dimension = %d", idx.Dimension)
+	}
+	if idx.Distance != MTreeDistanceCosine {
+		t.Errorf("Distance = %q", idx.Distance)
+	}
+	if idx.VectorType != MTreeVectorF32 {
+		t.Errorf("VectorType = %q", idx.VectorType)
+	}
+}
+
+func TestParseIndex_HNSW(t *testing.T) {
+	idx, err := ParseIndex("hnsw_idx",
+		"DEFINE INDEX hnsw_idx ON TABLE doc COLUMNS embedding HNSW DIMENSION 256 DIST EUCLIDEAN TYPE F64 EFC 200 M 16;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx.Type != IndexTypeHNSW {
+		t.Errorf("Type = %q, want HNSW", idx.Type)
+	}
+	if idx.Dimension != 256 {
+		t.Errorf("Dimension = %d", idx.Dimension)
+	}
+	if idx.HnswDistance != HnswDistanceEuclidean {
+		t.Errorf("HnswDistance = %q", idx.HnswDistance)
+	}
+	if idx.VectorType != MTreeVectorF64 {
+		t.Errorf("VectorType = %q", idx.VectorType)
+	}
+	if idx.EFC != 200 {
+		t.Errorf("EFC = %d", idx.EFC)
+	}
+	if idx.M != 16 {
+		t.Errorf("M = %d", idx.M)
+	}
+}
+
+func TestParseIndex_HNSWChebyshev(t *testing.T) {
+	idx, err := ParseIndex("h",
+		"DEFINE INDEX h ON TABLE x COLUMNS v HNSW DIMENSION 4 DIST CHEBYSHEV;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx.HnswDistance != HnswDistanceChebyshev {
+		t.Errorf("got %q", idx.HnswDistance)
+	}
+}
+
+func TestParseIndex_EmptyDefinition(t *testing.T) {
+	_, err := ParseIndex("x", "   ")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrSchemaParse) {
+		t.Errorf("expected ErrSchemaParse")
+	}
+}
+
+func TestParseIndex_RoundTripUnique(t *testing.T) {
+	orig := UniqueIndex("email_idx", []string{"email"})
+	parsed, err := ParseIndex(orig.Name, orig.ToSurql("user"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Type != orig.Type {
+		t.Errorf("Type: got %q, want %q", parsed.Type, orig.Type)
+	}
+	if !reflect.DeepEqual(parsed.Columns, orig.Columns) {
+		t.Errorf("Columns: got %v, want %v", parsed.Columns, orig.Columns)
+	}
+}
+
+func TestParseIndex_RoundTripMTree(t *testing.T) {
+	orig := MTreeIndex("emb_idx", "embedding", 64, MTreeIndexOptions{
+		Distance:   MTreeDistanceEuclidean,
+		VectorType: MTreeVectorF32,
+	})
+	parsed, err := ParseIndex(orig.Name, orig.ToSurql("doc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Type != IndexTypeMTree {
+		t.Errorf("Type = %q", parsed.Type)
+	}
+	if parsed.Dimension != 64 {
+		t.Errorf("Dimension = %d", parsed.Dimension)
+	}
+	if parsed.Distance != MTreeDistanceEuclidean {
+		t.Errorf("Distance = %q", parsed.Distance)
+	}
+	if parsed.VectorType != MTreeVectorF32 {
+		t.Errorf("VectorType = %q", parsed.VectorType)
+	}
+}
+
+func TestParseIndex_RoundTripHnsw(t *testing.T) {
+	orig := HnswIndex("h", "v", 128, HnswIndexOptions{
+		Distance:   HnswDistanceCosine,
+		VectorType: MTreeVectorF32,
+		EFC:        150,
+		M:          12,
+	})
+	parsed, err := ParseIndex(orig.Name, orig.ToSurql("doc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.HnswDistance != HnswDistanceCosine {
+		t.Errorf("HnswDistance = %q", parsed.HnswDistance)
+	}
+	if parsed.EFC != 150 || parsed.M != 12 {
+		t.Errorf("EFC=%d M=%d", parsed.EFC, parsed.M)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseEvent
+// ---------------------------------------------------------------------------
+
+func TestParseEvent_Simple(t *testing.T) {
+	ev, err := ParseEvent("on_create",
+		"DEFINE EVENT on_create ON TABLE user WHEN $event = 'CREATE' THEN (SELECT 1);")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.Condition != "$event = 'CREATE'" {
+		t.Errorf("Condition = %q", ev.Condition)
+	}
+	if ev.Action != "(SELECT 1)" {
+		t.Errorf("Action = %q", ev.Action)
+	}
+}
+
+func TestParseEvent_WithBraces(t *testing.T) {
+	ev, err := ParseEvent("on_create",
+		"DEFINE EVENT on_create ON TABLE user WHEN $event = 'CREATE' THEN { CREATE log SET type = 'create' };")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.Action != "CREATE log SET type = 'create'" {
+		t.Errorf("Action = %q", ev.Action)
+	}
+}
+
+func TestParseEvent_MissingWhen(t *testing.T) {
+	_, err := ParseEvent("bad",
+		"DEFINE EVENT bad ON TABLE user THEN (SELECT 1);")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrSchemaParse) {
+		t.Error("expected ErrSchemaParse")
+	}
+}
+
+func TestParseEvent_EmptyDefinition(t *testing.T) {
+	_, err := ParseEvent("x", "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseEvent_RoundTrip(t *testing.T) {
+	orig := NewEvent("trigger", "$before.count < $after.count", "(UPDATE stats SET incremented += 1)")
+	parsed, err := ParseEvent(orig.Name, orig.ToSurql("t"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Condition != orig.Condition {
+		t.Errorf("Condition: got %q, want %q", parsed.Condition, orig.Condition)
+	}
+	if parsed.Action != "(UPDATE stats SET incremented += 1)" {
+		t.Errorf("Action: got %q", parsed.Action)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseAccess
+// ---------------------------------------------------------------------------
+
+func TestParseAccess_JWTKey(t *testing.T) {
+	def := "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'secret';"
+	ad, err := ParseAccess("api", def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ad.Type != AccessTypeJWT {
+		t.Errorf("Type = %q", ad.Type)
+	}
+	if ad.JWT == nil {
+		t.Fatal("JWT config nil")
+	}
+	if ad.JWT.Algorithm != "HS256" {
+		t.Errorf("Algorithm = %q", ad.JWT.Algorithm)
+	}
+	if ad.JWT.Key != "secret" {
+		t.Errorf("Key = %q", ad.JWT.Key)
+	}
+}
+
+func TestParseAccess_JWTURLIssuer(t *testing.T) {
+	def := "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM RS256 URL 'https://jwks.example/.well-known/jwks.json' WITH ISSUER 'issuer-x';"
+	ad, err := ParseAccess("api", def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ad.JWT.URL != "https://jwks.example/.well-known/jwks.json" {
+		t.Errorf("URL = %q", ad.JWT.URL)
+	}
+	if ad.JWT.Issuer != "issuer-x" {
+		t.Errorf("Issuer = %q", ad.JWT.Issuer)
+	}
+	if ad.JWT.Algorithm != "RS256" {
+		t.Errorf("Algorithm = %q", ad.JWT.Algorithm)
+	}
+}
+
+func TestParseAccess_Record(t *testing.T) {
+	def := "DEFINE ACCESS user ON DATABASE TYPE RECORD SIGNUP (CREATE user SET email=$email) SIGNIN (SELECT * FROM user WHERE email=$email);"
+	ad, err := ParseAccess("user", def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ad.Type != AccessTypeRecord {
+		t.Errorf("Type = %q", ad.Type)
+	}
+	if ad.Record == nil {
+		t.Fatal("Record config nil")
+	}
+	if ad.Record.Signup != "CREATE user SET email=$email" {
+		t.Errorf("Signup = %q", ad.Record.Signup)
+	}
+	if ad.Record.Signin != "SELECT * FROM user WHERE email=$email" {
+		t.Errorf("Signin = %q", ad.Record.Signin)
+	}
+}
+
+func TestParseAccess_Duration(t *testing.T) {
+	def := "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'x' DURATION FOR SESSION 12h, FOR TOKEN 1h;"
+	ad, err := ParseAccess("api", def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ad.DurationSession != "12h" {
+		t.Errorf("DurationSession = %q", ad.DurationSession)
+	}
+	if ad.DurationToken != "1h" {
+		t.Errorf("DurationToken = %q", ad.DurationToken)
+	}
+}
+
+func TestParseAccess_UnknownTypeError(t *testing.T) {
+	def := "DEFINE ACCESS api ON DATABASE TYPE FOO;"
+	_, err := ParseAccess("api", def)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrSchemaParse) {
+		t.Errorf("expected ErrSchemaParse")
+	}
+}
+
+func TestParseAccess_EmptyDefError(t *testing.T) {
+	_, err := ParseAccess("api", "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseAccess_EmptyNameError(t *testing.T) {
+	_, err := ParseAccess("", "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'x';")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseAccess_JWTRoundTrip(t *testing.T) {
+	orig := JwtAccess("api", JwtConfig{Algorithm: "HS256", Key: "topsecret", Issuer: "me"})
+	parsed, err := ParseAccess(orig.Name, orig.ToSurql())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.JWT.Key != "topsecret" || parsed.JWT.Issuer != "me" || parsed.JWT.Algorithm != "HS256" {
+		t.Errorf("JWT round trip mismatch: %+v", parsed.JWT)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseDBInfo
+// ---------------------------------------------------------------------------
+
+func TestParseDBInfo_Nil(t *testing.T) {
+	got, err := ParseDBInfo(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Tables == nil || got.Edges == nil || got.Accesses == nil {
+		t.Error("expected non-nil maps")
+	}
+}
+
+func TestParseDBInfo_TablesAndEdges(t *testing.T) {
+	info := map[string]any{
+		"tb": map[string]any{
+			"user":    "DEFINE TABLE user SCHEMAFULL;",
+			"product": "DEFINE TABLE product SCHEMALESS;",
+			"likes":   "DEFINE TABLE likes TYPE RELATION FROM user TO product;",
+		},
+	}
+	got, err := ParseDBInfo(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Tables) != 2 {
+		t.Errorf("tables = %d, want 2", len(got.Tables))
+	}
+	if _, ok := got.Tables["user"]; !ok {
+		t.Error("missing user table")
+	}
+	if got.Tables["user"].Mode != TableModeSchemafull {
+		t.Errorf("user mode = %q", got.Tables["user"].Mode)
+	}
+	if got.Tables["product"].Mode != TableModeSchemaless {
+		t.Errorf("product mode = %q", got.Tables["product"].Mode)
+	}
+	if len(got.Edges) != 1 {
+		t.Errorf("edges = %d, want 1", len(got.Edges))
+	}
+	likes := got.Edges["likes"]
+	if likes.FromTable != "user" || likes.ToTable != "product" {
+		t.Errorf("likes from/to = %q/%q", likes.FromTable, likes.ToTable)
+	}
+	if likes.Mode != EdgeModeRelation {
+		t.Errorf("likes mode = %q", likes.Mode)
+	}
+}
+
+func TestParseDBInfo_Accesses(t *testing.T) {
+	info := map[string]any{
+		"ac": map[string]any{
+			"api":  "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'k';",
+			"user": "DEFINE ACCESS user ON DATABASE TYPE RECORD SIGNUP (CREATE user) SIGNIN (SELECT * FROM user);",
+		},
+	}
+	got, err := ParseDBInfo(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Accesses) != 2 {
+		t.Errorf("accesses = %d, want 2", len(got.Accesses))
+	}
+	names := []string{}
+	for n := range got.Accesses {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	if !reflect.DeepEqual(names, []string{"api", "user"}) {
+		t.Errorf("names = %v", names)
+	}
+}
+
+func TestParseDBInfo_SkipsMalformedAccess(t *testing.T) {
+	info := map[string]any{
+		"ac": map[string]any{
+			"good": "DEFINE ACCESS good ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'k';",
+			"bad":  "DEFINE ACCESS bad ON DATABASE TYPE UNKNOWN;",
+		},
+	}
+	got, err := ParseDBInfo(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got.Accesses["good"]; !ok {
+		t.Error("good access missing")
+	}
+	if _, ok := got.Accesses["bad"]; ok {
+		t.Error("bad access should have been skipped")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseEdgeInfo
+// ---------------------------------------------------------------------------
+
+func TestParseEdgeInfo_Relation(t *testing.T) {
+	info := map[string]any{
+		"tb": "DEFINE TABLE likes TYPE RELATION FROM user TO product;",
+		"fields": map[string]any{
+			"weight": "DEFINE FIELD weight ON TABLE likes TYPE float DEFAULT 1.0;",
+		},
+	}
+	edge, err := ParseEdgeInfo("likes", info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if edge.Mode != EdgeModeRelation {
+		t.Errorf("Mode = %q", edge.Mode)
+	}
+	if edge.FromTable != "user" || edge.ToTable != "product" {
+		t.Errorf("from/to = %q/%q", edge.FromTable, edge.ToTable)
+	}
+	if len(edge.Fields) != 1 || edge.Fields[0].Name != "weight" {
+		t.Errorf("fields = %+v", edge.Fields)
+	}
+}
+
+func TestParseEdgeInfo_EmptyName(t *testing.T) {
+	_, err := ParseEdgeInfo("", map[string]any{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractParenClause / helpers
+// ---------------------------------------------------------------------------
+
+func TestExtractParenClause_Nested(t *testing.T) {
+	def := "DEFINE ACCESS u ON DATABASE TYPE RECORD SIGNUP (CREATE user SET x = (1 + 2));"
+	got := extractParenClause(def, "SIGNUP")
+	want := "CREATE user SET x = (1 + 2)"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExtractParenClause_Missing(t *testing.T) {
+	def := "DEFINE ACCESS u ON DATABASE TYPE RECORD;"
+	if got := extractParenClause(def, "SIGNUP"); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestSplitColumns_TrimsEmpties(t *testing.T) {
+	got := splitColumns("a, ,b , c,")
+	want := []string{"a", "b", "c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestExtractStringMap_ReadsAlias(t *testing.T) {
+	in := map[string]any{
+		"fd": map[string]any{"x": "def"},
+	}
+	got := extractStringMap(in, "fields", "fd")
+	if got["x"] != "def" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestExtractStringMap_IgnoresNonString(t *testing.T) {
+	in := map[string]any{
+		"fd": map[string]any{"x": 123, "y": "ok"},
+	}
+	got := extractStringMap(in, "fd")
+	if _, ok := got["x"]; ok {
+		t.Error("numeric entry should be dropped")
+	}
+	if got["y"] != "ok" {
+		t.Errorf("y = %q", got["y"])
+	}
+}
+
+func TestStringAt_WrongTypeReturnsEmpty(t *testing.T) {
+	in := map[string]any{"tb": 5}
+	if got := stringAt(in, "tb"); got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestIsEdgeDefinitionSource(t *testing.T) {
+	if !isEdgeDefinitionSource("DEFINE TABLE likes TYPE RELATION FROM a TO b;") {
+		t.Error("should detect RELATION")
+	}
+	if isEdgeDefinitionSource("DEFINE TABLE user SCHEMAFULL;") {
+		t.Error("should not flag plain table")
+	}
+}

--- a/pkg/surql/schema/registry.go
+++ b/pkg/surql/schema/registry.go
@@ -1,0 +1,166 @@
+package schema
+
+import (
+	"sort"
+	"sync"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// SchemaRegistry is a thread-safe registry for code-defined table and edge
+// schemas. It mirrors surql-py's SchemaRegistry but uses a sync.RWMutex for
+// concurrent access and emits definitions in deterministic (alphabetical)
+// order for schema comparison and SQL generation.
+type SchemaRegistry struct {
+	mu     sync.RWMutex
+	tables map[string]TableDefinition
+	edges  map[string]EdgeDefinition
+}
+
+// NewSchemaRegistry constructs an empty SchemaRegistry. Prefer GetRegistry for
+// the process-wide singleton used by code-as-schema consumers; NewSchemaRegistry
+// is primarily useful for tests and scoped schema registration.
+func NewSchemaRegistry() *SchemaRegistry {
+	return &SchemaRegistry{
+		tables: make(map[string]TableDefinition),
+		edges:  make(map[string]EdgeDefinition),
+	}
+}
+
+var (
+	globalRegistry     *SchemaRegistry
+	globalRegistryOnce sync.Once
+)
+
+// GetRegistry returns the process-wide SchemaRegistry singleton, creating it
+// on first call. It is safe for concurrent use.
+func GetRegistry() *SchemaRegistry {
+	globalRegistryOnce.Do(func() {
+		globalRegistry = NewSchemaRegistry()
+	})
+	return globalRegistry
+}
+
+// RegisterTable stores a table definition keyed by its name. An empty-name
+// table returns ErrValidation. Re-registering the same name silently replaces
+// the previous definition, matching surql-py semantics.
+func (r *SchemaRegistry) RegisterTable(table TableDefinition) error {
+	if table.Name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"cannot register table with empty name")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tables[table.Name] = table
+	return nil
+}
+
+// RegisterEdge stores an edge definition keyed by its name.
+func (r *SchemaRegistry) RegisterEdge(edge EdgeDefinition) error {
+	if edge.Name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"cannot register edge with empty name")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.edges[edge.Name] = edge
+	return nil
+}
+
+// GetTable returns a registered table definition and a boolean indicating
+// whether it was found.
+func (r *SchemaRegistry) GetTable(name string) (TableDefinition, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	t, ok := r.tables[name]
+	return t, ok
+}
+
+// GetEdge returns a registered edge definition and a boolean indicating
+// whether it was found.
+func (r *SchemaRegistry) GetEdge(name string) (EdgeDefinition, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	e, ok := r.edges[name]
+	return e, ok
+}
+
+// Tables returns every registered TableDefinition sorted alphabetically by
+// name. The returned slice is a fresh copy; callers may mutate it freely.
+func (r *SchemaRegistry) Tables() []TableDefinition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.tables))
+	for name := range r.tables {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]TableDefinition, 0, len(names))
+	for _, name := range names {
+		out = append(out, r.tables[name])
+	}
+	return out
+}
+
+// Edges returns every registered EdgeDefinition sorted alphabetically by name.
+// The returned slice is a fresh copy.
+func (r *SchemaRegistry) Edges() []EdgeDefinition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.edges))
+	for name := range r.edges {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]EdgeDefinition, 0, len(names))
+	for _, name := range names {
+		out = append(out, r.edges[name])
+	}
+	return out
+}
+
+// TableNames returns the names of every registered table, sorted.
+func (r *SchemaRegistry) TableNames() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.tables))
+	for name := range r.tables {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// EdgeNames returns the names of every registered edge, sorted.
+func (r *SchemaRegistry) EdgeNames() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.edges))
+	for name := range r.edges {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TableCount returns the number of registered tables.
+func (r *SchemaRegistry) TableCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.tables)
+}
+
+// EdgeCount returns the number of registered edges.
+func (r *SchemaRegistry) EdgeCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.edges)
+}
+
+// Clear removes every registered table and edge. Useful for test isolation.
+func (r *SchemaRegistry) Clear() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tables = make(map[string]TableDefinition)
+	r.edges = make(map[string]EdgeDefinition)
+}

--- a/pkg/surql/schema/registry_test.go
+++ b/pkg/surql/schema/registry_test.go
@@ -1,0 +1,312 @@
+package schema
+
+import (
+	stdErrors "errors"
+	"sync"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestNewSchemaRegistry_Empty(t *testing.T) {
+	r := NewSchemaRegistry()
+	if r.TableCount() != 0 {
+		t.Errorf("TableCount() = %d, want 0", r.TableCount())
+	}
+	if r.EdgeCount() != 0 {
+		t.Errorf("EdgeCount() = %d, want 0", r.EdgeCount())
+	}
+}
+
+func TestRegistry_RegisterAndGetTable(t *testing.T) {
+	r := NewSchemaRegistry()
+	tbl := NewTable("user", WithMode(TableModeSchemafull))
+	if err := r.RegisterTable(tbl); err != nil {
+		t.Fatalf("RegisterTable: %v", err)
+	}
+	got, ok := r.GetTable("user")
+	if !ok {
+		t.Fatal("GetTable returned not-found")
+	}
+	if got.Name != "user" {
+		t.Errorf("got.Name = %q", got.Name)
+	}
+	if got.Mode != TableModeSchemafull {
+		t.Errorf("got.Mode = %q", got.Mode)
+	}
+}
+
+func TestRegistry_RegisterAndGetEdge(t *testing.T) {
+	r := NewSchemaRegistry()
+	e := TypedEdge("likes", "user", "post")
+	if err := r.RegisterEdge(e); err != nil {
+		t.Fatalf("RegisterEdge: %v", err)
+	}
+	got, ok := r.GetEdge("likes")
+	if !ok {
+		t.Fatal("GetEdge returned not-found")
+	}
+	if got.Name != "likes" {
+		t.Errorf("got.Name = %q", got.Name)
+	}
+	if got.FromTable != "user" || got.ToTable != "post" {
+		t.Errorf("from/to mismatch: %q/%q", got.FromTable, got.ToTable)
+	}
+}
+
+func TestRegistry_GetTable_NotFound(t *testing.T) {
+	r := NewSchemaRegistry()
+	_, ok := r.GetTable("missing")
+	if ok {
+		t.Error("expected not-found for missing table")
+	}
+}
+
+func TestRegistry_GetEdge_NotFound(t *testing.T) {
+	r := NewSchemaRegistry()
+	_, ok := r.GetEdge("missing")
+	if ok {
+		t.Error("expected not-found for missing edge")
+	}
+}
+
+func TestRegistry_RegisterTable_EmptyNameReturnsError(t *testing.T) {
+	r := NewSchemaRegistry()
+	err := r.RegisterTable(TableDefinition{Mode: TableModeSchemafull})
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestRegistry_RegisterEdge_EmptyNameReturnsError(t *testing.T) {
+	r := NewSchemaRegistry()
+	err := r.RegisterEdge(EdgeDefinition{Mode: EdgeModeRelation})
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestRegistry_Tables_SortedByName(t *testing.T) {
+	r := NewSchemaRegistry()
+	for _, name := range []string{"zebra", "apple", "mango"} {
+		if err := r.RegisterTable(NewTable(name)); err != nil {
+			t.Fatalf("RegisterTable(%q): %v", name, err)
+		}
+	}
+	tables := r.Tables()
+	if len(tables) != 3 {
+		t.Fatalf("len(tables) = %d, want 3", len(tables))
+	}
+	want := []string{"apple", "mango", "zebra"}
+	for i, tbl := range tables {
+		if tbl.Name != want[i] {
+			t.Errorf("tables[%d].Name = %q, want %q", i, tbl.Name, want[i])
+		}
+	}
+}
+
+func TestRegistry_Edges_SortedByName(t *testing.T) {
+	r := NewSchemaRegistry()
+	for _, name := range []string{"follows", "authored", "likes"} {
+		if err := r.RegisterEdge(TypedEdge(name, "user", "post")); err != nil {
+			t.Fatalf("RegisterEdge(%q): %v", name, err)
+		}
+	}
+	edges := r.Edges()
+	want := []string{"authored", "follows", "likes"}
+	for i, e := range edges {
+		if e.Name != want[i] {
+			t.Errorf("edges[%d].Name = %q, want %q", i, e.Name, want[i])
+		}
+	}
+}
+
+func TestRegistry_TableNames_Sorted(t *testing.T) {
+	r := NewSchemaRegistry()
+	for _, n := range []string{"c", "a", "b"} {
+		_ = r.RegisterTable(NewTable(n))
+	}
+	got := r.TableNames()
+	want := []string{"a", "b", "c"}
+	for i, n := range got {
+		if n != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, n, want[i])
+		}
+	}
+}
+
+func TestRegistry_EdgeNames_Sorted(t *testing.T) {
+	r := NewSchemaRegistry()
+	for _, n := range []string{"c", "a", "b"} {
+		_ = r.RegisterEdge(TypedEdge(n, "x", "y"))
+	}
+	got := r.EdgeNames()
+	want := []string{"a", "b", "c"}
+	for i, n := range got {
+		if n != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, n, want[i])
+		}
+	}
+}
+
+func TestRegistry_ReRegisterReplaces(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user", WithMode(TableModeSchemafull)))
+	_ = r.RegisterTable(NewTable("user", WithMode(TableModeSchemaless)))
+	got, ok := r.GetTable("user")
+	if !ok {
+		t.Fatal("missing table after re-register")
+	}
+	if got.Mode != TableModeSchemaless {
+		t.Errorf("got.Mode = %q, want SCHEMALESS after re-register", got.Mode)
+	}
+	if r.TableCount() != 1 {
+		t.Errorf("TableCount() = %d, want 1", r.TableCount())
+	}
+}
+
+func TestRegistry_Clear(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user"))
+	_ = r.RegisterEdge(TypedEdge("likes", "user", "post"))
+	r.Clear()
+	if r.TableCount() != 0 {
+		t.Errorf("TableCount() = %d, want 0 after Clear", r.TableCount())
+	}
+	if r.EdgeCount() != 0 {
+		t.Errorf("EdgeCount() = %d, want 0 after Clear", r.EdgeCount())
+	}
+}
+
+func TestRegistry_TablesReturnsCopy(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user"))
+	tables := r.Tables()
+	tables[0] = NewTable("other") // should not affect registry
+	got, ok := r.GetTable("user")
+	if !ok || got.Name != "user" {
+		t.Errorf("registry state mutated by caller; got %q / %v", got.Name, ok)
+	}
+}
+
+func TestRegistry_EdgesReturnsCopy(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterEdge(TypedEdge("likes", "user", "post"))
+	edges := r.Edges()
+	edges[0] = TypedEdge("other", "a", "b")
+	got, ok := r.GetEdge("likes")
+	if !ok || got.Name != "likes" {
+		t.Errorf("registry state mutated by caller; got %q / %v", got.Name, ok)
+	}
+}
+
+func TestGetRegistry_ReturnsSingleton(t *testing.T) {
+	r1 := GetRegistry()
+	r2 := GetRegistry()
+	if r1 != r2 {
+		t.Error("GetRegistry returned distinct instances")
+	}
+}
+
+func TestGetRegistry_SingletonClearIsolation(t *testing.T) {
+	r := GetRegistry()
+	r.Clear()
+	if err := r.RegisterTable(NewTable("singleton_user")); err != nil {
+		t.Fatalf("RegisterTable: %v", err)
+	}
+	other := GetRegistry()
+	if _, ok := other.GetTable("singleton_user"); !ok {
+		t.Error("expected singleton to share state across GetRegistry calls")
+	}
+	// cleanup so we don't leak across tests
+	r.Clear()
+}
+
+func TestRegistry_ConcurrentRegister(t *testing.T) {
+	r := NewSchemaRegistry()
+	var wg sync.WaitGroup
+	const goroutines = 32
+	const perGoroutine = 16
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				name := tableNameFor(gid, i)
+				_ = r.RegisterTable(NewTable(name))
+			}
+		}(g)
+	}
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				name := edgeNameFor(gid, i)
+				_ = r.RegisterEdge(TypedEdge(name, "user", "post"))
+			}
+		}(g)
+	}
+	// readers in parallel
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				_ = r.Tables()
+				_ = r.Edges()
+				_ = r.TableCount()
+				_ = r.EdgeCount()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if r.TableCount() != goroutines*perGoroutine {
+		t.Errorf("TableCount() = %d, want %d",
+			r.TableCount(), goroutines*perGoroutine)
+	}
+	if r.EdgeCount() != goroutines*perGoroutine {
+		t.Errorf("EdgeCount() = %d, want %d",
+			r.EdgeCount(), goroutines*perGoroutine)
+	}
+}
+
+func tableNameFor(g, i int) string {
+	return "t_" + itoa(g) + "_" + itoa(i)
+}
+
+func edgeNameFor(g, i int) string {
+	return "e_" + itoa(g) + "_" + itoa(i)
+}
+
+// itoa is a tiny allocation-free integer->string formatter used by the
+// concurrent-registration test; avoids pulling strconv into a test helper.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/pkg/surql/schema/sql.go
+++ b/pkg/surql/schema/sql.go
@@ -1,0 +1,95 @@
+package schema
+
+import (
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// GenerateTableSQL emits the full list of DEFINE statements for a table: the
+// DEFINE TABLE line followed by each DEFINE FIELD / INDEX / EVENT, plus any
+// DEFINE FIELD PERMISSIONS rendered from the permission map.
+//
+// It mirrors surql-py's generate_table_sql and delegates to the TableDefinition
+// ToSurqlStatements* methods for deterministic output (permissions are sorted
+// by action name).
+//
+// When ifNotExists is true, every DEFINE statement that supports it is emitted
+// with an IF NOT EXISTS clause.
+func GenerateTableSQL(table TableDefinition, ifNotExists bool) []string {
+	if ifNotExists {
+		return table.ToSurqlStatementsIfNotExists()
+	}
+	return table.ToSurqlStatements()
+}
+
+// GenerateEdgeSQL emits the full list of DEFINE statements for an edge table.
+// It returns an ErrValidation error when the edge has RELATION mode without
+// both from_table and to_table set (matching surql-py behaviour).
+func GenerateEdgeSQL(edge EdgeDefinition, ifNotExists bool) ([]string, error) {
+	if ifNotExists {
+		return edge.ToSurqlStatementsIfNotExists()
+	}
+	return edge.ToSurqlStatements()
+}
+
+// GenerateAccessSQL emits the DEFINE ACCESS statement for an access definition.
+// It always returns a single-element slice to match the surql-py signature.
+func GenerateAccessSQL(access AccessDefinition) []string {
+	return []string{access.ToSurql()}
+}
+
+// GenerateSchemaSQL composes a full SurrealQL schema script from every table
+// and edge registered in r. Tables are emitted first (in sorted order),
+// followed by edges (also sorted). Each definition group is separated by a
+// blank line for readability, matching the surql-py output format.
+//
+// A nil registry produces an empty script. When ifNotExists is true, every
+// emitted DEFINE statement includes IF NOT EXISTS.
+//
+// GenerateSchemaSQL surfaces the same validation errors as GenerateEdgeSQL:
+// an edge registered in RELATION mode without from/to tables yields an
+// ErrValidation error.
+func GenerateSchemaSQL(r *SchemaRegistry, ifNotExists bool) (string, error) {
+	if r == nil {
+		return "", nil
+	}
+
+	tables := r.Tables()
+	edges := r.Edges()
+
+	return generateSchemaScript(tables, edges, ifNotExists)
+}
+
+// GenerateSchemaSQLFromSlices composes a full SurrealQL schema script from the
+// supplied table and edge slices without consulting any registry. Inputs are
+// emitted in the order provided (callers sort first if determinism is
+// required).
+func GenerateSchemaSQLFromSlices(tables []TableDefinition, edges []EdgeDefinition, ifNotExists bool) (string, error) {
+	return generateSchemaScript(tables, edges, ifNotExists)
+}
+
+func generateSchemaScript(tables []TableDefinition, edges []EdgeDefinition, ifNotExists bool) (string, error) {
+	if len(tables) == 0 && len(edges) == 0 {
+		return "", nil
+	}
+
+	stmts := make([]string, 0, len(tables)*3+len(edges)*3)
+
+	for _, t := range tables {
+		stmts = append(stmts, GenerateTableSQL(t, ifNotExists)...)
+		stmts = append(stmts, "")
+	}
+
+	for _, e := range edges {
+		edgeStmts, err := GenerateEdgeSQL(e, ifNotExists)
+		if err != nil {
+			return "", surqlerrors.Wrapf(surqlerrors.ErrValidation, err,
+				"failed to generate SQL for edge %q", e.Name)
+		}
+		stmts = append(stmts, edgeStmts...)
+		stmts = append(stmts, "")
+	}
+
+	return strings.TrimRight(strings.Join(stmts, "\n"), "\n"), nil
+}

--- a/pkg/surql/schema/sql_test.go
+++ b/pkg/surql/schema/sql_test.go
@@ -1,0 +1,579 @@
+package schema
+
+import (
+	stdErrors "errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// ---------- GenerateTableSQL ----------
+
+func TestGenerateTableSQL_SchemafullMinimal(t *testing.T) {
+	tbl := NewTable("user", WithMode(TableModeSchemafull))
+	stmts := GenerateTableSQL(tbl, false)
+	if len(stmts) != 1 {
+		t.Fatalf("len(stmts) = %d, want 1", len(stmts))
+	}
+	if stmts[0] != "DEFINE TABLE user SCHEMAFULL;" {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+}
+
+func TestGenerateTableSQL_Schemaless(t *testing.T) {
+	tbl := NewTable("log", WithMode(TableModeSchemaless))
+	stmts := GenerateTableSQL(tbl, false)
+	if stmts[0] != "DEFINE TABLE log SCHEMALESS;" {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+}
+
+func TestGenerateTableSQL_WithFields(t *testing.T) {
+	tbl := NewTable("user",
+		WithMode(TableModeSchemafull),
+		WithFields(StringField("name"), IntField("age")),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	if !containsSubstring(stmts, "DEFINE FIELD name ON TABLE user TYPE string") {
+		t.Errorf("missing name field; stmts = %v", stmts)
+	}
+	if !containsSubstring(stmts, "DEFINE FIELD age ON TABLE user TYPE int") {
+		t.Errorf("missing age field; stmts = %v", stmts)
+	}
+}
+
+func TestGenerateTableSQL_WithFieldAssertion(t *testing.T) {
+	tbl := NewTable("user",
+		WithFields(StringField("email",
+			WithAssertion("string::is::email($value)"))),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	if !containsSubstring(stmts, "ASSERT string::is::email($value)") {
+		t.Errorf("missing assertion; stmts = %v", stmts)
+	}
+}
+
+func TestGenerateTableSQL_WithFieldDefault(t *testing.T) {
+	tbl := NewTable("event",
+		WithFields(DatetimeField("created_at", WithDefault("time::now()"))),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	if !containsSubstring(stmts, "DEFAULT time::now()") {
+		t.Errorf("missing default; stmts = %v", stmts)
+	}
+}
+
+func TestGenerateTableSQL_WithReadOnlyField(t *testing.T) {
+	tbl := NewTable("event",
+		WithFields(DatetimeField("created_at", WithReadOnly(true))),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	if !containsSubstring(stmts, "READONLY") {
+		t.Errorf("missing READONLY; stmts = %v", stmts)
+	}
+}
+
+func TestGenerateTableSQL_WithUniqueIndex(t *testing.T) {
+	tbl := NewTable("user",
+		WithIndexes(UniqueIndex("email_idx", []string{"email"})),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	want := "DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE;"
+	if !hasExact(stmts, want) {
+		t.Errorf("expected %q in stmts = %v", want, stmts)
+	}
+}
+
+func TestGenerateTableSQL_WithStandardIndex(t *testing.T) {
+	tbl := NewTable("post",
+		WithIndexes(NewIndex("title_idx", []string{"title"}, IndexTypeStandard)),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	want := "DEFINE INDEX title_idx ON TABLE post COLUMNS title;"
+	if !hasExact(stmts, want) {
+		t.Errorf("expected %q in stmts = %v", want, stmts)
+	}
+}
+
+func TestGenerateTableSQL_WithEvent(t *testing.T) {
+	tbl := NewTable("user",
+		WithEvents(NewEvent("email_changed",
+			"$before.email != $after.email",
+			"CREATE audit_log SET user = $value.id")),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	if !containsSubstring(stmts, "DEFINE EVENT email_changed ON TABLE user") {
+		t.Errorf("missing event header; stmts = %v", stmts)
+	}
+	if !containsSubstring(stmts, "WHEN $before.email != $after.email") {
+		t.Errorf("missing event WHEN; stmts = %v", stmts)
+	}
+}
+
+func TestGenerateTableSQL_WithPermissions(t *testing.T) {
+	tbl := NewTable("user",
+		WithTablePermissions(map[string]string{"select": "$auth.id = id"}),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "FOR SELECT") && strings.Contains(s, "$auth.id = id") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected FOR SELECT ... $auth.id = id; stmts = %v", stmts)
+	}
+}
+
+func TestGenerateTableSQL_MinimalSingleStatement(t *testing.T) {
+	tbl := NewTable("empty")
+	stmts := GenerateTableSQL(tbl, false)
+	if len(stmts) != 1 {
+		t.Errorf("len(stmts) = %d, want 1", len(stmts))
+	}
+}
+
+func TestGenerateTableSQL_FirstStatementIsTable(t *testing.T) {
+	tbl := NewTable("user",
+		WithFields(StringField("name")),
+		WithIndexes(UniqueIndex("name_idx", []string{"name"})),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	if !strings.HasPrefix(stmts[0], "DEFINE TABLE") {
+		t.Errorf("first stmt = %q, want prefix DEFINE TABLE", stmts[0])
+	}
+}
+
+// ---------- GenerateEdgeSQL ----------
+
+func TestGenerateEdgeSQL_RelationWithFromTo(t *testing.T) {
+	e := TypedEdge("likes", "user", "post")
+	stmts, err := GenerateEdgeSQL(e, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := "DEFINE TABLE likes TYPE RELATION FROM user TO post;"
+	if stmts[0] != want {
+		t.Errorf("stmts[0] = %q, want %q", stmts[0], want)
+	}
+}
+
+func TestGenerateEdgeSQL_Schemafull(t *testing.T) {
+	e := NewEdge("entity_relation", WithEdgeMode(EdgeModeSchemafull))
+	stmts, err := GenerateEdgeSQL(e, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := "DEFINE TABLE entity_relation SCHEMAFULL;"
+	if stmts[0] != want {
+		t.Errorf("stmts[0] = %q, want %q", stmts[0], want)
+	}
+}
+
+func TestGenerateEdgeSQL_Schemaless(t *testing.T) {
+	e := NewEdge("loose_rel", WithEdgeMode(EdgeModeSchemaless))
+	stmts, err := GenerateEdgeSQL(e, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := "DEFINE TABLE loose_rel SCHEMALESS;"
+	if stmts[0] != want {
+		t.Errorf("stmts[0] = %q, want %q", stmts[0], want)
+	}
+}
+
+func TestGenerateEdgeSQL_WithFields(t *testing.T) {
+	e := TypedEdge("likes", "user", "post",
+		WithEdgeFields(DatetimeField("created_at", WithDefault("time::now()"))),
+	)
+	stmts, err := GenerateEdgeSQL(e, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !containsSubstring(stmts, "DEFINE FIELD created_at ON TABLE likes TYPE datetime") {
+		t.Errorf("missing field; stmts = %v", stmts)
+	}
+}
+
+func TestGenerateEdgeSQL_RelationMissingFrom(t *testing.T) {
+	e := NewEdge("likes", WithToTable("post"))
+	_, err := GenerateEdgeSQL(e, false)
+	if err == nil {
+		t.Fatal("expected error for missing from_table")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestGenerateEdgeSQL_RelationMissingTo(t *testing.T) {
+	e := NewEdge("likes", WithFromTable("user"))
+	_, err := GenerateEdgeSQL(e, false)
+	if err == nil {
+		t.Fatal("expected error for missing to_table")
+	}
+}
+
+func TestGenerateEdgeSQL_RelationMissingBoth(t *testing.T) {
+	e := NewEdge("likes")
+	_, err := GenerateEdgeSQL(e, false)
+	if err == nil {
+		t.Fatal("expected error for missing both tables")
+	}
+}
+
+func TestGenerateEdgeSQL_SchemafullNoTablesRequired(t *testing.T) {
+	e := NewEdge("entity_rel", WithEdgeMode(EdgeModeSchemafull))
+	stmts, err := GenerateEdgeSQL(e, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(stmts) < 1 {
+		t.Errorf("want >=1 stmts, got %d", len(stmts))
+	}
+}
+
+func TestGenerateEdgeSQL_FirstStatementIsTable(t *testing.T) {
+	e := BidirectionalEdge("follows", "user")
+	stmts, err := GenerateEdgeSQL(e, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.HasPrefix(stmts[0], "DEFINE TABLE") {
+		t.Errorf("first stmt = %q", stmts[0])
+	}
+}
+
+// ---------- GenerateAccessSQL ----------
+
+func TestGenerateAccessSQL_JWT(t *testing.T) {
+	a := JwtAccess("api", JwtConfig{Key: "secret"})
+	stmts := GenerateAccessSQL(a)
+	if len(stmts) != 1 {
+		t.Fatalf("len(stmts) = %d, want 1", len(stmts))
+	}
+	want := "DEFINE ACCESS api ON DATABASE TYPE JWT ALGORITHM HS256 KEY 'secret';"
+	if stmts[0] != want {
+		t.Errorf("stmts[0] = %q, want %q", stmts[0], want)
+	}
+}
+
+func TestGenerateAccessSQL_Record(t *testing.T) {
+	a := RecordAccess("users", RecordAccessConfig{
+		Signup: "CREATE user SET email = $email",
+		Signin: "SELECT * FROM user WHERE email = $email",
+	})
+	stmts := GenerateAccessSQL(a)
+	if !strings.Contains(stmts[0], "SIGNUP (CREATE user SET email = $email)") {
+		t.Errorf("missing SIGNUP; got %q", stmts[0])
+	}
+	if !strings.Contains(stmts[0], "SIGNIN (SELECT * FROM user WHERE email = $email)") {
+		t.Errorf("missing SIGNIN; got %q", stmts[0])
+	}
+}
+
+// ---------- GenerateSchemaSQL (registry) ----------
+
+func TestGenerateSchemaSQL_CombinesTablesAndEdges(t *testing.T) {
+	r := NewSchemaRegistry()
+	if err := r.RegisterTable(NewTable("user", WithMode(TableModeSchemafull))); err != nil {
+		t.Fatalf("register table: %v", err)
+	}
+	if err := r.RegisterEdge(TypedEdge("likes", "user", "post")); err != nil {
+		t.Fatalf("register edge: %v", err)
+	}
+	sql, err := GenerateSchemaSQL(r, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(sql, "DEFINE TABLE user SCHEMAFULL") {
+		t.Errorf("missing user table; sql = %q", sql)
+	}
+	if !strings.Contains(sql, "DEFINE TABLE likes TYPE RELATION FROM user TO post") {
+		t.Errorf("missing likes edge; sql = %q", sql)
+	}
+}
+
+func TestGenerateSchemaSQL_TablesOnly(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user"))
+	sql, err := GenerateSchemaSQL(r, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(sql, "DEFINE TABLE user") {
+		t.Errorf("sql missing user; sql = %q", sql)
+	}
+}
+
+func TestGenerateSchemaSQL_EdgesOnly(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterEdge(BidirectionalEdge("follows", "user"))
+	sql, err := GenerateSchemaSQL(r, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(sql, "DEFINE TABLE follows TYPE RELATION") {
+		t.Errorf("missing edge; sql = %q", sql)
+	}
+}
+
+func TestGenerateSchemaSQL_EmptyRegistryReturnsEmpty(t *testing.T) {
+	r := NewSchemaRegistry()
+	sql, err := GenerateSchemaSQL(r, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if sql != "" {
+		t.Errorf("expected empty string, got %q", sql)
+	}
+}
+
+func TestGenerateSchemaSQL_NilRegistryReturnsEmpty(t *testing.T) {
+	sql, err := GenerateSchemaSQL(nil, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if sql != "" {
+		t.Errorf("expected empty string, got %q", sql)
+	}
+}
+
+func TestGenerateSchemaSQL_MultipleTablesSorted(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user"))
+	_ = r.RegisterTable(NewTable("post"))
+	sql, err := GenerateSchemaSQL(r, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	// sorted: post should appear before user
+	postIdx := strings.Index(sql, "DEFINE TABLE post")
+	userIdx := strings.Index(sql, "DEFINE TABLE user")
+	if postIdx == -1 || userIdx == -1 {
+		t.Fatalf("missing tables; sql = %q", sql)
+	}
+	if postIdx > userIdx {
+		t.Errorf("tables not sorted: post index %d > user index %d", postIdx, userIdx)
+	}
+}
+
+func TestGenerateSchemaSQL_TablesSeparatedByBlankLines(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user"))
+	_ = r.RegisterTable(NewTable("post"))
+	sql, err := GenerateSchemaSQL(r, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	hasBlank := false
+	for _, line := range strings.Split(sql, "\n") {
+		if line == "" {
+			hasBlank = true
+			break
+		}
+	}
+	if !hasBlank {
+		t.Errorf("expected blank line separator; sql = %q", sql)
+	}
+}
+
+func TestGenerateSchemaSQL_EdgeValidationError(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterEdge(NewEdge("bad", WithFromTable("user")))
+	_, err := GenerateSchemaSQL(r, false)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestGenerateSchemaSQLFromSlices_PreservesOrder(t *testing.T) {
+	tables := []TableDefinition{NewTable("z"), NewTable("a")}
+	sql, err := GenerateSchemaSQLFromSlices(tables, nil, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	zIdx := strings.Index(sql, "DEFINE TABLE z")
+	aIdx := strings.Index(sql, "DEFINE TABLE a")
+	if zIdx == -1 || aIdx == -1 {
+		t.Fatalf("missing tables; sql = %q", sql)
+	}
+	if zIdx > aIdx {
+		t.Errorf("slice order not preserved: z at %d, a at %d", zIdx, aIdx)
+	}
+}
+
+// ---------- IF NOT EXISTS ----------
+
+func TestIfNotExists_TableDefinition(t *testing.T) {
+	tbl := NewTable("user", WithMode(TableModeSchemafull))
+	stmts := GenerateTableSQL(tbl, true)
+	want := "DEFINE TABLE IF NOT EXISTS user SCHEMAFULL;"
+	if stmts[0] != want {
+		t.Errorf("stmts[0] = %q, want %q", stmts[0], want)
+	}
+}
+
+func TestIfNotExists_Field(t *testing.T) {
+	tbl := NewTable("user",
+		WithMode(TableModeSchemafull),
+		WithFields(StringField("name")),
+	)
+	stmts := GenerateTableSQL(tbl, true)
+	want := "DEFINE FIELD IF NOT EXISTS name ON TABLE user TYPE string;"
+	if !hasExact(stmts, want) {
+		t.Errorf("missing %q; stmts = %v", want, stmts)
+	}
+}
+
+func TestIfNotExists_Index(t *testing.T) {
+	tbl := NewTable("user",
+		WithIndexes(UniqueIndex("email_idx", []string{"email"})),
+	)
+	stmts := GenerateTableSQL(tbl, true)
+	want := "DEFINE INDEX IF NOT EXISTS email_idx ON TABLE user COLUMNS email UNIQUE;"
+	if !hasExact(stmts, want) {
+		t.Errorf("missing %q; stmts = %v", want, stmts)
+	}
+}
+
+func TestIfNotExists_StandardIndex(t *testing.T) {
+	tbl := NewTable("post",
+		WithIndexes(NewIndex("title_idx", []string{"title"}, IndexTypeStandard)),
+	)
+	stmts := GenerateTableSQL(tbl, true)
+	want := "DEFINE INDEX IF NOT EXISTS title_idx ON TABLE post COLUMNS title;"
+	if !hasExact(stmts, want) {
+		t.Errorf("missing %q; stmts = %v", want, stmts)
+	}
+}
+
+func TestIfNotExists_Event(t *testing.T) {
+	tbl := NewTable("user",
+		WithEvents(NewEvent("email_changed",
+			"$before.email != $after.email",
+			"CREATE audit_log SET user = $value.id")),
+	)
+	stmts := GenerateTableSQL(tbl, true)
+	found := false
+	for _, s := range stmts {
+		if strings.HasPrefix(s, "DEFINE EVENT IF NOT EXISTS email_changed ON TABLE user") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("missing DEFINE EVENT IF NOT EXISTS; stmts = %v", stmts)
+	}
+}
+
+func TestIfNotExists_EdgeRelation(t *testing.T) {
+	e := TypedEdge("likes", "user", "post")
+	stmts, err := GenerateEdgeSQL(e, true)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := "DEFINE TABLE IF NOT EXISTS likes TYPE RELATION FROM user TO post;"
+	if stmts[0] != want {
+		t.Errorf("stmts[0] = %q, want %q", stmts[0], want)
+	}
+}
+
+func TestIfNotExists_EdgeSchemafull(t *testing.T) {
+	e := NewEdge("entity_relation", WithEdgeMode(EdgeModeSchemafull))
+	stmts, err := GenerateEdgeSQL(e, true)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := "DEFINE TABLE IF NOT EXISTS entity_relation SCHEMAFULL;"
+	if stmts[0] != want {
+		t.Errorf("stmts[0] = %q, want %q", stmts[0], want)
+	}
+}
+
+func TestIfNotExists_EdgeSchemaless(t *testing.T) {
+	e := NewEdge("loose_rel", WithEdgeMode(EdgeModeSchemaless))
+	stmts, err := GenerateEdgeSQL(e, true)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := "DEFINE TABLE IF NOT EXISTS loose_rel SCHEMALESS;"
+	if stmts[0] != want {
+		t.Errorf("stmts[0] = %q, want %q", stmts[0], want)
+	}
+}
+
+func TestIfNotExists_EdgeFields(t *testing.T) {
+	e := TypedEdge("likes", "user", "post",
+		WithEdgeFields(DatetimeField("created_at", WithDefault("time::now()"))),
+	)
+	stmts, err := GenerateEdgeSQL(e, true)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !containsSubstring(stmts, "DEFINE FIELD IF NOT EXISTS created_at ON TABLE likes") {
+		t.Errorf("missing IF NOT EXISTS field; stmts = %v", stmts)
+	}
+}
+
+func TestIfNotExists_SchemaSQL(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user", WithMode(TableModeSchemafull)))
+	_ = r.RegisterEdge(TypedEdge("likes", "user", "post"))
+	sql, err := GenerateSchemaSQL(r, true)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(sql, "DEFINE TABLE IF NOT EXISTS user SCHEMAFULL") {
+		t.Errorf("missing IF NOT EXISTS table; sql = %q", sql)
+	}
+	if !strings.Contains(sql, "DEFINE TABLE IF NOT EXISTS likes TYPE RELATION FROM user TO post") {
+		t.Errorf("missing IF NOT EXISTS edge; sql = %q", sql)
+	}
+}
+
+func TestIfNotExistsDefault_False(t *testing.T) {
+	tbl := NewTable("user",
+		WithMode(TableModeSchemafull),
+		WithFields(StringField("name")),
+		WithIndexes(UniqueIndex("email_idx", []string{"email"})),
+		WithEvents(NewEvent("email_changed",
+			"$before.email != $after.email",
+			"CREATE audit_log SET user = $value.id")),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	if stmts[0] != "DEFINE TABLE user SCHEMAFULL;" {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+	for _, s := range stmts {
+		if strings.Contains(s, "IF NOT EXISTS") {
+			t.Errorf("did not expect IF NOT EXISTS; got %q", s)
+		}
+	}
+}
+
+// ---------- helpers ----------
+
+func containsSubstring(stmts []string, needle string) bool {
+	for _, s := range stmts {
+		if strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExact(stmts []string, needle string) bool {
+	for _, s := range stmts {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/surql/schema/table.go
+++ b/pkg/surql/schema/table.go
@@ -1,0 +1,556 @@
+package schema
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// TableMode enumerates the table schema modes.
+type TableMode string
+
+// TableMode values.
+const (
+	TableModeSchemafull TableMode = "SCHEMAFULL"
+	TableModeSchemaless TableMode = "SCHEMALESS"
+	TableModeDrop       TableMode = "DROP"
+)
+
+// IsValid reports whether the TableMode is recognised.
+func (m TableMode) IsValid() bool {
+	switch m {
+	case TableModeSchemafull, TableModeSchemaless, TableModeDrop:
+		return true
+	}
+	return false
+}
+
+// IndexType enumerates the supported DEFINE INDEX flavours.
+type IndexType string
+
+// IndexType values.
+const (
+	IndexTypeStandard IndexType = "INDEX"
+	IndexTypeUnique   IndexType = "UNIQUE"
+	IndexTypeSearch   IndexType = "SEARCH"
+	IndexTypeMTree    IndexType = "MTREE"
+	IndexTypeHNSW     IndexType = "HNSW"
+)
+
+// IsValid reports whether the IndexType is recognised.
+func (t IndexType) IsValid() bool {
+	switch t {
+	case IndexTypeStandard, IndexTypeUnique, IndexTypeSearch, IndexTypeMTree, IndexTypeHNSW:
+		return true
+	}
+	return false
+}
+
+// MTreeDistanceType enumerates distance metrics for MTREE indexes.
+type MTreeDistanceType string
+
+// MTreeDistanceType values.
+const (
+	MTreeDistanceCosine    MTreeDistanceType = "COSINE"
+	MTreeDistanceEuclidean MTreeDistanceType = "EUCLIDEAN"
+	MTreeDistanceManhattan MTreeDistanceType = "MANHATTAN"
+	MTreeDistanceMinkowski MTreeDistanceType = "MINKOWSKI"
+)
+
+// IsValid reports whether the MTreeDistanceType is recognised.
+func (d MTreeDistanceType) IsValid() bool {
+	switch d {
+	case MTreeDistanceCosine, MTreeDistanceEuclidean, MTreeDistanceManhattan, MTreeDistanceMinkowski:
+		return true
+	}
+	return false
+}
+
+// HnswDistanceType enumerates distance metrics for HNSW indexes (superset of
+// MTreeDistanceType).
+type HnswDistanceType string
+
+// HnswDistanceType values.
+const (
+	HnswDistanceChebyshev HnswDistanceType = "CHEBYSHEV"
+	HnswDistanceCosine    HnswDistanceType = "COSINE"
+	HnswDistanceEuclidean HnswDistanceType = "EUCLIDEAN"
+	HnswDistanceHamming   HnswDistanceType = "HAMMING"
+	HnswDistanceJaccard   HnswDistanceType = "JACCARD"
+	HnswDistanceManhattan HnswDistanceType = "MANHATTAN"
+	HnswDistanceMinkowski HnswDistanceType = "MINKOWSKI"
+	HnswDistancePearson   HnswDistanceType = "PEARSON"
+)
+
+// IsValid reports whether the HnswDistanceType is recognised.
+func (d HnswDistanceType) IsValid() bool {
+	switch d {
+	case HnswDistanceChebyshev, HnswDistanceCosine, HnswDistanceEuclidean,
+		HnswDistanceHamming, HnswDistanceJaccard, HnswDistanceManhattan,
+		HnswDistanceMinkowski, HnswDistancePearson:
+		return true
+	}
+	return false
+}
+
+// MTreeVectorType enumerates the vector component numeric types supported by
+// both MTREE and HNSW indexes.
+type MTreeVectorType string
+
+// MTreeVectorType values.
+const (
+	MTreeVectorF64 MTreeVectorType = "F64"
+	MTreeVectorF32 MTreeVectorType = "F32"
+	MTreeVectorI64 MTreeVectorType = "I64"
+	MTreeVectorI32 MTreeVectorType = "I32"
+	MTreeVectorI16 MTreeVectorType = "I16"
+)
+
+// IsValid reports whether the MTreeVectorType is recognised.
+func (v MTreeVectorType) IsValid() bool {
+	switch v {
+	case MTreeVectorF64, MTreeVectorF32, MTreeVectorI64, MTreeVectorI32, MTreeVectorI16:
+		return true
+	}
+	return false
+}
+
+// IndexDefinition captures the fields required to emit a DEFINE INDEX statement.
+type IndexDefinition struct {
+	Name    string
+	Columns []string
+	Type    IndexType
+
+	// MTREE & HNSW shared
+	Dimension  int
+	VectorType MTreeVectorType
+
+	// MTREE-specific
+	Distance MTreeDistanceType
+
+	// HNSW-specific
+	HnswDistance HnswDistanceType
+	EFC          int // zero means unset
+	M            int // zero means unset
+}
+
+// EventDefinition captures a DEFINE EVENT trigger.
+type EventDefinition struct {
+	Name      string
+	Condition string
+	Action    string
+}
+
+// TableDefinition captures the fields required to emit a DEFINE TABLE
+// statement plus its attendant DEFINE FIELD / INDEX / EVENT children.
+type TableDefinition struct {
+	Name        string
+	Mode        TableMode
+	Fields      []FieldDefinition
+	Indexes     []IndexDefinition
+	Events      []EventDefinition
+	Permissions map[string]string
+	Drop        bool
+}
+
+// TableOption customises a TableDefinition created via NewTable.
+type TableOption func(*TableDefinition)
+
+// WithMode sets the schema mode (SCHEMAFULL / SCHEMALESS / DROP).
+func WithMode(mode TableMode) TableOption {
+	return func(t *TableDefinition) { t.Mode = mode }
+}
+
+// WithFields appends fields to the table definition.
+func WithFields(fields ...FieldDefinition) TableOption {
+	return func(t *TableDefinition) { t.Fields = append(t.Fields, fields...) }
+}
+
+// WithIndexes appends indexes to the table definition.
+func WithIndexes(indexes ...IndexDefinition) TableOption {
+	return func(t *TableDefinition) { t.Indexes = append(t.Indexes, indexes...) }
+}
+
+// WithEvents appends events to the table definition.
+func WithEvents(events ...EventDefinition) TableOption {
+	return func(t *TableDefinition) { t.Events = append(t.Events, events...) }
+}
+
+// WithTablePermissions sets permissions for the table.
+func WithTablePermissions(perms map[string]string) TableOption {
+	return func(t *TableDefinition) {
+		if perms == nil {
+			t.Permissions = nil
+			return
+		}
+		copied := make(map[string]string, len(perms))
+		for k, v := range perms {
+			copied[k] = v
+		}
+		t.Permissions = copied
+	}
+}
+
+// WithDrop marks the table for deletion.
+func WithDrop(drop bool) TableOption {
+	return func(t *TableDefinition) { t.Drop = drop }
+}
+
+// NewTable constructs a TableDefinition, defaulting to SCHEMAFULL mode.
+func NewTable(name string, opts ...TableOption) TableDefinition {
+	t := TableDefinition{Name: name, Mode: TableModeSchemafull}
+	for _, opt := range opts {
+		opt(&t)
+	}
+	return t
+}
+
+// Validate checks table-level invariants plus each child field, index, and event.
+func (t TableDefinition) Validate() error {
+	if t.Name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "table name cannot be empty")
+	}
+	if !t.Mode.IsValid() {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"invalid table mode %q for table %q", string(t.Mode), t.Name)
+	}
+	for _, f := range t.Fields {
+		if err := f.Validate(); err != nil {
+			return err
+		}
+	}
+	for _, i := range t.Indexes {
+		if err := i.Validate(); err != nil {
+			return err
+		}
+	}
+	for _, e := range t.Events {
+		if err := e.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ToSurql emits the DEFINE TABLE statement only (no fields, indexes, events).
+func (t TableDefinition) ToSurql() string {
+	return t.toSurqlTable(false)
+}
+
+// ToSurqlIfNotExists emits the DEFINE TABLE statement with IF NOT EXISTS.
+func (t TableDefinition) ToSurqlIfNotExists() string {
+	return t.toSurqlTable(true)
+}
+
+func (t TableDefinition) toSurqlTable(ifNotExists bool) string {
+	var b strings.Builder
+	b.WriteString("DEFINE TABLE")
+	if ifNotExists {
+		b.WriteString(" IF NOT EXISTS")
+	}
+	b.WriteString(" ")
+	b.WriteString(t.Name)
+	b.WriteString(" ")
+	b.WriteString(string(t.Mode))
+	b.WriteString(";")
+	return b.String()
+}
+
+// ToSurqlStatements returns the full list of DEFINE statements for the table:
+// the DEFINE TABLE line followed by each DEFINE FIELD / INDEX / EVENT, plus
+// any DEFINE FIELD PERMISSIONS rendered from the permission map.
+func (t TableDefinition) ToSurqlStatements() []string {
+	return t.toSurqlStatements(false)
+}
+
+// ToSurqlStatementsIfNotExists is like ToSurqlStatements but adds IF NOT
+// EXISTS to every DEFINE statement that supports it.
+func (t TableDefinition) ToSurqlStatementsIfNotExists() []string {
+	return t.toSurqlStatements(true)
+}
+
+func (t TableDefinition) toSurqlStatements(ifNotExists bool) []string {
+	stmts := make([]string, 0, 1+len(t.Fields)+len(t.Indexes)+len(t.Events))
+	stmts = append(stmts, t.toSurqlTable(ifNotExists))
+
+	for _, f := range t.Fields {
+		stmts = append(stmts, f.toSurql(t.Name, ifNotExists))
+	}
+	for _, i := range t.Indexes {
+		stmts = append(stmts, i.toSurql(t.Name, ifNotExists))
+	}
+	for _, e := range t.Events {
+		stmts = append(stmts, e.toSurql(t.Name, ifNotExists))
+	}
+
+	if len(t.Permissions) > 0 {
+		keys := make([]string, 0, len(t.Permissions))
+		for k := range t.Permissions {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			stmts = append(stmts,
+				"DEFINE FIELD PERMISSIONS FOR "+strings.ToUpper(k)+
+					" ON TABLE "+t.Name+" WHERE "+t.Permissions[k]+";")
+		}
+	}
+	return stmts
+}
+
+// NewIndex builds a standard IndexDefinition.
+func NewIndex(name string, columns []string, indexType IndexType) IndexDefinition {
+	cols := make([]string, len(columns))
+	copy(cols, columns)
+	return IndexDefinition{Name: name, Columns: cols, Type: indexType}
+}
+
+// UniqueIndex is sugar for NewIndex(name, columns, IndexTypeUnique).
+func UniqueIndex(name string, columns []string) IndexDefinition {
+	return NewIndex(name, columns, IndexTypeUnique)
+}
+
+// SearchIndex is sugar for NewIndex(name, columns, IndexTypeSearch).
+func SearchIndex(name string, columns []string) IndexDefinition {
+	return NewIndex(name, columns, IndexTypeSearch)
+}
+
+// MTreeIndexOptions configures an MTREE vector index.
+type MTreeIndexOptions struct {
+	Distance   MTreeDistanceType
+	VectorType MTreeVectorType
+}
+
+// MTreeIndex builds an MTREE IndexDefinition.
+func MTreeIndex(name, column string, dimension int, opts MTreeIndexOptions) IndexDefinition {
+	if opts.Distance == "" {
+		opts.Distance = MTreeDistanceEuclidean
+	}
+	if opts.VectorType == "" {
+		opts.VectorType = MTreeVectorF64
+	}
+	return IndexDefinition{
+		Name:       name,
+		Columns:    []string{column},
+		Type:       IndexTypeMTree,
+		Dimension:  dimension,
+		Distance:   opts.Distance,
+		VectorType: opts.VectorType,
+	}
+}
+
+// HnswIndexOptions configures an HNSW vector index. EFC and M are optional
+// (zero means "use SurrealDB default" and the EFC / M clauses are omitted).
+type HnswIndexOptions struct {
+	Distance   HnswDistanceType
+	VectorType MTreeVectorType
+	EFC        int
+	M          int
+}
+
+// HnswIndex builds an HNSW IndexDefinition.
+func HnswIndex(name, column string, dimension int, opts HnswIndexOptions) IndexDefinition {
+	if opts.Distance == "" {
+		opts.Distance = HnswDistanceEuclidean
+	}
+	if opts.VectorType == "" {
+		opts.VectorType = MTreeVectorF64
+	}
+	return IndexDefinition{
+		Name:         name,
+		Columns:      []string{column},
+		Type:         IndexTypeHNSW,
+		Dimension:    dimension,
+		VectorType:   opts.VectorType,
+		HnswDistance: opts.Distance,
+		EFC:          opts.EFC,
+		M:            opts.M,
+	}
+}
+
+// Validate verifies structural invariants of the index definition.
+func (i IndexDefinition) Validate() error {
+	if i.Name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "index name cannot be empty")
+	}
+	if !i.Type.IsValid() {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"invalid index type %q for index %q", string(i.Type), i.Name)
+	}
+	if len(i.Columns) == 0 {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"index %q requires at least one column", i.Name)
+	}
+	for _, col := range i.Columns {
+		if col == "" {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"index %q has an empty column name", i.Name)
+		}
+	}
+
+	switch i.Type {
+	case IndexTypeMTree:
+		if i.Dimension <= 0 {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"MTREE index %q requires a positive dimension", i.Name)
+		}
+		if i.Distance != "" && !i.Distance.IsValid() {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"MTREE index %q has invalid distance %q", i.Name, string(i.Distance))
+		}
+		if i.VectorType != "" && !i.VectorType.IsValid() {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"MTREE index %q has invalid vector type %q", i.Name, string(i.VectorType))
+		}
+	case IndexTypeHNSW:
+		if i.Dimension <= 0 {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"HNSW index %q requires a positive dimension", i.Name)
+		}
+		if i.HnswDistance != "" && !i.HnswDistance.IsValid() {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"HNSW index %q has invalid distance %q", i.Name, string(i.HnswDistance))
+		}
+		if i.VectorType != "" && !i.VectorType.IsValid() {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"HNSW index %q has invalid vector type %q", i.Name, string(i.VectorType))
+		}
+	}
+	return nil
+}
+
+// ToSurql emits the DEFINE INDEX statement for this index on tableName.
+func (i IndexDefinition) ToSurql(tableName string) string {
+	return i.toSurql(tableName, false)
+}
+
+// ToSurqlIfNotExists emits the DEFINE INDEX statement with IF NOT EXISTS.
+func (i IndexDefinition) ToSurqlIfNotExists(tableName string) string {
+	return i.toSurql(tableName, true)
+}
+
+func (i IndexDefinition) toSurql(tableName string, ifNotExists bool) string {
+	var b strings.Builder
+	b.WriteString("DEFINE INDEX")
+	if ifNotExists {
+		b.WriteString(" IF NOT EXISTS")
+	}
+	b.WriteString(" ")
+	b.WriteString(i.Name)
+	b.WriteString(" ON TABLE ")
+	b.WriteString(tableName)
+
+	switch i.Type {
+	case IndexTypeMTree:
+		field := ""
+		if len(i.Columns) > 0 {
+			field = i.Columns[0]
+		}
+		b.WriteString(" COLUMNS ")
+		b.WriteString(field)
+		b.WriteString(" MTREE DIMENSION ")
+		b.WriteString(strconv.Itoa(i.Dimension))
+		if i.Distance != "" {
+			b.WriteString(" DIST ")
+			b.WriteString(string(i.Distance))
+		}
+		if i.VectorType != "" {
+			b.WriteString(" TYPE ")
+			b.WriteString(string(i.VectorType))
+		}
+		b.WriteString(";")
+		return b.String()
+
+	case IndexTypeHNSW:
+		field := ""
+		if len(i.Columns) > 0 {
+			field = i.Columns[0]
+		}
+		b.WriteString(" COLUMNS ")
+		b.WriteString(field)
+		b.WriteString(" HNSW DIMENSION ")
+		b.WriteString(strconv.Itoa(i.Dimension))
+		if i.HnswDistance != "" {
+			b.WriteString(" DIST ")
+			b.WriteString(string(i.HnswDistance))
+		}
+		if i.VectorType != "" {
+			b.WriteString(" TYPE ")
+			b.WriteString(string(i.VectorType))
+		}
+		if i.EFC > 0 {
+			b.WriteString(" EFC ")
+			b.WriteString(strconv.Itoa(i.EFC))
+		}
+		if i.M > 0 {
+			b.WriteString(" M ")
+			b.WriteString(strconv.Itoa(i.M))
+		}
+		b.WriteString(";")
+		return b.String()
+	}
+
+	b.WriteString(" COLUMNS ")
+	b.WriteString(strings.Join(i.Columns, ", "))
+
+	switch i.Type {
+	case IndexTypeUnique:
+		b.WriteString(" UNIQUE")
+	case IndexTypeSearch:
+		b.WriteString(" SEARCH ANALYZER ascii")
+	}
+
+	b.WriteString(";")
+	return b.String()
+}
+
+// NewEvent builds an EventDefinition.
+func NewEvent(name, condition, action string) EventDefinition {
+	return EventDefinition{Name: name, Condition: condition, Action: action}
+}
+
+// Validate ensures the event has a non-empty name, condition, and action.
+func (e EventDefinition) Validate() error {
+	if e.Name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "event name cannot be empty")
+	}
+	if e.Condition == "" {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"event %q requires a non-empty condition", e.Name)
+	}
+	if e.Action == "" {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"event %q requires a non-empty action", e.Name)
+	}
+	return nil
+}
+
+// ToSurql emits the DEFINE EVENT statement for this event on tableName.
+func (e EventDefinition) ToSurql(tableName string) string {
+	return e.toSurql(tableName, false)
+}
+
+// ToSurqlIfNotExists emits the DEFINE EVENT statement with IF NOT EXISTS.
+func (e EventDefinition) ToSurqlIfNotExists(tableName string) string {
+	return e.toSurql(tableName, true)
+}
+
+func (e EventDefinition) toSurql(tableName string, ifNotExists bool) string {
+	var b strings.Builder
+	b.WriteString("DEFINE EVENT")
+	if ifNotExists {
+		b.WriteString(" IF NOT EXISTS")
+	}
+	b.WriteString(" ")
+	b.WriteString(e.Name)
+	b.WriteString(" ON TABLE ")
+	b.WriteString(tableName)
+	b.WriteString(" WHEN ")
+	b.WriteString(e.Condition)
+	b.WriteString(" THEN ")
+	b.WriteString(e.Action)
+	b.WriteString(";")
+	return b.String()
+}

--- a/pkg/surql/schema/table_test.go
+++ b/pkg/surql/schema/table_test.go
@@ -1,0 +1,487 @@
+package schema
+
+import (
+	stdErrors "errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestTableMode_IsValid(t *testing.T) {
+	for _, m := range []TableMode{TableModeSchemafull, TableModeSchemaless, TableModeDrop} {
+		if !m.IsValid() {
+			t.Errorf("%q should be valid", string(m))
+		}
+	}
+	if TableMode("bogus").IsValid() {
+		t.Error("bogus mode should not be valid")
+	}
+}
+
+func TestNewTable_DefaultMode(t *testing.T) {
+	t1 := NewTable("user")
+	if t1.Mode != TableModeSchemafull {
+		t.Errorf("default mode = %q, want SCHEMAFULL", string(t1.Mode))
+	}
+}
+
+func TestTableToSurql_Schemafull(t *testing.T) {
+	tbl := NewTable("user", WithMode(TableModeSchemafull))
+	got := tbl.ToSurql()
+	want := "DEFINE TABLE user SCHEMAFULL;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestTableToSurql_Schemaless(t *testing.T) {
+	tbl := NewTable("log", WithMode(TableModeSchemaless))
+	got := tbl.ToSurql()
+	want := "DEFINE TABLE log SCHEMALESS;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestTableToSurql_Drop(t *testing.T) {
+	tbl := NewTable("temp", WithMode(TableModeDrop))
+	got := tbl.ToSurql()
+	want := "DEFINE TABLE temp DROP;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestTableToSurqlIfNotExists(t *testing.T) {
+	tbl := NewTable("user", WithMode(TableModeSchemafull))
+	got := tbl.ToSurqlIfNotExists()
+	want := "DEFINE TABLE IF NOT EXISTS user SCHEMAFULL;"
+	if got != want {
+		t.Errorf("ToSurqlIfNotExists() = %q, want %q", got, want)
+	}
+}
+
+func TestTableStatements_Minimal(t *testing.T) {
+	tbl := NewTable("empty")
+	stmts := tbl.ToSurqlStatements()
+	if len(stmts) != 1 {
+		t.Fatalf("len(stmts) = %d, want 1", len(stmts))
+	}
+	if !strings.HasPrefix(stmts[0], "DEFINE TABLE") {
+		t.Errorf("first stmt = %q", stmts[0])
+	}
+}
+
+func TestTableStatements_WithFields(t *testing.T) {
+	tbl := NewTable("user",
+		WithFields(StringField("name"), IntField("age")),
+	)
+	stmts := tbl.ToSurqlStatements()
+	if len(stmts) != 3 {
+		t.Fatalf("len(stmts) = %d, want 3", len(stmts))
+	}
+	if !strings.HasPrefix(stmts[0], "DEFINE TABLE user") {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+	if stmts[1] != "DEFINE FIELD name ON TABLE user TYPE string;" {
+		t.Errorf("stmts[1] = %q", stmts[1])
+	}
+	if stmts[2] != "DEFINE FIELD age ON TABLE user TYPE int;" {
+		t.Errorf("stmts[2] = %q", stmts[2])
+	}
+}
+
+func TestTableStatements_WithAssertion(t *testing.T) {
+	tbl := NewTable("user",
+		WithFields(StringField("email", WithAssertion("string::is::email($value)"))),
+	)
+	stmts := tbl.ToSurqlStatements()
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "ASSERT string::is::email($value)") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected ASSERT clause in statements: %v", stmts)
+	}
+}
+
+func TestTableStatements_WithDefault(t *testing.T) {
+	tbl := NewTable("event",
+		WithFields(DatetimeField("created_at", WithDefault("time::now()"))),
+	)
+	stmts := tbl.ToSurqlStatements()
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "DEFAULT time::now()") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected DEFAULT clause: %v", stmts)
+	}
+}
+
+func TestTableStatements_WithReadonly(t *testing.T) {
+	tbl := NewTable("event",
+		WithFields(DatetimeField("created_at", WithReadOnly(true))),
+	)
+	stmts := tbl.ToSurqlStatements()
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "READONLY") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected READONLY clause: %v", stmts)
+	}
+}
+
+func TestTableStatements_WithUniqueIndex(t *testing.T) {
+	tbl := NewTable("user",
+		WithIndexes(UniqueIndex("email_idx", []string{"email"})),
+	)
+	stmts := tbl.ToSurqlStatements()
+	found := false
+	for _, s := range stmts {
+		if s == "DEFINE INDEX email_idx ON TABLE user COLUMNS email UNIQUE;" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected unique index statement: %v", stmts)
+	}
+}
+
+func TestTableStatements_WithStandardIndex(t *testing.T) {
+	tbl := NewTable("post",
+		WithIndexes(NewIndex("title_idx", []string{"title"}, IndexTypeStandard)),
+	)
+	stmts := tbl.ToSurqlStatements()
+	found := false
+	for _, s := range stmts {
+		if s == "DEFINE INDEX title_idx ON TABLE post COLUMNS title;" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected standard index statement: %v", stmts)
+	}
+}
+
+func TestTableStatements_WithSearchIndex(t *testing.T) {
+	tbl := NewTable("post",
+		WithIndexes(SearchIndex("content_search", []string{"title", "content"})),
+	)
+	stmts := tbl.ToSurqlStatements()
+	found := false
+	for _, s := range stmts {
+		if s == "DEFINE INDEX content_search ON TABLE post COLUMNS title, content SEARCH ANALYZER ascii;" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected search index statement: %v", stmts)
+	}
+}
+
+func TestTableStatements_WithEvent(t *testing.T) {
+	tbl := NewTable("user",
+		WithEvents(NewEvent(
+			"email_changed",
+			"$before.email != $after.email",
+			"CREATE audit_log SET user = $value.id",
+		)),
+	)
+	stmts := tbl.ToSurqlStatements()
+	want := "DEFINE EVENT email_changed ON TABLE user WHEN $before.email != $after.email THEN CREATE audit_log SET user = $value.id;"
+	found := false
+	for _, s := range stmts {
+		if s == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected event statement %q, got %v", want, stmts)
+	}
+}
+
+func TestTableStatements_WithPermissions(t *testing.T) {
+	tbl := NewTable("user",
+		WithTablePermissions(map[string]string{"select": "$auth.id = id"}),
+	)
+	stmts := tbl.ToSurqlStatements()
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "FOR SELECT") && strings.Contains(s, "$auth.id = id") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected permissions statement: %v", stmts)
+	}
+}
+
+func TestTableStatements_IfNotExists(t *testing.T) {
+	tbl := NewTable("user",
+		WithMode(TableModeSchemafull),
+		WithFields(StringField("name")),
+		WithIndexes(UniqueIndex("email_idx", []string{"email"})),
+		WithEvents(NewEvent("e", "$cond", "DO")),
+	)
+	stmts := tbl.ToSurqlStatementsIfNotExists()
+	if stmts[0] != "DEFINE TABLE IF NOT EXISTS user SCHEMAFULL;" {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+	found := 0
+	for _, s := range stmts {
+		if strings.Contains(s, "DEFINE FIELD IF NOT EXISTS name") {
+			found++
+		}
+		if strings.Contains(s, "DEFINE INDEX IF NOT EXISTS email_idx") {
+			found++
+		}
+		if strings.Contains(s, "DEFINE EVENT IF NOT EXISTS e") {
+			found++
+		}
+	}
+	if found != 3 {
+		t.Errorf("expected 3 IF NOT EXISTS matches, got %d: %v", found, stmts)
+	}
+}
+
+func TestTableStatements_DefaultOmitsIfNotExists(t *testing.T) {
+	tbl := NewTable("user",
+		WithFields(StringField("name")),
+		WithIndexes(UniqueIndex("email_idx", []string{"email"})),
+		WithEvents(NewEvent("e", "$cond", "DO")),
+	)
+	stmts := tbl.ToSurqlStatements()
+	for _, s := range stmts {
+		if strings.Contains(s, "IF NOT EXISTS") {
+			t.Errorf("unexpected IF NOT EXISTS in %q", s)
+		}
+	}
+}
+
+func TestIndexType_IsValid(t *testing.T) {
+	for _, ty := range []IndexType{
+		IndexTypeStandard, IndexTypeUnique, IndexTypeSearch,
+		IndexTypeMTree, IndexTypeHNSW,
+	} {
+		if !ty.IsValid() {
+			t.Errorf("%q should be valid", string(ty))
+		}
+	}
+	if IndexType("X").IsValid() {
+		t.Error("bogus IndexType")
+	}
+}
+
+func TestMTreeDistance_Values(t *testing.T) {
+	for _, v := range []MTreeDistanceType{
+		MTreeDistanceCosine, MTreeDistanceEuclidean,
+		MTreeDistanceManhattan, MTreeDistanceMinkowski,
+	} {
+		if !v.IsValid() {
+			t.Errorf("MTree distance %q should be valid", string(v))
+		}
+	}
+	if MTreeDistanceType("X").IsValid() {
+		t.Error("bogus MTree distance")
+	}
+}
+
+func TestHnswDistance_Values(t *testing.T) {
+	for _, v := range []HnswDistanceType{
+		HnswDistanceChebyshev, HnswDistanceCosine, HnswDistanceEuclidean,
+		HnswDistanceHamming, HnswDistanceJaccard, HnswDistanceManhattan,
+		HnswDistanceMinkowski, HnswDistancePearson,
+	} {
+		if !v.IsValid() {
+			t.Errorf("Hnsw distance %q should be valid", string(v))
+		}
+	}
+}
+
+func TestVectorType_Values(t *testing.T) {
+	for _, v := range []MTreeVectorType{
+		MTreeVectorF64, MTreeVectorF32, MTreeVectorI64, MTreeVectorI32, MTreeVectorI16,
+	} {
+		if !v.IsValid() {
+			t.Errorf("vector type %q should be valid", string(v))
+		}
+	}
+}
+
+func TestMTreeIndex_ToSurql(t *testing.T) {
+	idx := MTreeIndex("embedding_idx", "embedding", 1536, MTreeIndexOptions{
+		Distance:   MTreeDistanceCosine,
+		VectorType: MTreeVectorF32,
+	})
+	got := idx.ToSurql("doc")
+	want := "DEFINE INDEX embedding_idx ON TABLE doc COLUMNS embedding MTREE DIMENSION 1536 DIST COSINE TYPE F32;"
+	if got != want {
+		t.Errorf("ToSurql = %q, want %q", got, want)
+	}
+}
+
+func TestMTreeIndex_Defaults(t *testing.T) {
+	idx := MTreeIndex("e", "v", 8, MTreeIndexOptions{})
+	got := idx.ToSurql("t")
+	if !strings.Contains(got, "DIST EUCLIDEAN") {
+		t.Errorf("default distance missing: %q", got)
+	}
+	if !strings.Contains(got, "TYPE F64") {
+		t.Errorf("default vector type missing: %q", got)
+	}
+}
+
+func TestHnswIndex_ToSurql(t *testing.T) {
+	idx := HnswIndex("embedding_idx", "embedding", 1536, HnswIndexOptions{
+		Distance:   HnswDistanceCosine,
+		VectorType: MTreeVectorF32,
+		EFC:        150,
+		M:          12,
+	})
+	got := idx.ToSurql("doc")
+	want := "DEFINE INDEX embedding_idx ON TABLE doc COLUMNS embedding HNSW DIMENSION 1536 DIST COSINE TYPE F32 EFC 150 M 12;"
+	if got != want {
+		t.Errorf("ToSurql = %q, want %q", got, want)
+	}
+}
+
+func TestHnswIndex_OmitsEFCAndMWhenZero(t *testing.T) {
+	idx := HnswIndex("e", "v", 8, HnswIndexOptions{})
+	got := idx.ToSurql("t")
+	if strings.Contains(got, "EFC") {
+		t.Errorf("unexpected EFC clause: %q", got)
+	}
+	if strings.Contains(got, " M ") {
+		t.Errorf("unexpected M clause: %q", got)
+	}
+}
+
+func TestIndexToSurql_UniqueAndStandard(t *testing.T) {
+	u := UniqueIndex("u", []string{"email"})
+	if g := u.ToSurql("user"); g != "DEFINE INDEX u ON TABLE user COLUMNS email UNIQUE;" {
+		t.Errorf("unique = %q", g)
+	}
+	s := NewIndex("t", []string{"title"}, IndexTypeStandard)
+	if g := s.ToSurql("post"); g != "DEFINE INDEX t ON TABLE post COLUMNS title;" {
+		t.Errorf("standard = %q", g)
+	}
+}
+
+func TestIndexValidate_Empty(t *testing.T) {
+	cases := []IndexDefinition{
+		{Name: "", Columns: []string{"x"}, Type: IndexTypeUnique},
+		{Name: "n", Columns: []string{}, Type: IndexTypeUnique},
+		{Name: "n", Columns: []string{""}, Type: IndexTypeUnique},
+		{Name: "n", Columns: []string{"x"}, Type: IndexType("bogus")},
+	}
+	for i, idx := range cases {
+		err := idx.Validate()
+		if err == nil {
+			t.Errorf("case %d: Validate() returned nil", i)
+			continue
+		}
+		if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+			t.Errorf("case %d: err = %v", i, err)
+		}
+	}
+}
+
+func TestIndexValidate_MTreeDimension(t *testing.T) {
+	idx := IndexDefinition{Name: "n", Columns: []string{"v"}, Type: IndexTypeMTree, Dimension: 0}
+	if err := idx.Validate(); err == nil {
+		t.Error("MTREE with dimension 0 should fail")
+	}
+}
+
+func TestIndexValidate_HnswDimension(t *testing.T) {
+	idx := IndexDefinition{Name: "n", Columns: []string{"v"}, Type: IndexTypeHNSW, Dimension: 0}
+	if err := idx.Validate(); err == nil {
+		t.Error("HNSW with dimension 0 should fail")
+	}
+}
+
+func TestEventToSurql(t *testing.T) {
+	e := NewEvent("audit", "$before != $after", "CREATE log")
+	got := e.ToSurql("user")
+	want := "DEFINE EVENT audit ON TABLE user WHEN $before != $after THEN CREATE log;"
+	if got != want {
+		t.Errorf("ToSurql() = %q, want %q", got, want)
+	}
+}
+
+func TestEventValidate(t *testing.T) {
+	cases := []EventDefinition{
+		{Name: "", Condition: "c", Action: "a"},
+		{Name: "n", Condition: "", Action: "a"},
+		{Name: "n", Condition: "c", Action: ""},
+	}
+	for _, e := range cases {
+		if err := e.Validate(); err == nil {
+			t.Errorf("expected error for %+v", e)
+		}
+	}
+	ok := NewEvent("n", "c", "a")
+	if err := ok.Validate(); err != nil {
+		t.Errorf("valid event errored: %v", err)
+	}
+}
+
+func TestTableValidate_EmptyName(t *testing.T) {
+	tbl := NewTable("")
+	if err := tbl.Validate(); err == nil {
+		t.Error("empty name should fail")
+	}
+}
+
+func TestTableValidate_InvalidMode(t *testing.T) {
+	tbl := TableDefinition{Name: "t", Mode: TableMode("bogus")}
+	if err := tbl.Validate(); err == nil {
+		t.Error("invalid mode should fail")
+	}
+}
+
+func TestTableValidate_PropagatesField(t *testing.T) {
+	tbl := NewTable("t", WithFields(NewField("1bad", FieldTypeString)))
+	err := tbl.Validate()
+	if err == nil {
+		t.Fatal("expected validation error from field")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestTablePermissions_MapCopyIsolation(t *testing.T) {
+	perms := map[string]string{"select": "$auth.id = id"}
+	tbl := NewTable("t", WithTablePermissions(perms))
+	perms["select"] = "MUTATED"
+	if tbl.Permissions["select"] != "$auth.id = id" {
+		t.Errorf("expected copied map; got %q", tbl.Permissions["select"])
+	}
+}
+
+func TestTableStatements_StatementOrder(t *testing.T) {
+	tbl := NewTable("user",
+		WithFields(StringField("name")),
+		WithIndexes(UniqueIndex("name_idx", []string{"name"})),
+	)
+	stmts := tbl.ToSurqlStatements()
+	if !strings.HasPrefix(stmts[0], "DEFINE TABLE") {
+		t.Errorf("stmts[0] = %q", stmts[0])
+	}
+	if !strings.HasPrefix(stmts[1], "DEFINE FIELD") {
+		t.Errorf("stmts[1] = %q", stmts[1])
+	}
+	if !strings.HasPrefix(stmts[2], "DEFINE INDEX") {
+		t.Errorf("stmts[2] = %q", stmts[2])
+	}
+}

--- a/pkg/surql/schema/themes.go
+++ b/pkg/surql/schema/themes.go
@@ -1,0 +1,350 @@
+package schema
+
+import (
+	"sort"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// ColorScheme is the base color palette used across visualization themes.
+// All colors are hex color codes (e.g. "#6366f1").
+type ColorScheme struct {
+	Primary    string
+	Secondary  string
+	Background string
+	Text       string
+	Accent     string
+	Success    string
+	Warning    string
+	Error      string
+	Muted      string
+}
+
+// GraphVizTheme controls visual aspects of GraphViz DOT output: node and edge
+// styling, layout, and advanced features like gradients and clustering.
+type GraphVizTheme struct {
+	NodeColor    string
+	EdgeColor    string
+	BgColor      string // use "transparent" for none
+	FontName     string
+	NodeShape    string // e.g. "record", "box"
+	NodeStyle    string // e.g. "filled,rounded"
+	EdgeStyle    string // e.g. "solid", "dashed"
+	UseGradients bool
+	UseClusters  bool
+}
+
+// MermaidTheme controls Mermaid ER diagram appearance via Mermaid's theming
+// system. Supports both built-in themes and custom CSS variables.
+type MermaidTheme struct {
+	ThemeName      string // one of "default", "dark", "forest", "neutral", "base"
+	PrimaryColor   string
+	SecondaryColor string
+	UseCustomCSS   bool
+}
+
+// ASCIITheme controls ASCII diagram rendering including box drawing
+// characters, ANSI colors, and Unicode icons.
+type ASCIITheme struct {
+	BoxStyle    string // one of "single", "double", "rounded", "heavy"
+	UseUnicode  bool
+	UseColors   bool
+	UseIcons    bool
+	ColorScheme string
+}
+
+// Theme bundles a color scheme with format-specific configurations into a
+// coherent visual design.
+type Theme struct {
+	Name        string
+	Description string
+	Colors      ColorScheme
+	GraphViz    GraphVizTheme
+	Mermaid     MermaidTheme
+	ASCII       ASCIITheme
+}
+
+// ModernColorScheme returns the clean professional palette used by the
+// "modern" preset (indigo primary, pink secondary, slate backgrounds).
+func ModernColorScheme() ColorScheme {
+	return ColorScheme{
+		Primary:    "#6366f1",
+		Secondary:  "#ec4899",
+		Background: "#f8fafc",
+		Text:       "#0f172a",
+		Accent:     "#8b5cf6",
+		Success:    "#10b981",
+		Warning:    "#f59e0b",
+		Error:      "#ef4444",
+		Muted:      "#94a3b8",
+	}
+}
+
+// DarkColorScheme returns the dark-mode palette (violet primary, fuchsia
+// secondary, indigo-950 background).
+func DarkColorScheme() ColorScheme {
+	return ColorScheme{
+		Primary:    "#8b5cf6",
+		Secondary:  "#d946ef",
+		Background: "#1e1b4b",
+		Text:       "#f1f5f9",
+		Accent:     "#a78bfa",
+		Success:    "#34d399",
+		Warning:    "#fbbf24",
+		Error:      "#f87171",
+		Muted:      "#64748b",
+	}
+}
+
+// ForestColorScheme returns the nature-inspired palette (emerald primary,
+// teal secondary, green-50 background).
+func ForestColorScheme() ColorScheme {
+	return ColorScheme{
+		Primary:    "#10b981",
+		Secondary:  "#14b8a6",
+		Background: "#f0fdf4",
+		Text:       "#14532d",
+		Accent:     "#059669",
+		Success:    "#22c55e",
+		Warning:    "#f59e0b",
+		Error:      "#ef4444",
+		Muted:      "#86efac",
+	}
+}
+
+// MinimalColorScheme returns the grayscale palette used by the "minimal"
+// preset.
+func MinimalColorScheme() ColorScheme {
+	return ColorScheme{
+		Primary:    "#6b7280",
+		Secondary:  "#64748b",
+		Background: "#ffffff",
+		Text:       "#1f2937",
+		Accent:     "#9ca3af",
+		Success:    "#10b981",
+		Warning:    "#f59e0b",
+		Error:      "#ef4444",
+		Muted:      "#d1d5db",
+	}
+}
+
+// ModernGraphVizTheme returns the GraphViz styling for the "modern" preset.
+func ModernGraphVizTheme() GraphVizTheme {
+	return GraphVizTheme{
+		NodeColor:    "#6366f1",
+		EdgeColor:    "#64748b",
+		BgColor:      "transparent",
+		FontName:     "Arial",
+		NodeShape:    "record",
+		NodeStyle:    "filled,rounded",
+		EdgeStyle:    "solid",
+		UseGradients: true,
+		UseClusters:  false,
+	}
+}
+
+// DarkGraphVizTheme returns the GraphViz styling for the "dark" preset.
+func DarkGraphVizTheme() GraphVizTheme {
+	return GraphVizTheme{
+		NodeColor:    "#8b5cf6",
+		EdgeColor:    "#64748b",
+		BgColor:      "#1e1b4b",
+		FontName:     "Arial",
+		NodeShape:    "record",
+		NodeStyle:    "filled,rounded",
+		EdgeStyle:    "solid",
+		UseGradients: true,
+		UseClusters:  false,
+	}
+}
+
+// ForestGraphVizTheme returns the GraphViz styling for the "forest" preset.
+func ForestGraphVizTheme() GraphVizTheme {
+	return GraphVizTheme{
+		NodeColor:    "#10b981",
+		EdgeColor:    "#059669",
+		BgColor:      "transparent",
+		FontName:     "Arial",
+		NodeShape:    "record",
+		NodeStyle:    "filled,rounded",
+		EdgeStyle:    "solid",
+		UseGradients: true,
+		UseClusters:  false,
+	}
+}
+
+// MinimalGraphVizTheme returns the GraphViz styling for the "minimal" preset.
+func MinimalGraphVizTheme() GraphVizTheme {
+	return GraphVizTheme{
+		NodeColor:    "#6b7280",
+		EdgeColor:    "#9ca3af",
+		BgColor:      "transparent",
+		FontName:     "Arial",
+		NodeShape:    "record",
+		NodeStyle:    "filled",
+		EdgeStyle:    "solid",
+		UseGradients: false,
+		UseClusters:  false,
+	}
+}
+
+// ModernMermaidTheme returns the Mermaid styling for the "modern" preset.
+func ModernMermaidTheme() MermaidTheme {
+	return MermaidTheme{
+		ThemeName:      "default",
+		PrimaryColor:   "#6366f1",
+		SecondaryColor: "#ec4899",
+		UseCustomCSS:   true,
+	}
+}
+
+// DarkMermaidTheme returns the Mermaid styling for the "dark" preset.
+func DarkMermaidTheme() MermaidTheme {
+	return MermaidTheme{
+		ThemeName:      "dark",
+		PrimaryColor:   "#8b5cf6",
+		SecondaryColor: "#d946ef",
+		UseCustomCSS:   true,
+	}
+}
+
+// ForestMermaidTheme returns the Mermaid styling for the "forest" preset.
+func ForestMermaidTheme() MermaidTheme {
+	return MermaidTheme{
+		ThemeName:      "forest",
+		PrimaryColor:   "#10b981",
+		SecondaryColor: "#14b8a6",
+		UseCustomCSS:   true,
+	}
+}
+
+// MinimalMermaidTheme returns the Mermaid styling for the "minimal" preset.
+func MinimalMermaidTheme() MermaidTheme {
+	return MermaidTheme{
+		ThemeName:      "neutral",
+		PrimaryColor:   "#6b7280",
+		SecondaryColor: "#64748b",
+		UseCustomCSS:   true,
+	}
+}
+
+// ModernASCIITheme returns the ASCII styling for the "modern" preset
+// (rounded unicode boxes, colors, and icons enabled).
+func ModernASCIITheme() ASCIITheme {
+	return ASCIITheme{
+		BoxStyle:    "rounded",
+		UseUnicode:  true,
+		UseColors:   true,
+		UseIcons:    true,
+		ColorScheme: "default",
+	}
+}
+
+// DarkASCIITheme returns the ASCII styling for the "dark" preset.
+func DarkASCIITheme() ASCIITheme {
+	return ASCIITheme{
+		BoxStyle:    "rounded",
+		UseUnicode:  true,
+		UseColors:   true,
+		UseIcons:    true,
+		ColorScheme: "dark",
+	}
+}
+
+// ForestASCIITheme returns the ASCII styling for the "forest" preset.
+func ForestASCIITheme() ASCIITheme {
+	return ASCIITheme{
+		BoxStyle:    "rounded",
+		UseUnicode:  true,
+		UseColors:   true,
+		UseIcons:    true,
+		ColorScheme: "forest",
+	}
+}
+
+// MinimalASCIITheme returns the ASCII styling for the "minimal" preset
+// (single-line boxes, no colors, no icons).
+func MinimalASCIITheme() ASCIITheme {
+	return ASCIITheme{
+		BoxStyle:    "single",
+		UseUnicode:  true,
+		UseColors:   false,
+		UseIcons:    false,
+		ColorScheme: "minimal",
+	}
+}
+
+// ModernTheme returns the "modern" bundled theme.
+func ModernTheme() Theme {
+	return Theme{
+		Name:        "modern",
+		Description: "Clean, professional design with indigo and pink accents",
+		Colors:      ModernColorScheme(),
+		GraphViz:    ModernGraphVizTheme(),
+		Mermaid:     ModernMermaidTheme(),
+		ASCII:       ModernASCIITheme(),
+	}
+}
+
+// DarkTheme returns the "dark" bundled theme.
+func DarkTheme() Theme {
+	return Theme{
+		Name:        "dark",
+		Description: "Dark background theme with violet and fuchsia for dark mode environments",
+		Colors:      DarkColorScheme(),
+		GraphViz:    DarkGraphVizTheme(),
+		Mermaid:     DarkMermaidTheme(),
+		ASCII:       DarkASCIITheme(),
+	}
+}
+
+// ForestTheme returns the "forest" bundled theme.
+func ForestTheme() Theme {
+	return Theme{
+		Name:        "forest",
+		Description: "Nature-inspired theme with emerald and teal on light green background",
+		Colors:      ForestColorScheme(),
+		GraphViz:    ForestGraphVizTheme(),
+		Mermaid:     ForestMermaidTheme(),
+		ASCII:       ForestASCIITheme(),
+	}
+}
+
+// MinimalTheme returns the "minimal" bundled theme.
+func MinimalTheme() Theme {
+	return Theme{
+		Name:        "minimal",
+		Description: "Minimalist grayscale theme with subtle styling",
+		Colors:      MinimalColorScheme(),
+		GraphViz:    MinimalGraphVizTheme(),
+		Mermaid:     MinimalMermaidTheme(),
+		ASCII:       MinimalASCIITheme(),
+	}
+}
+
+// GetTheme returns a preset theme by name. Recognised names are "modern",
+// "dark", "forest", and "minimal". Unknown names return a wrapped
+// ErrValidation.
+func GetTheme(name string) (Theme, error) {
+	switch name {
+	case "modern":
+		return ModernTheme(), nil
+	case "dark":
+		return DarkTheme(), nil
+	case "forest":
+		return ForestTheme(), nil
+	case "minimal":
+		return MinimalTheme(), nil
+	}
+	available := ListThemes()
+	return Theme{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+		"unknown theme %q. Available themes: %v", name, available)
+}
+
+// ListThemes returns the names of every built-in preset, sorted
+// alphabetically.
+func ListThemes() []string {
+	names := []string{"dark", "forest", "minimal", "modern"}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/surql/schema/utils.go
+++ b/pkg/surql/schema/utils.go
@@ -1,0 +1,219 @@
+package schema
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ansiEscapePattern matches ANSI CSI escape sequences so that display-width
+// calculations ignore color codes.
+var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// displayWidth returns the approximate terminal column width of text,
+// stripping ANSI escape codes and counting East Asian Wide / Fullwidth
+// characters as two columns. Emoji fall into the Wide category on most
+// terminals.
+func displayWidth(text string) int {
+	stripped := ansiEscapePattern.ReplaceAllString(text, "")
+	width := 0
+	for _, r := range stripped {
+		if r < 0x20 {
+			continue
+		}
+		if isWideRune(r) {
+			width += 2
+			continue
+		}
+		width++
+	}
+	return width
+}
+
+// isWideRune reports whether r occupies two terminal columns. Implemented as
+// a conservative range table covering the CJK, Fullwidth, emoji, and
+// Miscellaneous Symbols and Pictographs blocks used by the emoji icons
+// produced by the visualizer.
+func isWideRune(r rune) bool {
+	if r < 0x1100 {
+		return false
+	}
+	switch {
+	case r >= 0x1100 && r <= 0x115F: // Hangul Jamo
+		return true
+	case r >= 0x2E80 && r <= 0x303E: // CJK Radicals Supplement, Kangxi
+		return true
+	case r >= 0x3041 && r <= 0x33FF: // Hiragana through CJK Compatibility
+		return true
+	case r >= 0x3400 && r <= 0x4DBF: // CJK Unified Ideographs Extension A
+		return true
+	case r >= 0x4E00 && r <= 0x9FFF: // CJK Unified Ideographs
+		return true
+	case r >= 0xA000 && r <= 0xA4CF: // Yi Syllables
+		return true
+	case r >= 0xAC00 && r <= 0xD7A3: // Hangul Syllables
+		return true
+	case r >= 0xF900 && r <= 0xFAFF: // CJK Compatibility Ideographs
+		return true
+	case r >= 0xFE30 && r <= 0xFE4F: // CJK Compatibility Forms
+		return true
+	case r >= 0xFF00 && r <= 0xFF60: // Fullwidth Forms
+		return true
+	case r >= 0xFFE0 && r <= 0xFFE6: // Fullwidth Signs
+		return true
+	case r >= 0x1F300 && r <= 0x1F64F: // Misc Symbols and Pictographs + Emoticons
+		return true
+	case r >= 0x1F680 && r <= 0x1F6FF: // Transport and Map Symbols
+		return true
+	case r >= 0x1F900 && r <= 0x1F9FF: // Supplemental Symbols and Pictographs
+		return true
+	case r >= 0x1FA70 && r <= 0x1FAFF: // Symbols and Pictographs Extended-A
+		return true
+	case r >= 0x20000 && r <= 0x2FFFD: // CJK Unified Ideographs Extension B-F
+		return true
+	case r >= 0x30000 && r <= 0x3FFFD: // CJK Unified Ideographs Extension G
+		return true
+	}
+	return false
+}
+
+// fieldConstraint returns the constraint suffix (PK, FK, UK) that should be
+// displayed next to a field in diagrams. An empty string means the field has
+// no constraint.
+//
+// The rules mirror surql-py: "id" is always PK; a field that appears alone in
+// a unique index is UK; a FieldTypeRecord field is FK.
+func fieldConstraint(fieldName string, table TableDefinition) string {
+	if fieldName == "id" {
+		return "PK"
+	}
+	for _, idx := range table.Indexes {
+		if idx.Type != IndexTypeUnique {
+			continue
+		}
+		for _, col := range idx.Columns {
+			if col == fieldName {
+				return "UK"
+			}
+		}
+	}
+	for _, f := range table.Fields {
+		if f.Name == fieldName && f.Type == FieldTypeRecord {
+			return "FK"
+		}
+	}
+	return ""
+}
+
+// fieldTypeString returns the user-facing string form of a FieldType
+// (currently the enum value as a lowercase keyword).
+func fieldTypeString(t FieldType) string {
+	return string(t)
+}
+
+// centerPad returns text padded with spaces so the visible display-width is
+// width. Padding is split to match Python's str.center, which places the
+// extra space on the LEFT when padding is odd. Text wider than width is
+// returned unchanged.
+func centerPad(text string, width int) (left, right int) {
+	visible := displayWidth(text)
+	if visible >= width {
+		return 0, 0
+	}
+	padding := width - visible
+	right = padding / 2
+	left = padding - right
+	return left, right
+}
+
+// boxChars returns the box drawing characters to use for the supplied ASCII
+// theme. When the theme is the zero value or has UseUnicode disabled, it
+// returns plain ASCII characters.
+func boxChars(theme ASCIITheme) map[string]string {
+	if !theme.UseUnicode {
+		return map[string]string{
+			"tl": "+", "tr": "+", "bl": "+", "br": "+",
+			"h": "-", "v": "|", "ml": "+", "mr": "+",
+		}
+	}
+	switch theme.BoxStyle {
+	case "double":
+		return map[string]string{
+			"tl": "╔", "tr": "╗", "bl": "╚", "br": "╝",
+			"h": "═", "v": "║", "ml": "╠", "mr": "╣",
+		}
+	case "rounded":
+		return map[string]string{
+			"tl": "╭", "tr": "╮", "bl": "╰", "br": "╯",
+			"h": "─", "v": "│", "ml": "├", "mr": "┤",
+		}
+	case "heavy":
+		return map[string]string{
+			"tl": "┏", "tr": "┓", "bl": "┗", "br": "┛",
+			"h": "━", "v": "┃", "ml": "┣", "mr": "┫",
+		}
+	default: // "single" (and anything unknown)
+		return map[string]string{
+			"tl": "┌", "tr": "┐", "bl": "└", "br": "┘",
+			"h": "─", "v": "│", "ml": "├", "mr": "┤",
+		}
+	}
+}
+
+// ansi color codes used when ASCIITheme.UseColors is true.
+const (
+	ansiPK     = "\x1b[91m"
+	ansiFK     = "\x1b[94m"
+	ansiUK     = "\x1b[95m"
+	ansiHeader = "\x1b[1m"
+	ansiReset  = "\x1b[0m"
+)
+
+// colorize wraps text in an ANSI color sequence based on color_type. If the
+// theme disables colors, text is returned unchanged.
+func colorize(theme ASCIITheme, text, colorType string) string {
+	if !theme.UseColors {
+		return text
+	}
+	var code string
+	switch strings.ToLower(colorType) {
+	case "pk":
+		code = ansiPK
+	case "fk":
+		code = ansiFK
+	case "uk":
+		code = ansiUK
+	case "header":
+		code = ansiHeader
+	case "field", "":
+		return text
+	default:
+		return text
+	}
+	return code + text + ansiReset
+}
+
+// constraintIcon returns the unicode icon used next to a constraint label in
+// ASCII diagrams, or an empty string when the theme disables icons.
+func constraintIcon(theme ASCIITheme, constraint string) string {
+	if !theme.UseIcons {
+		return ""
+	}
+	switch constraint {
+	case "PK":
+		return "🔑 "
+	case "FK":
+		return "🔗 "
+	case "UK":
+		return "⭐ "
+	}
+	return ""
+}
+
+// repeatRune returns a string containing n copies of s. It is a convenience
+// helper for building box top/bottom/middle lines.
+func repeatRune(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return strings.Repeat(s, n)
+}

--- a/pkg/surql/schema/validator.go
+++ b/pkg/surql/schema/validator.go
@@ -1,0 +1,1151 @@
+package schema
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// ValidationSeverity enumerates the severity of a ValidationResult.
+type ValidationSeverity string
+
+// Severity values.
+const (
+	// SeverityError indicates a breaking issue requiring remediation.
+	SeverityError ValidationSeverity = "error"
+	// SeverityWarning indicates a non-critical inconsistency.
+	SeverityWarning ValidationSeverity = "warning"
+	// SeverityInfo indicates an informational finding only.
+	SeverityInfo ValidationSeverity = "info"
+)
+
+// IsValid reports whether the severity value is recognised.
+func (s ValidationSeverity) IsValid() bool {
+	switch s {
+	case SeverityError, SeverityWarning, SeverityInfo:
+		return true
+	}
+	return false
+}
+
+// ValidationResult is a single finding produced by the validator.
+type ValidationResult struct {
+	Severity  ValidationSeverity
+	Table     string
+	Field     string
+	Message   string
+	CodeValue string
+	DBValue   string
+}
+
+// String returns a human-readable representation of the result.
+func (r ValidationResult) String() string {
+	var b strings.Builder
+	b.WriteString("[")
+	b.WriteString(strings.ToUpper(string(r.Severity)))
+	b.WriteString("] ")
+	b.WriteString(r.Table)
+	if r.Field != "" {
+		b.WriteString(".")
+		b.WriteString(r.Field)
+	}
+	b.WriteString(": ")
+	b.WriteString(r.Message)
+	if r.CodeValue != "" || r.DBValue != "" {
+		b.WriteString(" (code: ")
+		b.WriteString(r.CodeValue)
+		b.WriteString(", db: ")
+		b.WriteString(r.DBValue)
+		b.WriteString(")")
+	}
+	return b.String()
+}
+
+// ValidationReport aggregates ValidationResults and exposes convenience
+// accessors for downstream tooling (CLI reporters, migration planners).
+type ValidationReport struct {
+	Results []ValidationResult
+}
+
+// NewValidationReport constructs an empty report.
+func NewValidationReport() *ValidationReport {
+	return &ValidationReport{}
+}
+
+// Add appends a single result to the report.
+func (vr *ValidationReport) Add(r ValidationResult) {
+	if vr == nil {
+		return
+	}
+	vr.Results = append(vr.Results, r)
+}
+
+// AddAll appends multiple results to the report.
+func (vr *ValidationReport) AddAll(rs []ValidationResult) {
+	if vr == nil {
+		return
+	}
+	vr.Results = append(vr.Results, rs...)
+}
+
+// Merge appends every result from other into vr. It is a no-op when either
+// report is nil.
+func (vr *ValidationReport) Merge(other *ValidationReport) {
+	if vr == nil || other == nil {
+		return
+	}
+	vr.Results = append(vr.Results, other.Results...)
+}
+
+// Errors returns only ERROR-severity results.
+func (vr *ValidationReport) Errors() []ValidationResult {
+	if vr == nil {
+		return nil
+	}
+	return FilterBySeverity(vr.Results, SeverityError)
+}
+
+// Warnings returns only WARNING-severity results.
+func (vr *ValidationReport) Warnings() []ValidationResult {
+	if vr == nil {
+		return nil
+	}
+	return FilterBySeverity(vr.Results, SeverityWarning)
+}
+
+// Infos returns only INFO-severity results.
+func (vr *ValidationReport) Infos() []ValidationResult {
+	if vr == nil {
+		return nil
+	}
+	return FilterBySeverity(vr.Results, SeverityInfo)
+}
+
+// HasErrors reports whether any ERROR-severity result is present.
+func (vr *ValidationReport) HasErrors() bool {
+	if vr == nil {
+		return false
+	}
+	return HasErrors(vr.Results)
+}
+
+// IsValid is the inverse of HasErrors.
+func (vr *ValidationReport) IsValid() bool {
+	return !vr.HasErrors()
+}
+
+// Len returns the total number of results in the report.
+func (vr *ValidationReport) Len() int {
+	if vr == nil {
+		return 0
+	}
+	return len(vr.Results)
+}
+
+// ValidateSchema performs cross-schema validation over every table, edge, and
+// access definition currently registered in r. It returns a ValidationReport
+// describing every inconsistency. A hard error is returned only when r is nil.
+//
+// The Access parameter is optional and may be supplied via the variadic accesses
+// argument for callers that manage access definitions outside the registry
+// (the current SchemaRegistry tracks tables and edges only).
+func ValidateSchema(r *SchemaRegistry, accesses ...AccessDefinition) (*ValidationReport, error) {
+	if r == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation,
+			"cannot validate schema: registry is nil")
+	}
+
+	report := NewValidationReport()
+	tables := r.Tables()
+	edges := r.Edges()
+
+	// Per-definition structural validation.
+	for _, t := range tables {
+		report.Merge(ValidateTable(t))
+	}
+	for _, e := range edges {
+		report.Merge(ValidateEdge(e))
+	}
+	for _, a := range accesses {
+		report.Merge(ValidateAccess(a))
+	}
+
+	// Cross-definition checks.
+	report.AddAll(detectNameCollisions(tables, edges))
+	report.AddAll(detectRecordFieldTargets(tables, edges))
+	report.AddAll(detectEdgeTableReferences(tables, edges))
+	report.AddAll(detectDuplicateAccessNames(accesses))
+
+	return report, nil
+}
+
+// ValidateTable performs internal consistency checks on a single table
+// definition. It never returns a hard error; every issue is expressed as a
+// ValidationResult so callers can display the full set.
+func ValidateTable(t TableDefinition) *ValidationReport {
+	report := NewValidationReport()
+
+	if t.Name == "" {
+		report.Add(ValidationResult{
+			Severity: SeverityError,
+			Message:  "table name cannot be empty",
+		})
+		return report
+	}
+
+	if !t.Mode.IsValid() {
+		report.Add(ValidationResult{
+			Severity:  SeverityError,
+			Table:     t.Name,
+			Message:   "invalid table mode",
+			CodeValue: string(t.Mode),
+		})
+	}
+
+	report.AddAll(validateFieldList(t.Name, t.Fields, false))
+	report.AddAll(validateIndexList(t.Name, t.Indexes, t.Fields))
+	report.AddAll(validateEventList(t.Name, t.Events))
+	report.AddAll(validatePermissions(t.Name, t.Permissions))
+
+	return report
+}
+
+// ValidateEdge performs internal consistency checks on a single edge
+// definition, including RELATION-mode requirements for from/to tables.
+func ValidateEdge(e EdgeDefinition) *ValidationReport {
+	report := NewValidationReport()
+
+	if e.Name == "" {
+		report.Add(ValidationResult{
+			Severity: SeverityError,
+			Message:  "edge name cannot be empty",
+		})
+		return report
+	}
+
+	if !e.Mode.IsValid() {
+		report.Add(ValidationResult{
+			Severity:  SeverityError,
+			Table:     e.Name,
+			Message:   "invalid edge mode",
+			CodeValue: string(e.Mode),
+		})
+	}
+
+	if e.Mode == EdgeModeRelation {
+		if e.FromTable == "" {
+			report.Add(ValidationResult{
+				Severity: SeverityError,
+				Table:    e.Name,
+				Message:  "edge with RELATION mode requires a from_table",
+			})
+		}
+		if e.ToTable == "" {
+			report.Add(ValidationResult{
+				Severity: SeverityError,
+				Table:    e.Name,
+				Message:  "edge with RELATION mode requires a to_table",
+			})
+		}
+	}
+
+	// Warn about reserved identifier usage (in/out are permitted on edges).
+	report.AddAll(validateFieldList(e.Name, e.Fields, true))
+	report.AddAll(validateIndexList(e.Name, e.Indexes, e.Fields))
+	report.AddAll(validateEventList(e.Name, e.Events))
+	report.AddAll(validatePermissions(e.Name, e.Permissions))
+
+	return report
+}
+
+// ValidateAccess performs internal consistency checks on a single access
+// definition.
+func ValidateAccess(a AccessDefinition) *ValidationReport {
+	report := NewValidationReport()
+
+	if a.Name == "" {
+		report.Add(ValidationResult{
+			Severity: SeverityError,
+			Message:  "access name cannot be empty",
+		})
+		return report
+	}
+
+	if !a.Type.IsValid() {
+		report.Add(ValidationResult{
+			Severity:  SeverityError,
+			Table:     a.Name,
+			Message:   "invalid access type",
+			CodeValue: string(a.Type),
+		})
+	}
+
+	switch a.Type {
+	case AccessTypeJWT:
+		if a.JWT == nil {
+			report.Add(ValidationResult{
+				Severity: SeverityError,
+				Table:    a.Name,
+				Message:  "JWT access requires a JWT configuration",
+			})
+		} else {
+			if a.JWT.Key == "" && a.JWT.URL == "" {
+				report.Add(ValidationResult{
+					Severity: SeverityError,
+					Table:    a.Name,
+					Message:  "JWT access requires either a KEY or a URL",
+				})
+			}
+			if a.JWT.Key != "" && a.JWT.URL != "" {
+				report.Add(ValidationResult{
+					Severity: SeverityWarning,
+					Table:    a.Name,
+					Message:  "JWT access has both KEY and URL; URL takes precedence",
+				})
+			}
+		}
+		if a.Record != nil {
+			report.Add(ValidationResult{
+				Severity: SeverityWarning,
+				Table:    a.Name,
+				Message:  "JWT access should not carry a record configuration",
+			})
+		}
+	case AccessTypeRecord:
+		if a.Record == nil {
+			report.Add(ValidationResult{
+				Severity: SeverityError,
+				Table:    a.Name,
+				Message:  "RECORD access requires a record configuration",
+			})
+		} else {
+			if a.Record.Signup == "" && a.Record.Signin == "" {
+				report.Add(ValidationResult{
+					Severity: SeverityWarning,
+					Table:    a.Name,
+					Message:  "RECORD access declares neither SIGNUP nor SIGNIN",
+				})
+			}
+		}
+		if a.JWT != nil {
+			report.Add(ValidationResult{
+				Severity: SeverityWarning,
+				Table:    a.Name,
+				Message:  "RECORD access should not carry a JWT configuration",
+			})
+		}
+	}
+
+	return report
+}
+
+// CompareSchemas reports drift between a code-defined schema and the schema
+// extracted from a live database. It mirrors the semantics of surql-py's
+// validate_schema but consumes pre-fetched TableDefinition / EdgeDefinition
+// slices so that the caller owns database I/O.
+//
+// Missing / extra / mismatched tables, fields, indexes, and events are
+// surfaced with the severity levels documented in the Python implementation.
+func CompareSchemas(
+	codeTables, dbTables []TableDefinition,
+	codeEdges, dbEdges []EdgeDefinition,
+) *ValidationReport {
+	report := NewValidationReport()
+
+	codeByName := tablesByName(codeTables)
+	dbByName := tablesByName(dbTables)
+
+	// Missing / extra tables.
+	for _, name := range sortedKeys(codeByName) {
+		if _, ok := dbByName[name]; !ok {
+			report.Add(ValidationResult{
+				Severity:  SeverityError,
+				Table:     name,
+				Message:   "Table defined in code but missing from database",
+				CodeValue: "exists",
+				DBValue:   "missing",
+			})
+		}
+	}
+	for _, name := range sortedKeys(dbByName) {
+		if _, ok := codeByName[name]; !ok {
+			report.Add(ValidationResult{
+				Severity:  SeverityWarning,
+				Table:     name,
+				Message:   "Table exists in database but not defined in code",
+				CodeValue: "missing",
+				DBValue:   "exists",
+			})
+		}
+	}
+
+	// Common tables: deep compare.
+	for _, name := range sortedKeys(codeByName) {
+		db, ok := dbByName[name]
+		if !ok {
+			continue
+		}
+		report.AddAll(diffTable(codeByName[name], db))
+	}
+
+	// Edges.
+	codeEdgeByName := edgesByName(codeEdges)
+	dbEdgeByName := edgesByName(dbEdges)
+
+	for _, name := range sortedKeys(codeEdgeByName) {
+		if _, ok := dbEdgeByName[name]; !ok {
+			report.Add(ValidationResult{
+				Severity:  SeverityError,
+				Table:     name,
+				Message:   "Edge defined in code but missing from database",
+				CodeValue: "exists",
+				DBValue:   "missing",
+			})
+		}
+	}
+	for _, name := range sortedKeys(dbEdgeByName) {
+		if _, ok := codeEdgeByName[name]; !ok {
+			report.Add(ValidationResult{
+				Severity:  SeverityWarning,
+				Table:     name,
+				Message:   "Edge exists in database but not defined in code",
+				CodeValue: "missing",
+				DBValue:   "exists",
+			})
+		}
+	}
+
+	for _, name := range sortedKeys(codeEdgeByName) {
+		db, ok := dbEdgeByName[name]
+		if !ok {
+			continue
+		}
+		report.AddAll(diffEdge(codeEdgeByName[name], db))
+	}
+
+	return report
+}
+
+// diffTable computes the drift between two TableDefinition objects.
+func diffTable(code, db TableDefinition) []ValidationResult {
+	var results []ValidationResult
+
+	if code.Mode != db.Mode {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     code.Name,
+			Message:   "Table mode mismatch",
+			CodeValue: string(code.Mode),
+			DBValue:   string(db.Mode),
+		})
+	}
+
+	results = append(results, diffFields(code.Name, code.Fields, db.Fields)...)
+	results = append(results, diffIndexes(code.Name, code.Indexes, db.Indexes)...)
+	results = append(results, diffEvents(code.Name, code.Events, db.Events)...)
+
+	return results
+}
+
+// diffEdge computes the drift between two EdgeDefinition objects.
+func diffEdge(code, db EdgeDefinition) []ValidationResult {
+	var results []ValidationResult
+
+	if code.Mode != db.Mode {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     code.Name,
+			Message:   "Edge mode mismatch",
+			CodeValue: string(code.Mode),
+			DBValue:   string(db.Mode),
+		})
+	}
+	if code.FromTable != db.FromTable {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     code.Name,
+			Message:   "Edge from_table mismatch",
+			CodeValue: code.FromTable,
+			DBValue:   db.FromTable,
+		})
+	}
+	if code.ToTable != db.ToTable {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     code.Name,
+			Message:   "Edge to_table mismatch",
+			CodeValue: code.ToTable,
+			DBValue:   db.ToTable,
+		})
+	}
+
+	results = append(results, diffFields(code.Name, code.Fields, db.Fields)...)
+	results = append(results, diffIndexes(code.Name, code.Indexes, db.Indexes)...)
+	results = append(results, diffEvents(code.Name, code.Events, db.Events)...)
+
+	return results
+}
+
+// diffFields enumerates missing / extra / mismatched fields between code and
+// database field slices for a given container (table or edge).
+func diffFields(container string, code, db []FieldDefinition) []ValidationResult {
+	var results []ValidationResult
+
+	codeByName := fieldsByName(code)
+	dbByName := fieldsByName(db)
+
+	for _, name := range sortedKeys(codeByName) {
+		if _, ok := dbByName[name]; !ok {
+			results = append(results, ValidationResult{
+				Severity:  SeverityError,
+				Table:     container,
+				Field:     name,
+				Message:   "Field defined in code but missing from database",
+				CodeValue: "exists",
+				DBValue:   "missing",
+			})
+		}
+	}
+	for _, name := range sortedKeys(dbByName) {
+		if _, ok := codeByName[name]; !ok {
+			results = append(results, ValidationResult{
+				Severity:  SeverityWarning,
+				Table:     container,
+				Field:     name,
+				Message:   "Field exists in database but not defined in code",
+				CodeValue: "missing",
+				DBValue:   "exists",
+			})
+		}
+	}
+	for _, name := range sortedKeys(codeByName) {
+		dbField, ok := dbByName[name]
+		if !ok {
+			continue
+		}
+		results = append(results, diffField(container, codeByName[name], dbField)...)
+	}
+
+	return results
+}
+
+// diffField compares a single pair of FieldDefinition objects.
+func diffField(container string, code, db FieldDefinition) []ValidationResult {
+	var results []ValidationResult
+
+	if code.Type != db.Type {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     container,
+			Field:     code.Name,
+			Message:   "Field type mismatch",
+			CodeValue: string(code.Type),
+			DBValue:   string(db.Type),
+		})
+	}
+	if normalizeExpression(code.Assertion) != normalizeExpression(db.Assertion) {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     code.Name,
+			Message:   "Field assertion mismatch",
+			CodeValue: code.Assertion,
+			DBValue:   db.Assertion,
+		})
+	}
+	if normalizeExpression(code.Default) != normalizeExpression(db.Default) {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     code.Name,
+			Message:   "Field default value mismatch",
+			CodeValue: code.Default,
+			DBValue:   db.Default,
+		})
+	}
+	if normalizeExpression(code.Value) != normalizeExpression(db.Value) {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     code.Name,
+			Message:   "Field computed value mismatch",
+			CodeValue: code.Value,
+			DBValue:   db.Value,
+		})
+	}
+	if code.ReadOnly != db.ReadOnly {
+		results = append(results, ValidationResult{
+			Severity:  SeverityInfo,
+			Table:     container,
+			Field:     code.Name,
+			Message:   "Field readonly flag mismatch",
+			CodeValue: strconv.FormatBool(code.ReadOnly),
+			DBValue:   strconv.FormatBool(db.ReadOnly),
+		})
+	}
+	if code.Flexible != db.Flexible {
+		results = append(results, ValidationResult{
+			Severity:  SeverityInfo,
+			Table:     container,
+			Field:     code.Name,
+			Message:   "Field flexible flag mismatch",
+			CodeValue: strconv.FormatBool(code.Flexible),
+			DBValue:   strconv.FormatBool(db.Flexible),
+		})
+	}
+
+	return results
+}
+
+// diffIndexes enumerates missing / extra / mismatched indexes.
+func diffIndexes(container string, code, db []IndexDefinition) []ValidationResult {
+	var results []ValidationResult
+
+	codeByName := indexesByName(code)
+	dbByName := indexesByName(db)
+
+	for _, name := range sortedKeys(codeByName) {
+		if _, ok := dbByName[name]; !ok {
+			results = append(results, ValidationResult{
+				Severity:  SeverityError,
+				Table:     container,
+				Field:     "index:" + name,
+				Message:   "Index defined in code but missing from database",
+				CodeValue: "exists",
+				DBValue:   "missing",
+			})
+		}
+	}
+	for _, name := range sortedKeys(dbByName) {
+		if _, ok := codeByName[name]; !ok {
+			results = append(results, ValidationResult{
+				Severity:  SeverityWarning,
+				Table:     container,
+				Field:     "index:" + name,
+				Message:   "Index exists in database but not defined in code",
+				CodeValue: "missing",
+				DBValue:   "exists",
+			})
+		}
+	}
+	for _, name := range sortedKeys(codeByName) {
+		dbIdx, ok := dbByName[name]
+		if !ok {
+			continue
+		}
+		results = append(results, diffIndex(container, codeByName[name], dbIdx)...)
+	}
+
+	return results
+}
+
+// diffIndex compares a single pair of IndexDefinition objects.
+func diffIndex(container string, code, db IndexDefinition) []ValidationResult {
+	var results []ValidationResult
+	indexField := "index:" + code.Name
+
+	if code.Type != db.Type {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     container,
+			Field:     indexField,
+			Message:   "Index type mismatch",
+			CodeValue: string(code.Type),
+			DBValue:   string(db.Type),
+		})
+	}
+	if !sortedSliceEqual(code.Columns, db.Columns) {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     container,
+			Field:     indexField,
+			Message:   "Index columns mismatch",
+			CodeValue: strings.Join(code.Columns, ","),
+			DBValue:   strings.Join(db.Columns, ","),
+		})
+	}
+
+	if code.Type == IndexTypeMTree && db.Type == IndexTypeMTree {
+		results = append(results, diffMTreeParams(container, code, db)...)
+	}
+	if code.Type == IndexTypeHNSW && db.Type == IndexTypeHNSW {
+		results = append(results, diffHnswParams(container, code, db)...)
+	}
+
+	return results
+}
+
+func diffMTreeParams(container string, code, db IndexDefinition) []ValidationResult {
+	var results []ValidationResult
+	indexField := "index:" + code.Name
+
+	if code.Dimension != db.Dimension {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     container,
+			Field:     indexField,
+			Message:   "MTREE index dimension mismatch",
+			CodeValue: strconv.Itoa(code.Dimension),
+			DBValue:   strconv.Itoa(db.Dimension),
+		})
+	}
+	if code.Distance != db.Distance {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     indexField,
+			Message:   "MTREE index distance metric mismatch",
+			CodeValue: string(code.Distance),
+			DBValue:   string(db.Distance),
+		})
+	}
+	if code.VectorType != db.VectorType {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     indexField,
+			Message:   "MTREE index vector type mismatch",
+			CodeValue: string(code.VectorType),
+			DBValue:   string(db.VectorType),
+		})
+	}
+	return results
+}
+
+func diffHnswParams(container string, code, db IndexDefinition) []ValidationResult {
+	var results []ValidationResult
+	indexField := "index:" + code.Name
+
+	if code.Dimension != db.Dimension {
+		results = append(results, ValidationResult{
+			Severity:  SeverityError,
+			Table:     container,
+			Field:     indexField,
+			Message:   "HNSW index dimension mismatch",
+			CodeValue: strconv.Itoa(code.Dimension),
+			DBValue:   strconv.Itoa(db.Dimension),
+		})
+	}
+	if code.HnswDistance != db.HnswDistance {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     indexField,
+			Message:   "HNSW index distance metric mismatch",
+			CodeValue: string(code.HnswDistance),
+			DBValue:   string(db.HnswDistance),
+		})
+	}
+	if code.VectorType != db.VectorType {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     indexField,
+			Message:   "HNSW index vector type mismatch",
+			CodeValue: string(code.VectorType),
+			DBValue:   string(db.VectorType),
+		})
+	}
+	if code.EFC != db.EFC {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     indexField,
+			Message:   "HNSW index EFC mismatch",
+			CodeValue: strconv.Itoa(code.EFC),
+			DBValue:   strconv.Itoa(db.EFC),
+		})
+	}
+	if code.M != db.M {
+		results = append(results, ValidationResult{
+			Severity:  SeverityWarning,
+			Table:     container,
+			Field:     indexField,
+			Message:   "HNSW index M mismatch",
+			CodeValue: strconv.Itoa(code.M),
+			DBValue:   strconv.Itoa(db.M),
+		})
+	}
+	return results
+}
+
+// diffEvents enumerates missing / extra events between two event slices.
+func diffEvents(container string, code, db []EventDefinition) []ValidationResult {
+	var results []ValidationResult
+
+	codeByName := eventsByName(code)
+	dbByName := eventsByName(db)
+
+	for _, name := range sortedKeys(codeByName) {
+		if _, ok := dbByName[name]; !ok {
+			results = append(results, ValidationResult{
+				Severity:  SeverityError,
+				Table:     container,
+				Field:     "event:" + name,
+				Message:   "Event defined in code but missing from database",
+				CodeValue: "exists",
+				DBValue:   "missing",
+			})
+		}
+	}
+	for _, name := range sortedKeys(dbByName) {
+		if _, ok := codeByName[name]; !ok {
+			results = append(results, ValidationResult{
+				Severity:  SeverityWarning,
+				Table:     container,
+				Field:     "event:" + name,
+				Message:   "Event exists in database but not defined in code",
+				CodeValue: "missing",
+				DBValue:   "exists",
+			})
+		}
+	}
+
+	return results
+}
+
+// Structural helpers.
+
+// validateFieldList checks per-field invariants plus duplicate-name detection.
+func validateFieldList(container string, fields []FieldDefinition, allowEdgeReserved bool) []ValidationResult {
+	var results []ValidationResult
+	seen := make(map[string]struct{}, len(fields))
+
+	for _, f := range fields {
+		if _, dup := seen[f.Name]; dup && f.Name != "" {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    container,
+				Field:    f.Name,
+				Message:  "duplicate field name",
+			})
+			continue
+		}
+		seen[f.Name] = struct{}{}
+
+		if err := f.Validate(); err != nil {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    container,
+				Field:    f.Name,
+				Message:  err.Error(),
+			})
+			continue
+		}
+
+		if warn := f.ReservedWarning(allowEdgeReserved); warn != "" {
+			results = append(results, ValidationResult{
+				Severity: SeverityWarning,
+				Table:    container,
+				Field:    f.Name,
+				Message:  warn,
+			})
+		}
+	}
+
+	return results
+}
+
+// validateIndexList checks per-index invariants, duplicate-name detection, and
+// that every index column references a known field (when the table is
+// SCHEMAFULL and fields are supplied).
+func validateIndexList(container string, indexes []IndexDefinition, fields []FieldDefinition) []ValidationResult {
+	var results []ValidationResult
+	seen := make(map[string]struct{}, len(indexes))
+	fieldSet := make(map[string]struct{}, len(fields))
+	for _, f := range fields {
+		fieldSet[f.Name] = struct{}{}
+	}
+
+	for _, idx := range indexes {
+		if _, dup := seen[idx.Name]; dup && idx.Name != "" {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    container,
+				Field:    "index:" + idx.Name,
+				Message:  "duplicate index name",
+			})
+			continue
+		}
+		seen[idx.Name] = struct{}{}
+
+		if err := idx.Validate(); err != nil {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    container,
+				Field:    "index:" + idx.Name,
+				Message:  err.Error(),
+			})
+			continue
+		}
+
+		// Warn when an index references a column absent from the field list
+		// (fields may be empty for SCHEMALESS tables, so only warn when we
+		// have a non-empty field set to compare against).
+		if len(fieldSet) == 0 {
+			continue
+		}
+		for _, col := range idx.Columns {
+			if _, ok := fieldSet[col]; !ok {
+				results = append(results, ValidationResult{
+					Severity:  SeverityWarning,
+					Table:     container,
+					Field:     "index:" + idx.Name,
+					Message:   fmt.Sprintf("index references unknown column %q", col),
+					CodeValue: col,
+				})
+			}
+		}
+	}
+
+	return results
+}
+
+// validateEventList checks per-event invariants plus duplicate-name detection.
+func validateEventList(container string, events []EventDefinition) []ValidationResult {
+	var results []ValidationResult
+	seen := make(map[string]struct{}, len(events))
+
+	for _, e := range events {
+		if _, dup := seen[e.Name]; dup && e.Name != "" {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    container,
+				Field:    "event:" + e.Name,
+				Message:  "duplicate event name",
+			})
+			continue
+		}
+		seen[e.Name] = struct{}{}
+
+		if err := e.Validate(); err != nil {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    container,
+				Field:    "event:" + e.Name,
+				Message:  err.Error(),
+			})
+		}
+	}
+
+	return results
+}
+
+// validatePermissions surfaces malformed permission entries.
+func validatePermissions(container string, perms map[string]string) []ValidationResult {
+	var results []ValidationResult
+	if len(perms) == 0 {
+		return nil
+	}
+	allowed := map[string]struct{}{
+		"select": {},
+		"create": {},
+		"update": {},
+		"delete": {},
+	}
+	for _, action := range sortedKeysString(perms) {
+		expr := perms[action]
+		lower := strings.ToLower(action)
+		if _, ok := allowed[lower]; !ok {
+			results = append(results, ValidationResult{
+				Severity:  SeverityWarning,
+				Table:     container,
+				Field:     "permissions:" + action,
+				Message:   "unknown permission action",
+				CodeValue: action,
+			})
+		}
+		if strings.TrimSpace(expr) == "" {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    container,
+				Field:    "permissions:" + action,
+				Message:  "permission expression cannot be empty",
+			})
+		}
+	}
+	return results
+}
+
+// detectNameCollisions reports tables and edges that share a name.
+func detectNameCollisions(tables []TableDefinition, edges []EdgeDefinition) []ValidationResult {
+	var results []ValidationResult
+	tableNames := make(map[string]struct{}, len(tables))
+	for _, t := range tables {
+		tableNames[t.Name] = struct{}{}
+	}
+	for _, e := range edges {
+		if _, clash := tableNames[e.Name]; clash {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    e.Name,
+				Message:  "name conflict: edge and table share the same name",
+			})
+		}
+	}
+	return results
+}
+
+// detectRecordFieldTargets warns when a record-typed field references an
+// unknown table. The Python implementation does not perform this check, but
+// it is a natural extension of cross-schema validation.
+func detectRecordFieldTargets(tables []TableDefinition, edges []EdgeDefinition) []ValidationResult {
+	var results []ValidationResult
+	known := make(map[string]struct{}, len(tables)+len(edges))
+	for _, t := range tables {
+		known[t.Name] = struct{}{}
+	}
+	for _, e := range edges {
+		known[e.Name] = struct{}{}
+	}
+
+	walk := func(container string, fields []FieldDefinition) {
+		for _, f := range fields {
+			if f.Type != FieldTypeRecord {
+				continue
+			}
+			target := extractRecordTarget(f.Assertion)
+			if target == "" {
+				continue
+			}
+			if _, ok := known[target]; !ok {
+				results = append(results, ValidationResult{
+					Severity:  SeverityWarning,
+					Table:     container,
+					Field:     f.Name,
+					Message:   "record field references unknown table",
+					CodeValue: target,
+				})
+			}
+		}
+	}
+
+	for _, t := range tables {
+		walk(t.Name, t.Fields)
+	}
+	for _, e := range edges {
+		walk(e.Name, e.Fields)
+	}
+	return results
+}
+
+// detectEdgeTableReferences warns when a RELATION edge references a table
+// that is not registered with the schema.
+func detectEdgeTableReferences(tables []TableDefinition, edges []EdgeDefinition) []ValidationResult {
+	var results []ValidationResult
+	known := make(map[string]struct{}, len(tables))
+	for _, t := range tables {
+		known[t.Name] = struct{}{}
+	}
+	for _, e := range edges {
+		if e.Mode != EdgeModeRelation {
+			continue
+		}
+		if e.FromTable != "" {
+			if _, ok := known[e.FromTable]; !ok {
+				results = append(results, ValidationResult{
+					Severity:  SeverityWarning,
+					Table:     e.Name,
+					Message:   "edge from_table is not a registered table",
+					CodeValue: e.FromTable,
+				})
+			}
+		}
+		if e.ToTable != "" {
+			if _, ok := known[e.ToTable]; !ok {
+				results = append(results, ValidationResult{
+					Severity:  SeverityWarning,
+					Table:     e.Name,
+					Message:   "edge to_table is not a registered table",
+					CodeValue: e.ToTable,
+				})
+			}
+		}
+	}
+	return results
+}
+
+// detectDuplicateAccessNames reports access definitions that share a name.
+func detectDuplicateAccessNames(accesses []AccessDefinition) []ValidationResult {
+	var results []ValidationResult
+	seen := make(map[string]struct{}, len(accesses))
+	for _, a := range accesses {
+		if a.Name == "" {
+			continue
+		}
+		if _, dup := seen[a.Name]; dup {
+			results = append(results, ValidationResult{
+				Severity: SeverityError,
+				Table:    a.Name,
+				Message:  "duplicate access definition",
+			})
+			continue
+		}
+		seen[a.Name] = struct{}{}
+	}
+	return results
+}
+
+// Lookup helpers.
+
+func tablesByName(tables []TableDefinition) map[string]TableDefinition {
+	out := make(map[string]TableDefinition, len(tables))
+	for _, t := range tables {
+		out[t.Name] = t
+	}
+	return out
+}
+
+func edgesByName(edges []EdgeDefinition) map[string]EdgeDefinition {
+	out := make(map[string]EdgeDefinition, len(edges))
+	for _, e := range edges {
+		out[e.Name] = e
+	}
+	return out
+}
+
+func fieldsByName(fields []FieldDefinition) map[string]FieldDefinition {
+	out := make(map[string]FieldDefinition, len(fields))
+	for _, f := range fields {
+		out[f.Name] = f
+	}
+	return out
+}
+
+func indexesByName(indexes []IndexDefinition) map[string]IndexDefinition {
+	out := make(map[string]IndexDefinition, len(indexes))
+	for _, i := range indexes {
+		out[i.Name] = i
+	}
+	return out
+}
+
+func eventsByName(events []EventDefinition) map[string]EventDefinition {
+	out := make(map[string]EventDefinition, len(events))
+	for _, e := range events {
+		out[e.Name] = e
+	}
+	return out
+}
+
+// sortedKeys is generic over maps keyed by string.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedKeysString(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/surql/schema/validator_test.go
+++ b/pkg/surql/schema/validator_test.go
@@ -1,0 +1,1337 @@
+package schema
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// ValidationSeverity.
+
+func TestValidationSeverityValues(t *testing.T) {
+	if SeverityError != "error" {
+		t.Errorf("SeverityError = %q, want error", SeverityError)
+	}
+	if SeverityWarning != "warning" {
+		t.Errorf("SeverityWarning = %q, want warning", SeverityWarning)
+	}
+	if SeverityInfo != "info" {
+		t.Errorf("SeverityInfo = %q, want info", SeverityInfo)
+	}
+}
+
+func TestValidationSeverityIsValid(t *testing.T) {
+	valid := []ValidationSeverity{SeverityError, SeverityWarning, SeverityInfo}
+	for _, s := range valid {
+		if !s.IsValid() {
+			t.Errorf("IsValid(%q) = false, want true", s)
+		}
+	}
+	if ValidationSeverity("bogus").IsValid() {
+		t.Errorf("IsValid(bogus) = true, want false")
+	}
+}
+
+// ValidationResult.
+
+func TestValidationResultStringWithField(t *testing.T) {
+	r := ValidationResult{
+		Severity:  SeverityError,
+		Table:     "user",
+		Field:     "email",
+		Message:   "Field type mismatch",
+		CodeValue: "string",
+		DBValue:   "int",
+	}
+	s := r.String()
+	for _, want := range []string{"[ERROR]", "user.email", "Field type mismatch",
+		"code: string", "db: int"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("String missing %q: %s", want, s)
+		}
+	}
+}
+
+func TestValidationResultStringWithoutField(t *testing.T) {
+	r := ValidationResult{
+		Severity: SeverityWarning,
+		Table:    "post",
+		Message:  "Table exists in database but not defined in code",
+	}
+	s := r.String()
+	if !strings.Contains(s, "[WARNING]") {
+		t.Errorf("missing [WARNING]: %s", s)
+	}
+	if strings.Contains(s, "post.") {
+		t.Errorf("unexpected field separator: %s", s)
+	}
+}
+
+func TestValidationResultStringWithoutValues(t *testing.T) {
+	r := ValidationResult{Severity: SeverityInfo, Table: "user", Field: "name", Message: "Info"}
+	s := r.String()
+	if !strings.Contains(s, "[INFO]") {
+		t.Errorf("missing [INFO]: %s", s)
+	}
+	if strings.Contains(s, "code:") {
+		t.Errorf("unexpected code: in output: %s", s)
+	}
+}
+
+// ValidationReport.
+
+func TestNewValidationReport(t *testing.T) {
+	vr := NewValidationReport()
+	if vr == nil {
+		t.Fatal("NewValidationReport returned nil")
+	}
+	if vr.Len() != 0 {
+		t.Errorf("Len = %d, want 0", vr.Len())
+	}
+}
+
+func TestValidationReportAdd(t *testing.T) {
+	vr := NewValidationReport()
+	vr.Add(ValidationResult{Severity: SeverityError, Table: "user"})
+	if vr.Len() != 1 {
+		t.Errorf("Len = %d, want 1", vr.Len())
+	}
+}
+
+func TestValidationReportAddAll(t *testing.T) {
+	vr := NewValidationReport()
+	vr.AddAll([]ValidationResult{
+		{Severity: SeverityError, Table: "a"},
+		{Severity: SeverityWarning, Table: "b"},
+	})
+	if vr.Len() != 2 {
+		t.Errorf("Len = %d, want 2", vr.Len())
+	}
+}
+
+func TestValidationReportMerge(t *testing.T) {
+	a := NewValidationReport()
+	a.Add(ValidationResult{Severity: SeverityError, Table: "one"})
+	b := NewValidationReport()
+	b.Add(ValidationResult{Severity: SeverityWarning, Table: "two"})
+	a.Merge(b)
+	if a.Len() != 2 {
+		t.Errorf("Len = %d, want 2", a.Len())
+	}
+}
+
+func TestValidationReportMergeNilSafe(t *testing.T) {
+	var vr *ValidationReport
+	vr.Merge(NewValidationReport()) // should not panic
+	other := NewValidationReport()
+	other.Merge(nil) // should not panic
+	if other.Len() != 0 {
+		t.Errorf("Len = %d, want 0", other.Len())
+	}
+}
+
+func TestValidationReportErrorsWarningsInfos(t *testing.T) {
+	vr := NewValidationReport()
+	vr.Add(ValidationResult{Severity: SeverityError})
+	vr.Add(ValidationResult{Severity: SeverityError})
+	vr.Add(ValidationResult{Severity: SeverityWarning})
+	vr.Add(ValidationResult{Severity: SeverityInfo})
+
+	if got := len(vr.Errors()); got != 2 {
+		t.Errorf("Errors = %d, want 2", got)
+	}
+	if got := len(vr.Warnings()); got != 1 {
+		t.Errorf("Warnings = %d, want 1", got)
+	}
+	if got := len(vr.Infos()); got != 1 {
+		t.Errorf("Infos = %d, want 1", got)
+	}
+	if !vr.HasErrors() {
+		t.Error("HasErrors = false, want true")
+	}
+	if vr.IsValid() {
+		t.Error("IsValid = true, want false")
+	}
+}
+
+func TestValidationReportNilAccessors(t *testing.T) {
+	var vr *ValidationReport
+	if vr.Len() != 0 {
+		t.Error("Len should be 0 for nil report")
+	}
+	if vr.HasErrors() {
+		t.Error("HasErrors should be false for nil report")
+	}
+	if !vr.IsValid() {
+		t.Error("IsValid should be true for nil report")
+	}
+	if vr.Errors() != nil {
+		t.Error("Errors should return nil for nil report")
+	}
+	if vr.Warnings() != nil {
+		t.Error("Warnings should return nil for nil report")
+	}
+	if vr.Infos() != nil {
+		t.Error("Infos should return nil for nil report")
+	}
+}
+
+// ValidateSchema top-level.
+
+func TestValidateSchemaNilRegistry(t *testing.T) {
+	_, err := ValidateSchema(nil)
+	if err == nil {
+		t.Fatal("expected error for nil registry")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestValidateSchemaEmptyRegistry(t *testing.T) {
+	r := NewSchemaRegistry()
+	report, err := ValidateSchema(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Len() != 0 {
+		t.Errorf("expected empty report, got %d results", report.Len())
+	}
+}
+
+func TestValidateSchemaHappyPath(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user", WithFields(StringField("name"))))
+	_ = r.RegisterEdge(TypedEdge("likes", "user", "post"))
+	_ = r.RegisterTable(NewTable("post", WithFields(StringField("title"))))
+
+	report, err := ValidateSchema(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.HasErrors() {
+		t.Errorf("expected no errors; got %+v", report.Errors())
+	}
+}
+
+func TestValidateSchemaNameCollision(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("likes"))
+	_ = r.RegisterTable(NewTable("user"))
+	_ = r.RegisterTable(NewTable("post"))
+	_ = r.RegisterEdge(TypedEdge("likes", "user", "post"))
+
+	report, err := ValidateSchema(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for _, res := range report.Errors() {
+		if res.Table == "likes" && strings.Contains(res.Message, "name conflict") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected name conflict error; got %+v", report.Results)
+	}
+}
+
+func TestValidateSchemaEdgeReferencesUnknownTable(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user"))
+	_ = r.RegisterEdge(TypedEdge("likes", "user", "missing"))
+
+	report, _ := ValidateSchema(r)
+	found := false
+	for _, res := range report.Warnings() {
+		if strings.Contains(res.Message, "to_table") && res.CodeValue == "missing" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for unknown to_table; got %+v", report.Results)
+	}
+}
+
+func TestValidateSchemaRecordFieldUnknownTarget(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("user", WithFields(
+		RecordField("favorite", "nonexistent"),
+	)))
+
+	report, _ := ValidateSchema(r)
+	found := false
+	for _, res := range report.Warnings() {
+		if res.Field == "favorite" && res.CodeValue == "nonexistent" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for unknown record target; got %+v", report.Results)
+	}
+}
+
+func TestValidateSchemaRecordFieldKnownTarget(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.RegisterTable(NewTable("post"))
+	_ = r.RegisterTable(NewTable("user", WithFields(RecordField("favorite", "post"))))
+
+	report, _ := ValidateSchema(r)
+	for _, res := range report.Warnings() {
+		if res.Field == "favorite" {
+			t.Errorf("unexpected warning for known record target: %+v", res)
+		}
+	}
+}
+
+func TestValidateSchemaDuplicateAccessNames(t *testing.T) {
+	r := NewSchemaRegistry()
+	acc := JwtAccess("api", JwtConfig{Key: "secret"})
+	report, _ := ValidateSchema(r, acc, acc)
+	found := false
+	for _, res := range report.Errors() {
+		if strings.Contains(res.Message, "duplicate access") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected duplicate access error; got %+v", report.Results)
+	}
+}
+
+// ValidateTable.
+
+func TestValidateTableEmptyName(t *testing.T) {
+	report := ValidateTable(TableDefinition{})
+	if !report.HasErrors() {
+		t.Error("expected error for empty name")
+	}
+}
+
+func TestValidateTableInvalidMode(t *testing.T) {
+	report := ValidateTable(TableDefinition{Name: "user", Mode: "FOO"})
+	if !report.HasErrors() {
+		t.Error("expected error for invalid mode")
+	}
+}
+
+func TestValidateTableValid(t *testing.T) {
+	report := ValidateTable(NewTable("user", WithFields(StringField("name"))))
+	if report.HasErrors() {
+		t.Errorf("unexpected errors: %+v", report.Errors())
+	}
+}
+
+func TestValidateTableDuplicateField(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithFields(StringField("name"), StringField("name")),
+	))
+	found := false
+	for _, res := range report.Errors() {
+		if res.Field == "name" && strings.Contains(res.Message, "duplicate") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected duplicate field error; got %+v", report.Results)
+	}
+}
+
+func TestValidateTableInvalidFieldName(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithFields(FieldDefinition{Name: "1invalid", Type: FieldTypeString}),
+	))
+	if !report.HasErrors() {
+		t.Error("expected error for invalid field name")
+	}
+}
+
+func TestValidateTableInvalidFieldType(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithFields(FieldDefinition{Name: "x", Type: "bogus"}),
+	))
+	if !report.HasErrors() {
+		t.Error("expected error for invalid field type")
+	}
+}
+
+func TestValidateTableDuplicateIndex(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithFields(StringField("name")),
+		WithIndexes(
+			NewIndex("idx", []string{"name"}, IndexTypeStandard),
+			NewIndex("idx", []string{"name"}, IndexTypeStandard),
+		),
+	))
+	found := false
+	for _, res := range report.Errors() {
+		if res.Field == "index:idx" && strings.Contains(res.Message, "duplicate") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected duplicate index error; got %+v", report.Results)
+	}
+}
+
+func TestValidateTableIndexUnknownColumn(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithFields(StringField("name")),
+		WithIndexes(NewIndex("idx", []string{"ghost"}, IndexTypeStandard)),
+	))
+	found := false
+	for _, res := range report.Warnings() {
+		if res.Field == "index:idx" && strings.Contains(res.Message, "unknown column") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected unknown column warning; got %+v", report.Results)
+	}
+}
+
+func TestValidateTableIndexUnknownColumnSchemalessNoWarning(t *testing.T) {
+	// A table with no fields declared skips the unknown-column check.
+	report := ValidateTable(NewTable("user",
+		WithMode(TableModeSchemaless),
+		WithIndexes(NewIndex("idx", []string{"name"}, IndexTypeStandard)),
+	))
+	for _, res := range report.Warnings() {
+		if strings.Contains(res.Message, "unknown column") {
+			t.Errorf("unexpected unknown-column warning for schemaless table: %+v", res)
+		}
+	}
+}
+
+func TestValidateTableInvalidIndex(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithIndexes(IndexDefinition{Name: "", Columns: []string{"x"}, Type: IndexTypeStandard}),
+	))
+	if !report.HasErrors() {
+		t.Error("expected error for unnamed index")
+	}
+}
+
+func TestValidateTableDuplicateEvent(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithEvents(
+			NewEvent("on_create", "$event = 'CREATE'", "SELECT 1"),
+			NewEvent("on_create", "$event = 'CREATE'", "SELECT 1"),
+		),
+	))
+	found := false
+	for _, res := range report.Errors() {
+		if res.Field == "event:on_create" && strings.Contains(res.Message, "duplicate") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected duplicate event error; got %+v", report.Results)
+	}
+}
+
+func TestValidateTableInvalidEvent(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithEvents(EventDefinition{Name: "evt", Condition: "", Action: ""}),
+	))
+	if !report.HasErrors() {
+		t.Error("expected error for empty event condition/action")
+	}
+}
+
+func TestValidateTableReservedFieldNameWarns(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithFields(StringField("select")),
+	))
+	// May or may not produce a reserved warning depending on the types
+	// package content, so we just ensure the validator does not crash and
+	// returns a ValidationReport.
+	_ = report
+}
+
+func TestValidateTablePermissions(t *testing.T) {
+	report := ValidateTable(NewTable("user",
+		WithFields(StringField("name")),
+		WithTablePermissions(map[string]string{"select": "true", "bogus": "true", "update": ""}),
+	))
+	warnings := report.Warnings()
+	if len(warnings) == 0 {
+		t.Errorf("expected permissions warnings; got %+v", report.Results)
+	}
+	hasEmptyErr := false
+	for _, res := range report.Errors() {
+		if strings.Contains(res.Message, "permission expression cannot be empty") {
+			hasEmptyErr = true
+		}
+	}
+	if !hasEmptyErr {
+		t.Error("expected error for empty permission expression")
+	}
+}
+
+// ValidateEdge.
+
+func TestValidateEdgeEmptyName(t *testing.T) {
+	report := ValidateEdge(EdgeDefinition{})
+	if !report.HasErrors() {
+		t.Error("expected error for empty edge name")
+	}
+}
+
+func TestValidateEdgeInvalidMode(t *testing.T) {
+	report := ValidateEdge(EdgeDefinition{Name: "likes", Mode: "BOGUS"})
+	if !report.HasErrors() {
+		t.Error("expected error for invalid edge mode")
+	}
+}
+
+func TestValidateEdgeRelationRequiresFromTo(t *testing.T) {
+	report := ValidateEdge(NewEdge("likes"))
+	errs := report.Errors()
+	gotFrom, gotTo := false, false
+	for _, res := range errs {
+		if strings.Contains(res.Message, "from_table") {
+			gotFrom = true
+		}
+		if strings.Contains(res.Message, "to_table") {
+			gotTo = true
+		}
+	}
+	if !gotFrom || !gotTo {
+		t.Errorf("expected from_table and to_table errors; got %+v", errs)
+	}
+}
+
+func TestValidateEdgeRelationValid(t *testing.T) {
+	report := ValidateEdge(TypedEdge("likes", "user", "post"))
+	if report.HasErrors() {
+		t.Errorf("unexpected errors: %+v", report.Errors())
+	}
+}
+
+func TestValidateEdgeAllowsInOutFields(t *testing.T) {
+	e := TypedEdge("likes", "user", "post",
+		WithEdgeFields(RecordField("in", "user"), RecordField("out", "post")),
+	)
+	report := ValidateEdge(e)
+	if report.HasErrors() {
+		t.Errorf("unexpected errors for in/out fields: %+v", report.Errors())
+	}
+}
+
+// ValidateAccess.
+
+func TestValidateAccessEmptyName(t *testing.T) {
+	report := ValidateAccess(AccessDefinition{})
+	if !report.HasErrors() {
+		t.Error("expected error for empty name")
+	}
+}
+
+func TestValidateAccessInvalidType(t *testing.T) {
+	report := ValidateAccess(AccessDefinition{Name: "a", Type: "BOGUS"})
+	if !report.HasErrors() {
+		t.Error("expected error for invalid type")
+	}
+}
+
+func TestValidateAccessJwtRequiresConfig(t *testing.T) {
+	report := ValidateAccess(AccessDefinition{Name: "a", Type: AccessTypeJWT})
+	if !report.HasErrors() {
+		t.Error("expected error for JWT without config")
+	}
+}
+
+func TestValidateAccessJwtRequiresKeyOrURL(t *testing.T) {
+	report := ValidateAccess(JwtAccess("a", JwtConfig{}))
+	if !report.HasErrors() {
+		t.Error("expected error for JWT without KEY or URL")
+	}
+}
+
+func TestValidateAccessJwtBothKeyAndURL(t *testing.T) {
+	report := ValidateAccess(JwtAccess("a", JwtConfig{Key: "x", URL: "http://y"}))
+	found := false
+	for _, res := range report.Warnings() {
+		if strings.Contains(res.Message, "both KEY and URL") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for both KEY and URL; got %+v", report.Results)
+	}
+}
+
+func TestValidateAccessRecordRequiresConfig(t *testing.T) {
+	report := ValidateAccess(AccessDefinition{Name: "a", Type: AccessTypeRecord})
+	if !report.HasErrors() {
+		t.Error("expected error for RECORD without config")
+	}
+}
+
+func TestValidateAccessRecordWarnsWithoutSignupSignin(t *testing.T) {
+	report := ValidateAccess(RecordAccess("a", RecordAccessConfig{}))
+	found := false
+	for _, res := range report.Warnings() {
+		if strings.Contains(res.Message, "SIGNUP") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected SIGNUP/SIGNIN warning; got %+v", report.Results)
+	}
+}
+
+func TestValidateAccessJwtWithRecordConfigWarns(t *testing.T) {
+	a := JwtAccess("a", JwtConfig{Key: "x"})
+	a.Record = &RecordAccessConfig{Signup: "SELECT 1"}
+	report := ValidateAccess(a)
+	found := false
+	for _, res := range report.Warnings() {
+		if strings.Contains(res.Message, "should not carry a record") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for JWT with record config; got %+v", report.Results)
+	}
+}
+
+func TestValidateAccessRecordWithJWTConfigWarns(t *testing.T) {
+	a := RecordAccess("a", RecordAccessConfig{Signup: "SELECT 1"})
+	a.JWT = &JwtConfig{Key: "x"}
+	report := ValidateAccess(a)
+	found := false
+	for _, res := range report.Warnings() {
+		if strings.Contains(res.Message, "should not carry a JWT") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning for RECORD with JWT config; got %+v", report.Results)
+	}
+}
+
+// CompareSchemas (drift detection).
+
+func TestCompareSchemasIdentical(t *testing.T) {
+	a := []TableDefinition{NewTable("user", WithFields(StringField("name")))}
+	report := CompareSchemas(a, a, nil, nil)
+	if report.Len() != 0 {
+		t.Errorf("expected empty report, got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasMissingTable(t *testing.T) {
+	code := []TableDefinition{NewTable("user")}
+	report := CompareSchemas(code, nil, nil, nil)
+	if report.Len() != 1 {
+		t.Fatalf("expected 1 result, got %d", report.Len())
+	}
+	res := report.Results[0]
+	if res.Severity != SeverityError || res.Table != "user" ||
+		!strings.Contains(res.Message, "missing from database") {
+		t.Errorf("unexpected result: %+v", res)
+	}
+}
+
+func TestCompareSchemasMultipleMissingTables(t *testing.T) {
+	code := []TableDefinition{NewTable("user"), NewTable("post")}
+	report := CompareSchemas(code, nil, nil, nil)
+	names := map[string]bool{}
+	for _, r := range report.Errors() {
+		names[r.Table] = true
+	}
+	if !names["user"] || !names["post"] {
+		t.Errorf("expected user and post; got %v", names)
+	}
+}
+
+func TestCompareSchemasExtraTable(t *testing.T) {
+	db := []TableDefinition{NewTable("legacy")}
+	report := CompareSchemas(nil, db, nil, nil)
+	if report.Len() != 1 {
+		t.Fatalf("expected 1 result, got %d", report.Len())
+	}
+	if report.Results[0].Severity != SeverityWarning {
+		t.Errorf("expected WARNING, got %+v", report.Results[0])
+	}
+}
+
+func TestCompareSchemasTableModeMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("user", WithMode(TableModeSchemafull))}
+	db := []TableDefinition{NewTable("user", WithMode(TableModeSchemaless))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if strings.Contains(strings.ToLower(r.Message), "mode mismatch") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected mode mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasFieldTypeMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("user", WithFields(IntField("age")))}
+	db := []TableDefinition{NewTable("user", WithFields(StringField("age")))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if r.Field == "age" && strings.Contains(r.Message, "type mismatch") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected type mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasFieldMissing(t *testing.T) {
+	code := []TableDefinition{NewTable("user",
+		WithFields(StringField("name"), StringField("email")))}
+	db := []TableDefinition{NewTable("user", WithFields(StringField("name")))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if r.Field == "email" && strings.Contains(r.Message, "missing from database") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected missing email field; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasExtraField(t *testing.T) {
+	code := []TableDefinition{NewTable("user", WithFields(StringField("name")))}
+	db := []TableDefinition{NewTable("user",
+		WithFields(StringField("name"), StringField("legacy")))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if r.Field == "legacy" && strings.Contains(r.Message, "not defined in code") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected extra legacy field; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasFieldAssertionMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("user", WithFields(
+		StringField("email", WithAssertion("string::is::email($value)"))))}
+	db := []TableDefinition{NewTable("user", WithFields(
+		StringField("email", WithAssertion("$value != NONE"))))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if r.Field == "email" && strings.Contains(r.Message, "assertion") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected assertion mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasFieldDefaultMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("u", WithFields(StringField("n", WithDefault("'a'"))))}
+	db := []TableDefinition{NewTable("u", WithFields(StringField("n", WithDefault("'b'"))))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if r.Field == "n" && strings.Contains(r.Message, "default") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected default mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasFieldValueMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("u", WithFields(StringField("n", WithValue("'a'"))))}
+	db := []TableDefinition{NewTable("u", WithFields(StringField("n", WithValue("'b'"))))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if r.Field == "n" && strings.Contains(r.Message, "computed value") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected computed value mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasFieldReadonlyMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("u",
+		WithFields(StringField("n", WithReadOnly(true))))}
+	db := []TableDefinition{NewTable("u",
+		WithFields(StringField("n", WithReadOnly(false))))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Infos() {
+		if r.Field == "n" && strings.Contains(r.Message, "readonly") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected readonly flag info; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasFieldFlexibleMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("u",
+		WithFields(StringField("n", WithFlexible(true))))}
+	db := []TableDefinition{NewTable("u",
+		WithFields(StringField("n", WithFlexible(false))))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Infos() {
+		if r.Field == "n" && strings.Contains(r.Message, "flexible") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected flexible flag info; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasAssertionWhitespaceNormalized(t *testing.T) {
+	code := []TableDefinition{NewTable("u", WithFields(
+		StringField("n", WithAssertion("$value  !=  NONE"))))}
+	db := []TableDefinition{NewTable("u", WithFields(
+		StringField("n", WithAssertion("$value != NONE"))))}
+	report := CompareSchemas(code, db, nil, nil)
+	for _, r := range report.Warnings() {
+		if r.Field == "n" && strings.Contains(r.Message, "assertion") {
+			t.Errorf("unexpected assertion warning after normalization: %+v", r)
+		}
+	}
+}
+
+func TestCompareSchemasIndexMissing(t *testing.T) {
+	code := []TableDefinition{NewTable("u",
+		WithFields(StringField("email")),
+		WithIndexes(UniqueIndex("email_idx", []string{"email"})))}
+	db := []TableDefinition{NewTable("u",
+		WithFields(StringField("email")))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if r.Field == "index:email_idx" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected missing index error; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasIndexExtra(t *testing.T) {
+	code := []TableDefinition{NewTable("u", WithFields(StringField("email")))}
+	db := []TableDefinition{NewTable("u",
+		WithFields(StringField("email")),
+		WithIndexes(UniqueIndex("legacy_idx", []string{"email"})))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if r.Field == "index:legacy_idx" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected extra index warning; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasIndexTypeMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("u",
+		WithFields(StringField("email")),
+		WithIndexes(UniqueIndex("email_idx", []string{"email"})))}
+	db := []TableDefinition{NewTable("u",
+		WithFields(StringField("email")),
+		WithIndexes(NewIndex("email_idx", []string{"email"}, IndexTypeStandard)))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if strings.Contains(r.Message, "Index type mismatch") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected index type mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasIndexColumnsMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("u",
+		WithFields(StringField("a"), StringField("b")),
+		WithIndexes(NewIndex("idx", []string{"a", "b"}, IndexTypeStandard)))}
+	db := []TableDefinition{NewTable("u",
+		WithFields(StringField("a")),
+		WithIndexes(NewIndex("idx", []string{"a"}, IndexTypeStandard)))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if strings.Contains(r.Message, "columns mismatch") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected columns mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasIndexColumnsOrderInsensitive(t *testing.T) {
+	code := []TableDefinition{NewTable("u",
+		WithFields(StringField("a"), StringField("b")),
+		WithIndexes(NewIndex("idx", []string{"a", "b"}, IndexTypeStandard)))}
+	db := []TableDefinition{NewTable("u",
+		WithFields(StringField("a"), StringField("b")),
+		WithIndexes(NewIndex("idx", []string{"b", "a"}, IndexTypeStandard)))}
+	report := CompareSchemas(code, db, nil, nil)
+	for _, r := range report.Errors() {
+		if strings.Contains(r.Message, "columns mismatch") {
+			t.Errorf("unexpected columns mismatch with reordered slice: %+v", r)
+		}
+	}
+}
+
+func TestCompareSchemasMTreeDimensionMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(MTreeIndex("vec", "emb", 1024, MTreeIndexOptions{
+			Distance: MTreeDistanceCosine, VectorType: MTreeVectorF32})))}
+	db := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(MTreeIndex("vec", "emb", 768, MTreeIndexOptions{
+			Distance: MTreeDistanceCosine, VectorType: MTreeVectorF32})))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if strings.Contains(r.Message, "MTREE index dimension") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected MTREE dim mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasMTreeDistanceMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(MTreeIndex("vec", "emb", 64, MTreeIndexOptions{
+			Distance: MTreeDistanceCosine, VectorType: MTreeVectorF32})))}
+	db := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(MTreeIndex("vec", "emb", 64, MTreeIndexOptions{
+			Distance: MTreeDistanceEuclidean, VectorType: MTreeVectorF32})))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if strings.Contains(r.Message, "distance metric") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected distance mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasHnswDimensionMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(HnswIndex("vec", "emb", 1024, HnswIndexOptions{
+			Distance: HnswDistanceCosine, VectorType: MTreeVectorF32})))}
+	db := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(HnswIndex("vec", "emb", 768, HnswIndexOptions{
+			Distance: HnswDistanceCosine, VectorType: MTreeVectorF32})))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if strings.Contains(r.Message, "HNSW index dimension") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected HNSW dim mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasHnswEfcMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(HnswIndex("vec", "emb", 64, HnswIndexOptions{EFC: 100})))}
+	db := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(HnswIndex("vec", "emb", 64, HnswIndexOptions{EFC: 200})))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if strings.Contains(r.Message, "EFC") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected EFC mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasHnswMMismatch(t *testing.T) {
+	code := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(HnswIndex("vec", "emb", 64, HnswIndexOptions{M: 16})))}
+	db := []TableDefinition{NewTable("d",
+		WithFields(ArrayField("emb")),
+		WithIndexes(HnswIndex("vec", "emb", 64, HnswIndexOptions{M: 32})))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if strings.Contains(r.Message, "HNSW index M mismatch") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected M mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasEventsMissing(t *testing.T) {
+	code := []TableDefinition{NewTable("u",
+		WithEvents(NewEvent("on_create", "$event = 'CREATE'", "SELECT 1")))}
+	db := []TableDefinition{NewTable("u")}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if r.Field == "event:on_create" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected missing event; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasEventsExtra(t *testing.T) {
+	code := []TableDefinition{NewTable("u")}
+	db := []TableDefinition{NewTable("u",
+		WithEvents(NewEvent("legacy_evt", "$event = 'CREATE'", "SELECT 1")))}
+	report := CompareSchemas(code, db, nil, nil)
+	found := false
+	for _, r := range report.Warnings() {
+		if r.Field == "event:legacy_evt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected extra event warning; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasEdgeMissing(t *testing.T) {
+	code := []EdgeDefinition{TypedEdge("likes", "user", "post")}
+	report := CompareSchemas(nil, nil, code, nil)
+	found := false
+	for _, r := range report.Errors() {
+		if r.Table == "likes" && strings.Contains(r.Message, "missing from database") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected missing edge error; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasEdgeExtra(t *testing.T) {
+	db := []EdgeDefinition{TypedEdge("likes", "user", "post")}
+	report := CompareSchemas(nil, nil, nil, db)
+	found := false
+	for _, r := range report.Warnings() {
+		if r.Table == "likes" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected extra edge warning; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasEdgeModeMismatch(t *testing.T) {
+	code := []EdgeDefinition{TypedEdge("likes", "user", "post")}
+	db := []EdgeDefinition{NewEdge("likes", WithEdgeMode(EdgeModeSchemafull))}
+	report := CompareSchemas(nil, nil, code, db)
+	found := false
+	for _, r := range report.Errors() {
+		if strings.Contains(r.Message, "Edge mode mismatch") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected edge mode mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasEdgeFromToMismatch(t *testing.T) {
+	code := []EdgeDefinition{TypedEdge("likes", "user", "post")}
+	db := []EdgeDefinition{TypedEdge("likes", "user", "comment")}
+	report := CompareSchemas(nil, nil, code, db)
+	found := false
+	for _, r := range report.Errors() {
+		if strings.Contains(r.Message, "to_table") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected to_table mismatch; got %+v", report.Results)
+	}
+}
+
+func TestCompareSchemasEdgeFieldMismatch(t *testing.T) {
+	code := []EdgeDefinition{TypedEdge("likes", "user", "post",
+		WithEdgeFields(IntField("weight")))}
+	db := []EdgeDefinition{TypedEdge("likes", "user", "post")}
+	report := CompareSchemas(nil, nil, code, db)
+	found := false
+	for _, r := range report.Errors() {
+		if r.Field == "weight" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected edge field missing; got %+v", report.Results)
+	}
+}
+
+// Utility functions.
+
+func sampleResults() []ValidationResult {
+	return []ValidationResult{
+		{Severity: SeverityError, Table: "user", Field: "email"},
+		{Severity: SeverityWarning, Table: "user", Field: "name"},
+		{Severity: SeverityInfo, Table: "user", Field: "age"},
+		{Severity: SeverityError, Table: "post", Field: "title"},
+	}
+}
+
+func TestFilterBySeverityError(t *testing.T) {
+	got := FilterBySeverity(sampleResults(), SeverityError)
+	if len(got) != 2 {
+		t.Errorf("got %d errors, want 2", len(got))
+	}
+}
+
+func TestFilterBySeverityWarning(t *testing.T) {
+	got := FilterBySeverity(sampleResults(), SeverityWarning)
+	if len(got) != 1 {
+		t.Errorf("got %d warnings, want 1", len(got))
+	}
+}
+
+func TestFilterBySeverityNoMatch(t *testing.T) {
+	got := FilterBySeverity([]ValidationResult{{Severity: SeverityError}}, SeverityInfo)
+	if len(got) != 0 {
+		t.Errorf("expected empty slice, got %d", len(got))
+	}
+}
+
+func TestFilterBySeverityEmpty(t *testing.T) {
+	got := FilterBySeverity(nil, SeverityError)
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestFilterErrors(t *testing.T) {
+	got := FilterErrors(sampleResults())
+	if len(got) != 2 {
+		t.Errorf("got %d, want 2", len(got))
+	}
+	for _, r := range got {
+		if r.Severity != SeverityError {
+			t.Errorf("unexpected severity: %v", r)
+		}
+	}
+}
+
+func TestFilterWarnings(t *testing.T) {
+	got := FilterWarnings(sampleResults())
+	if len(got) != 1 {
+		t.Errorf("got %d, want 1", len(got))
+	}
+}
+
+func TestFilterInfos(t *testing.T) {
+	got := FilterInfos(sampleResults())
+	if len(got) != 1 {
+		t.Errorf("got %d, want 1", len(got))
+	}
+}
+
+func TestGroupByTable(t *testing.T) {
+	grouped := GroupByTable(sampleResults())
+	if len(grouped["user"]) != 3 {
+		t.Errorf("user: got %d, want 3", len(grouped["user"]))
+	}
+	if len(grouped["post"]) != 1 {
+		t.Errorf("post: got %d, want 1", len(grouped["post"]))
+	}
+}
+
+func TestGroupByTableEmpty(t *testing.T) {
+	grouped := GroupByTable(nil)
+	if len(grouped) != 0 {
+		t.Errorf("expected empty, got %d keys", len(grouped))
+	}
+}
+
+func TestHasErrorsTrue(t *testing.T) {
+	if !HasErrors(sampleResults()) {
+		t.Error("HasErrors = false, want true")
+	}
+}
+
+func TestHasErrorsFalse(t *testing.T) {
+	results := []ValidationResult{
+		{Severity: SeverityWarning},
+		{Severity: SeverityInfo},
+	}
+	if HasErrors(results) {
+		t.Error("HasErrors = true, want false")
+	}
+}
+
+func TestHasErrorsEmpty(t *testing.T) {
+	if HasErrors(nil) {
+		t.Error("HasErrors(nil) = true, want false")
+	}
+}
+
+func TestFormatValidationReportEmpty(t *testing.T) {
+	s := FormatValidationReport(nil, false)
+	if !strings.Contains(s, "No schema validation issues") {
+		t.Errorf("unexpected empty report: %q", s)
+	}
+}
+
+func TestFormatValidationReportWithErrors(t *testing.T) {
+	s := FormatValidationReport(sampleResults(), false)
+	for _, want := range []string{"Schema Validation Report", "user", "post", "[!]", "[~]"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("report missing %q: %s", want, s)
+		}
+	}
+}
+
+func TestFormatValidationReportExcludesInfoByDefault(t *testing.T) {
+	results := []ValidationResult{{Severity: SeverityInfo, Table: "u", Message: "info"}}
+	s := FormatValidationReport(results, false)
+	if !strings.Contains(s, "No significant") {
+		t.Errorf("expected 'No significant' summary, got: %s", s)
+	}
+}
+
+func TestFormatValidationReportIncludesInfoWhenRequested(t *testing.T) {
+	results := []ValidationResult{{Severity: SeverityInfo, Table: "u", Message: "info"}}
+	s := FormatValidationReport(results, true)
+	if !strings.Contains(s, "u") || !strings.Contains(s, "[i]") {
+		t.Errorf("expected info marker in report, got: %s", s)
+	}
+}
+
+func TestGetValidationSummaryMixed(t *testing.T) {
+	summary := GetValidationSummary(sampleResults())
+	if summary.Total != 4 {
+		t.Errorf("Total = %d, want 4", summary.Total)
+	}
+	if summary.Errors != 2 {
+		t.Errorf("Errors = %d, want 2", summary.Errors)
+	}
+	if summary.Warnings != 1 {
+		t.Errorf("Warnings = %d, want 1", summary.Warnings)
+	}
+	if summary.Info != 1 {
+		t.Errorf("Info = %d, want 1", summary.Info)
+	}
+	if summary.TablesAffected != 2 {
+		t.Errorf("TablesAffected = %d, want 2", summary.TablesAffected)
+	}
+	if !summary.HasErrors {
+		t.Error("HasErrors = false, want true")
+	}
+}
+
+func TestGetValidationSummaryEmpty(t *testing.T) {
+	summary := GetValidationSummary(nil)
+	if summary.Total != 0 || summary.HasErrors {
+		t.Errorf("expected zero summary, got %+v", summary)
+	}
+}
+
+func TestGetValidationSummaryNoErrors(t *testing.T) {
+	summary := GetValidationSummary([]ValidationResult{{Severity: SeverityWarning}})
+	if summary.HasErrors {
+		t.Error("HasErrors = true, want false")
+	}
+}
+
+// normalizeExpression / extractRecordTarget helpers.
+
+func TestNormalizeExpression(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"  ", ""},
+		{"$value != NONE", "$value != NONE"},
+		{"$value  !=  NONE", "$value != NONE"},
+		{"\t$value\n!=\tNONE ", "$value != NONE"},
+	}
+	for _, c := range cases {
+		got := normalizeExpression(c.in)
+		if got != c.want {
+			t.Errorf("normalize(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestExtractRecordTarget(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{`$value.table = "post"`, "post"},
+		{`$value.table = 'post'`, "post"},
+		{`($value.table = "post") AND ($value != NONE)`, "post"},
+		{`$value != NONE`, ""},
+		{`$value.table =`, ""},
+	}
+	for _, c := range cases {
+		got := extractRecordTarget(c.in)
+		if got != c.want {
+			t.Errorf("extractRecordTarget(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSortedSliceEqual(t *testing.T) {
+	if !sortedSliceEqual([]string{"a", "b"}, []string{"b", "a"}) {
+		t.Error("expected equal sorted slices")
+	}
+	if sortedSliceEqual([]string{"a"}, []string{"a", "b"}) {
+		t.Error("unequal lengths must not match")
+	}
+	if sortedSliceEqual([]string{"a"}, []string{"b"}) {
+		t.Error("different elements must not match")
+	}
+	if !sortedSliceEqual(nil, nil) {
+		t.Error("nil/nil should match")
+	}
+}

--- a/pkg/surql/schema/validator_utils.go
+++ b/pkg/surql/schema/validator_utils.go
@@ -1,0 +1,206 @@
+package schema
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// FilterBySeverity returns the subset of results with the given severity.
+// The input slice is not mutated. A nil results slice returns nil.
+func FilterBySeverity(results []ValidationResult, severity ValidationSeverity) []ValidationResult {
+	if len(results) == 0 {
+		return nil
+	}
+	out := make([]ValidationResult, 0, len(results))
+	for _, r := range results {
+		if r.Severity == severity {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// FilterErrors returns only ERROR-severity results.
+func FilterErrors(results []ValidationResult) []ValidationResult {
+	return FilterBySeverity(results, SeverityError)
+}
+
+// FilterWarnings returns only WARNING-severity results.
+func FilterWarnings(results []ValidationResult) []ValidationResult {
+	return FilterBySeverity(results, SeverityWarning)
+}
+
+// FilterInfos returns only INFO-severity results.
+func FilterInfos(results []ValidationResult) []ValidationResult {
+	return FilterBySeverity(results, SeverityInfo)
+}
+
+// GroupByTable buckets results by their Table field. The returned map keys are
+// sortable by the caller; map ordering itself is not guaranteed.
+func GroupByTable(results []ValidationResult) map[string][]ValidationResult {
+	grouped := make(map[string][]ValidationResult)
+	for _, r := range results {
+		grouped[r.Table] = append(grouped[r.Table], r)
+	}
+	return grouped
+}
+
+// HasErrors reports whether any ERROR-severity result exists in results.
+func HasErrors(results []ValidationResult) bool {
+	for _, r := range results {
+		if r.Severity == SeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+// FormatValidationReport renders a human-readable schema report. When
+// includeInfo is false (the default in surql-py), INFO-severity findings are
+// omitted from the output.
+func FormatValidationReport(results []ValidationResult, includeInfo bool) string {
+	if len(results) == 0 {
+		return "No schema validation issues found."
+	}
+
+	filtered := results
+	if !includeInfo {
+		filtered = make([]ValidationResult, 0, len(results))
+		for _, r := range results {
+			if r.Severity != SeverityInfo {
+				filtered = append(filtered, r)
+			}
+		}
+	}
+
+	if len(filtered) == 0 {
+		return "No significant schema validation issues found."
+	}
+
+	grouped := GroupByTable(filtered)
+	errorCount := len(FilterErrors(filtered))
+	warningCount := len(FilterWarnings(filtered))
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Schema Validation Report: %d errors, %d warnings\n",
+		errorCount, warningCount)
+	b.WriteString(strings.Repeat("=", 60))
+
+	tableNames := make([]string, 0, len(grouped))
+	for k := range grouped {
+		tableNames = append(tableNames, k)
+	}
+	sort.Strings(tableNames)
+
+	for _, name := range tableNames {
+		b.WriteString("\n\n[")
+		b.WriteString(name)
+		b.WriteString("]")
+		for _, r := range grouped[name] {
+			b.WriteString("\n  ")
+			b.WriteString(severityIcon(r.Severity))
+			b.WriteString(" ")
+			b.WriteString(r.Message)
+			if r.Field != "" {
+				b.WriteString(".")
+				b.WriteString(r.Field)
+			}
+			if r.CodeValue != "" || r.DBValue != "" {
+				b.WriteString("\n      code: ")
+				b.WriteString(r.CodeValue)
+				b.WriteString(", db: ")
+				b.WriteString(r.DBValue)
+			}
+		}
+	}
+
+	return b.String()
+}
+
+// ValidationSummary aggregates counts across severity levels for quick
+// programmatic inspection (CLI JSON output, dashboards).
+type ValidationSummary struct {
+	Total          int  `json:"total"`
+	Errors         int  `json:"errors"`
+	Warnings       int  `json:"warnings"`
+	Info           int  `json:"info"`
+	TablesAffected int  `json:"tables_affected"`
+	HasErrors      bool `json:"has_errors"`
+}
+
+// GetValidationSummary returns a ValidationSummary for the provided results.
+func GetValidationSummary(results []ValidationResult) ValidationSummary {
+	return ValidationSummary{
+		Total:          len(results),
+		Errors:         len(FilterErrors(results)),
+		Warnings:       len(FilterWarnings(results)),
+		Info:           len(FilterInfos(results)),
+		TablesAffected: len(GroupByTable(results)),
+		HasErrors:      HasErrors(results),
+	}
+}
+
+// severityIcon returns a short ASCII badge for a severity level.
+func severityIcon(s ValidationSeverity) string {
+	switch s {
+	case SeverityError:
+		return "[!]"
+	case SeverityWarning:
+		return "[~]"
+	case SeverityInfo:
+		return "[i]"
+	}
+	return "[ ]"
+}
+
+// normalizeExpression collapses contiguous whitespace and trims the result for
+// comparing SurrealQL expression fragments (ASSERT, DEFAULT, VALUE). Returns
+// the empty string when the input is empty or only whitespace.
+func normalizeExpression(expr string) string {
+	return strings.Join(strings.Fields(expr), " ")
+}
+
+// extractRecordTarget pulls the target table name out of an assertion of the
+// form `$value.table = "name"` produced by RecordField. Returns the empty
+// string when no match is found (manual assertions are deliberately skipped to
+// avoid false positives).
+func extractRecordTarget(assertion string) string {
+	const prefix = "$value.table ="
+	idx := strings.Index(assertion, prefix)
+	if idx == -1 {
+		return ""
+	}
+	rest := strings.TrimSpace(assertion[idx+len(prefix):])
+	if rest == "" {
+		return ""
+	}
+	quote := rest[0]
+	if quote != '"' && quote != '\'' {
+		return ""
+	}
+	end := strings.IndexByte(rest[1:], quote)
+	if end == -1 {
+		return ""
+	}
+	return rest[1 : 1+end]
+}
+
+// sortedSliceEqual reports whether a and b contain the same strings, ignoring
+// their original order. Used by diffIndex so index column ordering differences
+// don't trigger false mismatches (matching surql-py behaviour).
+func sortedSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aa := append([]string(nil), a...)
+	bb := append([]string(nil), b...)
+	sort.Strings(aa)
+	sort.Strings(bb)
+	for i := range aa {
+		if aa[i] != bb[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/surql/schema/visualize.go
+++ b/pkg/surql/schema/visualize.go
@@ -1,0 +1,520 @@
+package schema
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// VisualizeOptions controls optional inclusion of fields and edges in the
+// generated diagram. The zero value includes both.
+type VisualizeOptions struct {
+	// IncludeFields, when false, omits per-field rows from the diagram.
+	// Default: true (represented as the zero value via a nil *bool pattern
+	// would be awkward, so callers opt in/out with WithIncludeFields.)
+	IncludeFields bool
+	// IncludeEdges, when false, omits edge/relationship output.
+	IncludeEdges bool
+	fieldsSet    bool
+	edgesSet     bool
+}
+
+// VisualizeOption customises a VisualizeOptions.
+type VisualizeOption func(*VisualizeOptions)
+
+// WithIncludeFields toggles inclusion of field definitions.
+func WithIncludeFields(include bool) VisualizeOption {
+	return func(o *VisualizeOptions) {
+		o.IncludeFields = include
+		o.fieldsSet = true
+	}
+}
+
+// WithIncludeEdges toggles inclusion of edge relationships.
+func WithIncludeEdges(include bool) VisualizeOption {
+	return func(o *VisualizeOptions) {
+		o.IncludeEdges = include
+		o.edgesSet = true
+	}
+}
+
+// resolveOptions applies opts and substitutes defaults for flags that were
+// never explicitly set.
+func resolveOptions(opts []VisualizeOption) VisualizeOptions {
+	o := VisualizeOptions{}
+	for _, fn := range opts {
+		fn(&o)
+	}
+	if !o.fieldsSet {
+		o.IncludeFields = true
+	}
+	if !o.edgesSet {
+		o.IncludeEdges = true
+	}
+	return o
+}
+
+// sortedTableMap returns a stable iteration order for tables.
+func sortedTableMap(tables map[string]TableDefinition) []string {
+	names := make([]string, 0, len(tables))
+	for k := range tables {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// sortedEdgeMap returns a stable iteration order for edges.
+func sortedEdgeMap(edges map[string]EdgeDefinition) []string {
+	names := make([]string, 0, len(edges))
+	for k := range edges {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// registryTables snapshots the registry tables into a map keyed by name.
+func registryTables(r *SchemaRegistry) map[string]TableDefinition {
+	out := map[string]TableDefinition{}
+	for _, t := range r.Tables() {
+		out[t.Name] = t
+	}
+	return out
+}
+
+// registryEdges snapshots the registry edges into a map keyed by name.
+func registryEdges(r *SchemaRegistry) map[string]EdgeDefinition {
+	out := map[string]EdgeDefinition{}
+	for _, e := range r.Edges() {
+		out[e.Name] = e
+	}
+	return out
+}
+
+// GenerateMermaid renders a Mermaid ER diagram from registry using theme.
+// The diagram contains entity blocks for every table (always showing the
+// implicit id PK row) and any relationships derived from edges. Pass an
+// empty MermaidTheme to suppress the %%{init}%% directive.
+func GenerateMermaid(r *SchemaRegistry, theme MermaidTheme, opts ...VisualizeOption) string {
+	return GenerateMermaidFromMaps(registryTables(r), registryEdges(r), theme, opts...)
+}
+
+// GenerateMermaidFromMaps is like GenerateMermaid but operates on raw
+// table/edge maps, matching the surql-py entry point signature.
+func GenerateMermaidFromMaps(
+	tables map[string]TableDefinition,
+	edges map[string]EdgeDefinition,
+	theme MermaidTheme,
+	opts ...VisualizeOption,
+) string {
+	options := resolveOptions(opts)
+	var b strings.Builder
+
+	if theme.ThemeName != "" {
+		fmt.Fprintf(&b, "%%%%{init: {'theme':'%s'}}%%%%\n", theme.ThemeName)
+	}
+	b.WriteString("erDiagram")
+
+	for _, name := range sortedTableMap(tables) {
+		table := tables[name]
+		b.WriteString("\n    ")
+		b.WriteString(name)
+		b.WriteString(" {")
+		if options.IncludeFields {
+			b.WriteString("\n        string id PK")
+			for _, f := range table.Fields {
+				constraint := fieldConstraint(f.Name, table)
+				constraintStr := ""
+				if constraint != "" {
+					constraintStr = " " + constraint
+				}
+				fmt.Fprintf(&b, "\n        %s %s%s", fieldTypeString(f.Type), f.Name, constraintStr)
+			}
+		}
+		b.WriteString("\n    }")
+	}
+
+	for _, name := range sortedEdgeMap(edges) {
+		edge := edges[name]
+		if !options.IncludeFields || len(edge.Fields) == 0 {
+			continue
+		}
+		b.WriteString("\n    ")
+		b.WriteString(name)
+		b.WriteString(" {")
+		for _, f := range edge.Fields {
+			fmt.Fprintf(&b, "\n        %s %s", fieldTypeString(f.Type), f.Name)
+		}
+		b.WriteString("\n    }")
+	}
+
+	if options.IncludeEdges {
+		b.WriteString("\n")
+		for _, name := range sortedEdgeMap(edges) {
+			edge := edges[name]
+			from := edge.FromTable
+			if from == "" {
+				from = "unknown"
+			}
+			to := edge.ToTable
+			if to == "" {
+				to = "unknown"
+			}
+			if _, ok := tables[from]; !ok && from != "unknown" {
+				continue
+			}
+			if _, ok := tables[to]; !ok && to != "unknown" {
+				continue
+			}
+			cardinality := mermaidCardinality(edge)
+			fmt.Fprintf(&b, "\n    %s %s %s : %s", from, cardinality, to, name)
+		}
+	}
+
+	return b.String()
+}
+
+// mermaidCardinality picks a Mermaid cardinality symbol based on edge
+// semantics. Self-referential edges (from == to) are rendered many-to-many;
+// everything else defaults to one-to-many.
+func mermaidCardinality(edge EdgeDefinition) string {
+	if edge.FromTable != "" && edge.FromTable == edge.ToTable {
+		return "}o--o{"
+	}
+	return "||--o{"
+}
+
+// GenerateGraphViz renders a GraphViz DOT diagram from registry using theme.
+func GenerateGraphViz(r *SchemaRegistry, theme GraphVizTheme, opts ...VisualizeOption) string {
+	return GenerateGraphVizFromMaps(registryTables(r), registryEdges(r), theme, opts...)
+}
+
+// GenerateGraphVizFromMaps is like GenerateGraphViz but operates on raw
+// table/edge maps.
+func GenerateGraphVizFromMaps(
+	tables map[string]TableDefinition,
+	edges map[string]EdgeDefinition,
+	theme GraphVizTheme,
+	opts ...VisualizeOption,
+) string {
+	options := resolveOptions(opts)
+	var b strings.Builder
+	b.WriteString("digraph schema {\n")
+	b.WriteString("    rankdir=LR;\n")
+
+	applyTheme := theme.UseGradients || (theme.NodeStyle != "" && theme.NodeStyle != "filled,rounded")
+	if applyTheme {
+		if theme.BgColor != "" && theme.BgColor != "transparent" {
+			fmt.Fprintf(&b, "    bgcolor=%q;\n", theme.BgColor)
+		}
+		fmt.Fprintf(&b, "    fontname=%q;\n", theme.FontName)
+
+		nodeAttrs := []string{fmt.Sprintf("shape=%s", theme.NodeShape)}
+		if theme.NodeStyle != "" {
+			nodeAttrs = append(nodeAttrs, fmt.Sprintf("style=%q", theme.NodeStyle))
+		}
+		nodeAttrs = append(nodeAttrs, fmt.Sprintf("fontname=%q", theme.FontName))
+		nodeAttrs = append(nodeAttrs, `pad="0.5"`, `margin="0.2"`)
+		fmt.Fprintf(&b, "    node [%s];\n", strings.Join(nodeAttrs, ", "))
+
+		edgeAttrs := []string{fmt.Sprintf("color=%q", theme.EdgeColor)}
+		if theme.EdgeStyle != "" {
+			edgeAttrs = append(edgeAttrs, fmt.Sprintf("style=%s", theme.EdgeStyle))
+		}
+		edgeAttrs = append(edgeAttrs, fmt.Sprintf("fontname=%q", theme.FontName))
+		fmt.Fprintf(&b, "    edge [%s];\n", strings.Join(edgeAttrs, ", "))
+	} else {
+		b.WriteString("    node [shape=record];\n")
+	}
+
+	b.WriteString("\n")
+
+	for _, name := range sortedTableMap(tables) {
+		table := tables[name]
+		label := buildGraphVizTableLabel(name, table, options.IncludeFields, theme)
+		fmt.Fprintf(&b, "    %s [label=%s];\n", name, label)
+	}
+	for _, name := range sortedEdgeMap(edges) {
+		edge := edges[name]
+		if !options.IncludeFields || len(edge.Fields) == 0 {
+			continue
+		}
+		label := buildGraphVizEdgeLabel(name, edge, theme)
+		fmt.Fprintf(&b, "    %s [label=%s];\n", name, label)
+	}
+
+	b.WriteString("\n")
+
+	if options.IncludeEdges {
+		modern := ModernTheme()
+		for _, name := range sortedEdgeMap(edges) {
+			edge := edges[name]
+			from := edge.FromTable
+			to := edge.ToTable
+			if from == "" || to == "" {
+				continue
+			}
+			if _, ok := tables[from]; !ok {
+				continue
+			}
+			if _, ok := tables[to]; !ok {
+				continue
+			}
+			style := graphVizEdgeStyle(edge, theme, modern.Colors)
+			fmt.Fprintf(&b, "    %s -> %s [label=%q%s];\n", from, to, name, style)
+		}
+	}
+
+	b.WriteString("}")
+	return b.String()
+}
+
+func buildGraphVizTableLabel(
+	tableName string,
+	table TableDefinition,
+	includeFields bool,
+	theme GraphVizTheme,
+) string {
+	if !includeFields {
+		return fmt.Sprintf("%q", tableName)
+	}
+	if theme.UseGradients {
+		return buildGraphVizHTMLLabel(tableName, table, theme)
+	}
+	parts := []string{tableName, "id : string (PK)\\l"}
+	for _, f := range table.Fields {
+		constraint := fieldConstraint(f.Name, table)
+		constraintStr := ""
+		if constraint != "" {
+			constraintStr = " (" + constraint + ")"
+		}
+		parts = append(parts, fmt.Sprintf("%s : %s%s\\l", f.Name, fieldTypeString(f.Type), constraintStr))
+	}
+	return `"{` + strings.Join(parts, "|") + `}"`
+}
+
+func buildGraphVizHTMLLabel(tableName string, table TableDefinition, theme GraphVizTheme) string {
+	modern := ModernTheme()
+	var b strings.Builder
+	b.WriteString("<")
+	b.WriteString(`<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4">`)
+	fmt.Fprintf(&b, `<TR><TD BGCOLOR="%s" COLSPAN="2">`, theme.NodeColor)
+	fmt.Fprintf(&b, `<FONT COLOR="#FFFFFF"><B>%s</B></FONT>`, tableName)
+	b.WriteString("</TD></TR>")
+
+	b.WriteString("<TR>")
+	b.WriteString(`<TD ALIGN="LEFT">id</TD>`)
+	b.WriteString(`<TD ALIGN="LEFT">`)
+	fmt.Fprintf(&b, `<FONT COLOR="%s">string</FONT>`, modern.Colors.Muted)
+	fmt.Fprintf(&b, ` <FONT COLOR="%s">PK</FONT>`, modern.Colors.Error)
+	b.WriteString("</TD></TR>")
+
+	for _, f := range table.Fields {
+		constraint := fieldConstraint(f.Name, table)
+		fieldColor := fieldTypeColor(f.Type, modern.Colors)
+
+		b.WriteString("<TR>")
+		fmt.Fprintf(&b, `<TD ALIGN="LEFT">%s</TD>`, f.Name)
+		b.WriteString(`<TD ALIGN="LEFT">`)
+		fmt.Fprintf(&b, `<FONT COLOR="%s">%s</FONT>`, fieldColor, fieldTypeString(f.Type))
+		if constraint != "" {
+			constraintColor := constraintColor(constraint, modern.Colors)
+			fmt.Fprintf(&b, ` <FONT COLOR="%s">%s</FONT>`, constraintColor, constraint)
+		}
+		b.WriteString("</TD></TR>")
+	}
+	b.WriteString("</TABLE>>")
+	return b.String()
+}
+
+func buildGraphVizEdgeLabel(edgeName string, edge EdgeDefinition, theme GraphVizTheme) string {
+	if theme.UseGradients {
+		modern := ModernTheme()
+		var b strings.Builder
+		b.WriteString("<")
+		b.WriteString(`<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4">`)
+		fmt.Fprintf(&b, `<TR><TD BGCOLOR="%s" COLSPAN="2">`, theme.NodeColor)
+		fmt.Fprintf(&b, `<FONT COLOR="#FFFFFF"><B>%s</B></FONT>`, edgeName)
+		b.WriteString("</TD></TR>")
+		for _, f := range edge.Fields {
+			fieldColor := fieldTypeColor(f.Type, modern.Colors)
+			b.WriteString("<TR>")
+			fmt.Fprintf(&b, `<TD ALIGN="LEFT">%s</TD>`, f.Name)
+			fmt.Fprintf(&b, `<TD ALIGN="LEFT"><FONT COLOR="%s">%s</FONT></TD>`, fieldColor, fieldTypeString(f.Type))
+			b.WriteString("</TR>")
+		}
+		b.WriteString("</TABLE>>")
+		return b.String()
+	}
+	parts := []string{edgeName}
+	for _, f := range edge.Fields {
+		parts = append(parts, fmt.Sprintf("%s : %s\\l", f.Name, fieldTypeString(f.Type)))
+	}
+	return `"{` + strings.Join(parts, "|") + `}"`
+}
+
+func graphVizEdgeStyle(edge EdgeDefinition, theme GraphVizTheme, colors ColorScheme) string {
+	if edge.FromTable != "" && edge.FromTable == edge.ToTable {
+		if theme.UseGradients {
+			return fmt.Sprintf(`, style=dashed, color=%q`, colors.Secondary)
+		}
+		return ", style=dashed"
+	}
+	return ""
+}
+
+func fieldTypeColor(t FieldType, c ColorScheme) string {
+	switch t {
+	case FieldTypeString:
+		return c.Success
+	case FieldTypeInt, FieldTypeFloat, FieldTypeDecimal, FieldTypeNumber:
+		return c.Warning
+	case FieldTypeBool:
+		return c.Accent
+	case FieldTypeDatetime, FieldTypeDuration:
+		return c.Secondary
+	case FieldTypeRecord:
+		return c.Primary
+	case FieldTypeObject, FieldTypeArray:
+		return c.Muted
+	}
+	return c.Text
+}
+
+func constraintColor(constraint string, c ColorScheme) string {
+	switch constraint {
+	case "PK":
+		return c.Error
+	case "FK":
+		return c.Primary
+	case "UK":
+		return c.Accent
+	}
+	return c.Text
+}
+
+// GenerateASCII renders a plain-text ASCII diagram for registry using theme.
+func GenerateASCII(r *SchemaRegistry, theme ASCIITheme, opts ...VisualizeOption) string {
+	return GenerateASCIIFromMaps(registryTables(r), registryEdges(r), theme, opts...)
+}
+
+// GenerateASCIIFromMaps is like GenerateASCII but operates on raw
+// table/edge maps.
+func GenerateASCIIFromMaps(
+	tables map[string]TableDefinition,
+	edges map[string]EdgeDefinition,
+	theme ASCIITheme,
+	opts ...VisualizeOption,
+) string {
+	options := resolveOptions(opts)
+
+	// Resolve the effective theme (zero value means "no unicode, no colors,
+	// no icons" which matches surql-py's default behaviour).
+	var lines []string
+	for _, name := range sortedTableMap(tables) {
+		box := buildASCIITableBox(name, tables[name], options.IncludeFields, theme)
+		lines = append(lines, box...)
+		lines = append(lines, "")
+	}
+
+	if options.IncludeEdges && len(edges) > 0 {
+		lines = append(lines, "Relationships:")
+		lines = append(lines, strings.Repeat("-", 40))
+		for _, name := range sortedEdgeMap(edges) {
+			edge := edges[name]
+			from := edge.FromTable
+			if from == "" {
+				from = "?"
+			}
+			to := edge.ToTable
+			if to == "" {
+				to = "?"
+			}
+			lines = append(lines, fmt.Sprintf("  %s --[%s]--> %s", from, name, to))
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func buildASCIITableBox(
+	name string,
+	table TableDefinition,
+	includeFields bool,
+	theme ASCIITheme,
+) []string {
+	chars := boxChars(theme)
+
+	var fieldLines []string
+	if includeFields {
+		pkIcon := constraintIcon(theme, "PK")
+		pkText := colorize(theme, fmt.Sprintf("%s(PK)", pkIcon), "pk")
+		fieldLines = append(fieldLines, fmt.Sprintf("id : string %s", pkText))
+		for _, f := range table.Fields {
+			constraint := fieldConstraint(f.Name, table)
+			constraintStr := ""
+			if constraint != "" {
+				icon := constraintIcon(theme, constraint)
+				colorType := strings.ToLower(constraint)
+				label := colorize(theme, fmt.Sprintf("%s(%s)", icon, constraint), colorType)
+				constraintStr = " " + label
+			}
+			fieldLines = append(fieldLines, fmt.Sprintf("%s : %s%s", f.Name, fieldTypeString(f.Type), constraintStr))
+		}
+	}
+
+	minWidth := len(name) + 4
+	if minWidth < 20 {
+		minWidth = 20
+	}
+	contentWidth := 0
+	for _, l := range fieldLines {
+		w := displayWidth(l)
+		if w > contentWidth {
+			contentWidth = w
+		}
+	}
+	width := minWidth
+	if contentWidth+2 > width {
+		width = contentWidth + 2
+	}
+
+	top := chars["tl"] + repeatRune(chars["h"], width) + chars["tr"]
+	bottom := chars["bl"] + repeatRune(chars["h"], width) + chars["br"]
+	out := []string{top}
+
+	styledName := colorize(theme, centerText(name, width), "header")
+	leftPad, rightPad := centerPad(styledName, width)
+	out = append(out, chars["v"]+strings.Repeat(" ", leftPad)+styledName+strings.Repeat(" ", rightPad)+chars["v"])
+
+	if includeFields {
+		separator := chars["ml"] + repeatRune(chars["h"], width) + chars["mr"]
+		out = append(out, separator)
+		for _, line := range fieldLines {
+			visible := displayWidth(line)
+			padding := width - visible - 1
+			if padding < 0 {
+				padding = 0
+			}
+			out = append(out, fmt.Sprintf("%s %s%s%s", chars["v"], line, strings.Repeat(" ", padding), chars["v"]))
+		}
+	}
+	out = append(out, bottom)
+	return out
+}
+
+// centerText produces a string whose display-width is >= width, centring
+// text within that width using plain space padding. Matches Python
+// str.center which places the extra padding char on the LEFT when the
+// padding amount is odd.
+func centerText(text string, width int) string {
+	visible := displayWidth(text)
+	if visible >= width {
+		return text
+	}
+	padding := width - visible
+	right := padding / 2
+	left := padding - right
+	return strings.Repeat(" ", left) + text + strings.Repeat(" ", right)
+}

--- a/pkg/surql/schema/visualize_test.go
+++ b/pkg/surql/schema/visualize_test.go
@@ -1,0 +1,713 @@
+package schema
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// -------------------- Helpers --------------------
+
+func newRegistryWith(
+	t *testing.T,
+	tables []TableDefinition,
+	edges []EdgeDefinition,
+) *SchemaRegistry {
+	t.Helper()
+	r := NewSchemaRegistry()
+	for _, tbl := range tables {
+		if err := r.RegisterTable(tbl); err != nil {
+			t.Fatalf("RegisterTable(%q): %v", tbl.Name, err)
+		}
+	}
+	for _, e := range edges {
+		if err := r.RegisterEdge(e); err != nil {
+			t.Fatalf("RegisterEdge(%q): %v", e.Name, err)
+		}
+	}
+	return r
+}
+
+func mustEqual(t *testing.T, got, want, label string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s mismatch\nwant:\n%q\n\ngot:\n%q", label, want, got)
+	}
+}
+
+// userTable returns a TableDefinition named "user" with a single string field.
+func userTable() TableDefinition {
+	return NewTable("user", WithFields(StringField("email")))
+}
+
+// -------------------- Theme presets --------------------
+
+func TestModernThemeConstants(t *testing.T) {
+	th := ModernTheme()
+	if th.Name != "modern" {
+		t.Errorf("modern.Name = %q", th.Name)
+	}
+	if th.Colors.Primary != "#6366f1" {
+		t.Errorf("modern.Colors.Primary = %q", th.Colors.Primary)
+	}
+	if th.GraphViz.NodeColor != "#6366f1" {
+		t.Errorf("modern.GraphViz.NodeColor = %q", th.GraphViz.NodeColor)
+	}
+	if th.Mermaid.ThemeName != "default" {
+		t.Errorf("modern.Mermaid.ThemeName = %q", th.Mermaid.ThemeName)
+	}
+	if th.ASCII.BoxStyle != "rounded" {
+		t.Errorf("modern.ASCII.BoxStyle = %q", th.ASCII.BoxStyle)
+	}
+	if !th.ASCII.UseUnicode || !th.ASCII.UseColors || !th.ASCII.UseIcons {
+		t.Errorf("modern.ASCII flags = %+v", th.ASCII)
+	}
+}
+
+func TestDarkThemeConstants(t *testing.T) {
+	th := DarkTheme()
+	if th.Name != "dark" {
+		t.Errorf("dark.Name = %q", th.Name)
+	}
+	if th.Colors.Primary != "#8b5cf6" {
+		t.Errorf("dark.Colors.Primary = %q", th.Colors.Primary)
+	}
+	if th.GraphViz.BgColor != "#1e1b4b" {
+		t.Errorf("dark.GraphViz.BgColor = %q", th.GraphViz.BgColor)
+	}
+	if th.Mermaid.ThemeName != "dark" {
+		t.Errorf("dark.Mermaid.ThemeName = %q", th.Mermaid.ThemeName)
+	}
+}
+
+func TestForestThemeConstants(t *testing.T) {
+	th := ForestTheme()
+	if th.Name != "forest" {
+		t.Errorf("forest.Name = %q", th.Name)
+	}
+	if th.Colors.Primary != "#10b981" {
+		t.Errorf("forest.Colors.Primary = %q", th.Colors.Primary)
+	}
+	if th.GraphViz.NodeColor != "#10b981" {
+		t.Errorf("forest.GraphViz.NodeColor = %q", th.GraphViz.NodeColor)
+	}
+	if th.Mermaid.ThemeName != "forest" {
+		t.Errorf("forest.Mermaid.ThemeName = %q", th.Mermaid.ThemeName)
+	}
+}
+
+func TestMinimalThemeConstants(t *testing.T) {
+	th := MinimalTheme()
+	if th.Name != "minimal" {
+		t.Errorf("minimal.Name = %q", th.Name)
+	}
+	if th.Colors.Primary != "#6b7280" {
+		t.Errorf("minimal.Colors.Primary = %q", th.Colors.Primary)
+	}
+	if th.Mermaid.ThemeName != "neutral" {
+		t.Errorf("minimal.Mermaid.ThemeName = %q", th.Mermaid.ThemeName)
+	}
+	if th.ASCII.BoxStyle != "single" {
+		t.Errorf("minimal.ASCII.BoxStyle = %q", th.ASCII.BoxStyle)
+	}
+	if th.ASCII.UseColors || th.ASCII.UseIcons {
+		t.Errorf("minimal.ASCII flags = %+v", th.ASCII)
+	}
+	if th.GraphViz.UseGradients {
+		t.Errorf("minimal.GraphViz.UseGradients = true, want false")
+	}
+}
+
+func TestGetThemeKnown(t *testing.T) {
+	for _, name := range []string{"modern", "dark", "forest", "minimal"} {
+		th, err := GetTheme(name)
+		if err != nil {
+			t.Fatalf("GetTheme(%q) error: %v", name, err)
+		}
+		if th.Name != name {
+			t.Errorf("GetTheme(%q).Name = %q", name, th.Name)
+		}
+	}
+}
+
+func TestGetThemeUnknown(t *testing.T) {
+	_, err := GetTheme("solarized")
+	if err == nil {
+		t.Fatalf("GetTheme(\"solarized\") error = nil, want non-nil")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("GetTheme unknown error kind = %v, want ErrValidation", err)
+	}
+	if !strings.Contains(err.Error(), "solarized") {
+		t.Errorf("GetTheme error = %q, want to contain %q", err.Error(), "solarized")
+	}
+}
+
+func TestListThemes(t *testing.T) {
+	names := ListThemes()
+	wantSorted := []string{"dark", "forest", "minimal", "modern"}
+	if len(names) != len(wantSorted) {
+		t.Fatalf("ListThemes length = %d, want %d", len(names), len(wantSorted))
+	}
+	for i, n := range wantSorted {
+		if names[i] != n {
+			t.Errorf("ListThemes[%d] = %q, want %q", i, names[i], n)
+		}
+	}
+}
+
+// -------------------- utils --------------------
+
+func TestFieldConstraintID(t *testing.T) {
+	tbl := NewTable("x")
+	if got := fieldConstraint("id", tbl); got != "PK" {
+		t.Errorf("id => %q, want PK", got)
+	}
+}
+
+func TestFieldConstraintUK(t *testing.T) {
+	tbl := NewTable("user",
+		WithFields(StringField("email")),
+		WithIndexes(UniqueIndex("u_email", []string{"email"})),
+	)
+	if got := fieldConstraint("email", tbl); got != "UK" {
+		t.Errorf("email UK => %q, want UK", got)
+	}
+}
+
+func TestFieldConstraintFK(t *testing.T) {
+	tbl := NewTable("post",
+		WithFields(RecordField("author", "user")),
+	)
+	if got := fieldConstraint("author", tbl); got != "FK" {
+		t.Errorf("author record => %q, want FK", got)
+	}
+}
+
+func TestFieldConstraintNone(t *testing.T) {
+	tbl := NewTable("user", WithFields(StringField("email")))
+	if got := fieldConstraint("email", tbl); got != "" {
+		t.Errorf("email no constraint => %q, want empty", got)
+	}
+}
+
+func TestDisplayWidthPlain(t *testing.T) {
+	if w := displayWidth("hello"); w != 5 {
+		t.Errorf("displayWidth hello = %d, want 5", w)
+	}
+}
+
+func TestDisplayWidthEmoji(t *testing.T) {
+	if w := displayWidth("🔑"); w != 2 {
+		t.Errorf("displayWidth 🔑 = %d, want 2", w)
+	}
+	if w := displayWidth("a🔑b"); w != 4 {
+		t.Errorf("displayWidth a🔑b = %d, want 4", w)
+	}
+}
+
+func TestDisplayWidthANSIStripped(t *testing.T) {
+	in := "\x1b[91m🔑 (PK)\x1b[0m"
+	// 🔑 = 2, " (PK)" = 5 => 7
+	if w := displayWidth(in); w != 7 {
+		t.Errorf("displayWidth with ANSI = %d, want 7", w)
+	}
+}
+
+func TestCenterPadPythonCompatible(t *testing.T) {
+	// Python str.center puts EXTRA on the left when padding is odd.
+	l, r := centerPad("post", 25)
+	if l != 11 || r != 10 {
+		t.Errorf("centerPad(post, 25) = (%d, %d), want (11, 10)", l, r)
+	}
+	l, r = centerPad("user", 20)
+	if l != 8 || r != 8 {
+		t.Errorf("centerPad(user, 20) = (%d, %d), want (8, 8)", l, r)
+	}
+}
+
+func TestBoxCharsUnicodeRounded(t *testing.T) {
+	th := ASCIITheme{BoxStyle: "rounded", UseUnicode: true}
+	ch := boxChars(th)
+	if ch["tl"] != "╭" || ch["br"] != "╯" {
+		t.Errorf("rounded box = %+v", ch)
+	}
+}
+
+func TestBoxCharsASCIIFallback(t *testing.T) {
+	ch := boxChars(ASCIITheme{}) // zero value => UseUnicode=false
+	if ch["tl"] != "+" || ch["h"] != "-" || ch["v"] != "|" {
+		t.Errorf("ascii fallback = %+v", ch)
+	}
+}
+
+func TestBoxCharsDouble(t *testing.T) {
+	th := ASCIITheme{BoxStyle: "double", UseUnicode: true}
+	ch := boxChars(th)
+	if ch["tl"] != "╔" || ch["h"] != "═" {
+		t.Errorf("double box = %+v", ch)
+	}
+}
+
+func TestBoxCharsHeavy(t *testing.T) {
+	th := ASCIITheme{BoxStyle: "heavy", UseUnicode: true}
+	ch := boxChars(th)
+	if ch["tl"] != "┏" || ch["h"] != "━" {
+		t.Errorf("heavy box = %+v", ch)
+	}
+}
+
+func TestColorizeDisabled(t *testing.T) {
+	th := ASCIITheme{UseColors: false}
+	if got := colorize(th, "x", "pk"); got != "x" {
+		t.Errorf("colorize off = %q", got)
+	}
+}
+
+func TestColorizeEnabled(t *testing.T) {
+	th := ASCIITheme{UseColors: true}
+	got := colorize(th, "(PK)", "pk")
+	want := "\x1b[91m(PK)\x1b[0m"
+	if got != want {
+		t.Errorf("colorize pk = %q, want %q", got, want)
+	}
+}
+
+func TestConstraintIconEnabled(t *testing.T) {
+	th := ASCIITheme{UseIcons: true}
+	if got := constraintIcon(th, "PK"); got != "🔑 " {
+		t.Errorf("icon PK = %q", got)
+	}
+	if got := constraintIcon(th, "FK"); got != "🔗 " {
+		t.Errorf("icon FK = %q", got)
+	}
+	if got := constraintIcon(th, "UK"); got != "⭐ " {
+		t.Errorf("icon UK = %q", got)
+	}
+}
+
+func TestConstraintIconDisabled(t *testing.T) {
+	th := ASCIITheme{UseIcons: false}
+	if got := constraintIcon(th, "PK"); got != "" {
+		t.Errorf("icon off PK = %q", got)
+	}
+}
+
+// -------------------- Mermaid --------------------
+
+func TestMermaidEmpty(t *testing.T) {
+	r := NewSchemaRegistry()
+	got := GenerateMermaid(r, MermaidTheme{})
+	want := "erDiagram\n"
+	mustEqual(t, got, want, "mermaid empty")
+}
+
+func TestMermaidUserNoTheme(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateMermaid(r, MermaidTheme{})
+	want := "erDiagram\n    user {\n        string id PK\n        string email\n    }\n"
+	mustEqual(t, got, want, "mermaid user no theme")
+}
+
+func TestMermaidUserModern(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateMermaid(r, ModernMermaidTheme())
+	want := "%%{init: {'theme':'default'}}%%\nerDiagram\n    user {\n        string id PK\n        string email\n    }\n"
+	mustEqual(t, got, want, "mermaid user modern")
+}
+
+func TestMermaidUserDark(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateMermaid(r, DarkMermaidTheme())
+	want := "%%{init: {'theme':'dark'}}%%\nerDiagram\n    user {\n        string id PK\n        string email\n    }\n"
+	mustEqual(t, got, want, "mermaid user dark")
+}
+
+func TestMermaidUserForest(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateMermaid(r, ForestMermaidTheme())
+	want := "%%{init: {'theme':'forest'}}%%\nerDiagram\n    user {\n        string id PK\n        string email\n    }\n"
+	mustEqual(t, got, want, "mermaid user forest")
+}
+
+func TestMermaidUserMinimal(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateMermaid(r, MinimalMermaidTheme())
+	want := "%%{init: {'theme':'neutral'}}%%\nerDiagram\n    user {\n        string id PK\n        string email\n    }\n"
+	mustEqual(t, got, want, "mermaid user minimal")
+}
+
+func TestMermaidUserUniqueIndex(t *testing.T) {
+	user := NewTable("user",
+		WithFields(StringField("email"), StringField("name")),
+		WithIndexes(UniqueIndex("u_email", []string{"email"})),
+	)
+	r := newRegistryWith(t, []TableDefinition{user}, nil)
+	got := GenerateMermaid(r, MermaidTheme{})
+	want := "erDiagram\n    user {\n        string id PK\n        string email UK\n        string name\n    }\n"
+	mustEqual(t, got, want, "mermaid user unique")
+}
+
+func TestMermaidEdgesBasic(t *testing.T) {
+	user := NewTable("user", WithFields(StringField("email")))
+	post := NewTable("post",
+		WithFields(StringField("title"), RecordField("author", "user")),
+	)
+	wrote := TypedEdge("wrote", "user", "post", WithEdgeFields(DatetimeField("at")))
+	follows := TypedEdge("follows", "user", "user")
+	r := newRegistryWith(t, []TableDefinition{user, post}, []EdgeDefinition{wrote, follows})
+
+	got := GenerateMermaid(r, ModernMermaidTheme())
+	want := "%%{init: {'theme':'default'}}%%\n" +
+		"erDiagram\n    post {\n        string id PK\n        string title\n        record author FK\n    }\n" +
+		"    user {\n        string id PK\n        string email\n    }\n" +
+		"    wrote {\n        datetime at\n    }\n" +
+		"\n    user }o--o{ user : follows" +
+		"\n    user ||--o{ post : wrote"
+	mustEqual(t, got, want, "mermaid edges")
+}
+
+func TestMermaidIncludeFieldsFalse(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateMermaid(r, MermaidTheme{}, WithIncludeFields(false))
+	want := "erDiagram\n    user {\n    }\n"
+	mustEqual(t, got, want, "mermaid include_fields=false")
+}
+
+func TestMermaidIncludeEdgesFalse(t *testing.T) {
+	user := NewTable("user", WithFields(StringField("email")))
+	post := NewTable("post", WithFields(StringField("title")))
+	e := TypedEdge("wrote", "user", "post")
+	r := newRegistryWith(t, []TableDefinition{user, post}, []EdgeDefinition{e})
+	got := GenerateMermaid(r, MermaidTheme{}, WithIncludeEdges(false))
+	// Tables are emitted in alphabetical order: post, user.
+	want := "erDiagram\n    post {\n        string id PK\n        string title\n    }\n" +
+		"    user {\n        string id PK\n        string email\n    }"
+	// With IncludeEdges=false we do not emit the blank line separator that
+	// precedes the edges section (Python: the empty-string list element is
+	// appended only when include_edges is true).
+	mustEqual(t, got, want, "mermaid include_edges=false")
+}
+
+// Skip-if-table-missing test: edge referencing unknown table is dropped.
+func TestMermaidEdgeDroppedWhenTableMissing(t *testing.T) {
+	user := NewTable("user", WithFields(StringField("email")))
+	e := TypedEdge("wrote", "user", "missing")
+	r := newRegistryWith(t, []TableDefinition{user}, []EdgeDefinition{e})
+	got := GenerateMermaid(r, MermaidTheme{})
+	want := "erDiagram\n    user {\n        string id PK\n        string email\n    }\n"
+	mustEqual(t, got, want, "mermaid missing table edge dropped")
+}
+
+// -------------------- GraphViz --------------------
+
+func TestGraphVizEmpty(t *testing.T) {
+	r := NewSchemaRegistry()
+	got := GenerateGraphViz(r, GraphVizTheme{})
+	want := "digraph schema {\n    rankdir=LR;\n    node [shape=record];\n\n\n}"
+	mustEqual(t, got, want, "graphviz empty")
+}
+
+func TestGraphVizUserDefault(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateGraphViz(r, GraphVizTheme{})
+	want := "digraph schema {\n    rankdir=LR;\n    node [shape=record];\n\n" +
+		"    user [label=\"{user|id : string (PK)\\l|email : string\\l}\"];\n\n}"
+	mustEqual(t, got, want, "graphviz user default")
+}
+
+func TestGraphVizUserModern(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateGraphViz(r, ModernGraphVizTheme())
+	want := `digraph schema {
+    rankdir=LR;
+    fontname="Arial";
+    node [shape=record, style="filled,rounded", fontname="Arial", pad="0.5", margin="0.2"];
+    edge [color="#64748b", style=solid, fontname="Arial"];
+
+    user [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4"><TR><TD BGCOLOR="#6366f1" COLSPAN="2"><FONT COLOR="#FFFFFF"><B>user</B></FONT></TD></TR><TR><TD ALIGN="LEFT">id</TD><TD ALIGN="LEFT"><FONT COLOR="#94a3b8">string</FONT> <FONT COLOR="#ef4444">PK</FONT></TD></TR><TR><TD ALIGN="LEFT">email</TD><TD ALIGN="LEFT"><FONT COLOR="#10b981">string</FONT></TD></TR></TABLE>>];
+
+}`
+	mustEqual(t, got, want, "graphviz user modern")
+}
+
+func TestGraphVizUserDark(t *testing.T) {
+	user := NewTable("user",
+		WithFields(StringField("email"), StringField("name")),
+		WithIndexes(UniqueIndex("u_email", []string{"email"})),
+	)
+	r := newRegistryWith(t, []TableDefinition{user}, nil)
+	got := GenerateGraphViz(r, DarkGraphVizTheme())
+	want := `digraph schema {
+    rankdir=LR;
+    bgcolor="#1e1b4b";
+    fontname="Arial";
+    node [shape=record, style="filled,rounded", fontname="Arial", pad="0.5", margin="0.2"];
+    edge [color="#64748b", style=solid, fontname="Arial"];
+
+    user [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4"><TR><TD BGCOLOR="#8b5cf6" COLSPAN="2"><FONT COLOR="#FFFFFF"><B>user</B></FONT></TD></TR><TR><TD ALIGN="LEFT">id</TD><TD ALIGN="LEFT"><FONT COLOR="#94a3b8">string</FONT> <FONT COLOR="#ef4444">PK</FONT></TD></TR><TR><TD ALIGN="LEFT">email</TD><TD ALIGN="LEFT"><FONT COLOR="#10b981">string</FONT> <FONT COLOR="#8b5cf6">UK</FONT></TD></TR><TR><TD ALIGN="LEFT">name</TD><TD ALIGN="LEFT"><FONT COLOR="#10b981">string</FONT></TD></TR></TABLE>>];
+
+}`
+	mustEqual(t, got, want, "graphviz user dark unique")
+}
+
+func TestGraphVizUserForest(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateGraphViz(r, ForestGraphVizTheme())
+	want := `digraph schema {
+    rankdir=LR;
+    fontname="Arial";
+    node [shape=record, style="filled,rounded", fontname="Arial", pad="0.5", margin="0.2"];
+    edge [color="#059669", style=solid, fontname="Arial"];
+
+    user [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4"><TR><TD BGCOLOR="#10b981" COLSPAN="2"><FONT COLOR="#FFFFFF"><B>user</B></FONT></TD></TR><TR><TD ALIGN="LEFT">id</TD><TD ALIGN="LEFT"><FONT COLOR="#94a3b8">string</FONT> <FONT COLOR="#ef4444">PK</FONT></TD></TR><TR><TD ALIGN="LEFT">email</TD><TD ALIGN="LEFT"><FONT COLOR="#10b981">string</FONT></TD></TR></TABLE>>];
+
+}`
+	mustEqual(t, got, want, "graphviz user forest")
+}
+
+func TestGraphVizUserMinimal(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateGraphViz(r, MinimalGraphVizTheme())
+	want := `digraph schema {
+    rankdir=LR;
+    fontname="Arial";
+    node [shape=record, style="filled", fontname="Arial", pad="0.5", margin="0.2"];
+    edge [color="#9ca3af", style=solid, fontname="Arial"];
+
+    user [label="{user|id : string (PK)\l|email : string\l}"];
+
+}`
+	mustEqual(t, got, want, "graphviz user minimal")
+}
+
+func TestGraphVizEdgesDefault(t *testing.T) {
+	user := NewTable("user", WithFields(StringField("email")))
+	post := NewTable("post",
+		WithFields(StringField("title"), RecordField("author", "user")),
+	)
+	wrote := TypedEdge("wrote", "user", "post", WithEdgeFields(DatetimeField("at")))
+	follows := TypedEdge("follows", "user", "user")
+	r := newRegistryWith(t, []TableDefinition{user, post}, []EdgeDefinition{wrote, follows})
+	got := GenerateGraphViz(r, GraphVizTheme{})
+	want := "digraph schema {\n    rankdir=LR;\n    node [shape=record];\n\n" +
+		"    post [label=\"{post|id : string (PK)\\l|title : string\\l|author : record (FK)\\l}\"];\n" +
+		"    user [label=\"{user|id : string (PK)\\l|email : string\\l}\"];\n" +
+		"    wrote [label=\"{wrote|at : datetime\\l}\"];\n\n" +
+		"    user -> user [label=\"follows\", style=dashed];\n" +
+		"    user -> post [label=\"wrote\"];\n}"
+	mustEqual(t, got, want, "graphviz edges default")
+}
+
+func TestGraphVizEdgesModernGradient(t *testing.T) {
+	// Self-referential follows edge picks up dashed + secondary color.
+	user := NewTable("user", WithFields(StringField("email")))
+	follows := TypedEdge("follows", "user", "user")
+	r := newRegistryWith(t, []TableDefinition{user}, []EdgeDefinition{follows})
+	got := GenerateGraphViz(r, ModernGraphVizTheme())
+	if !strings.Contains(got, `user -> user [label="follows", style=dashed, color="#ec4899"];`) {
+		t.Errorf("graphviz modern self-edge = %q", got)
+	}
+}
+
+func TestGraphVizIncludeFieldsFalse(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateGraphViz(r, GraphVizTheme{}, WithIncludeFields(false))
+	want := "digraph schema {\n    rankdir=LR;\n    node [shape=record];\n\n" +
+		"    user [label=\"user\"];\n\n}"
+	mustEqual(t, got, want, "graphviz no fields")
+}
+
+// -------------------- ASCII --------------------
+
+func TestASCIIEmpty(t *testing.T) {
+	r := NewSchemaRegistry()
+	got := GenerateASCII(r, ASCIITheme{})
+	if got != "" {
+		t.Errorf("ascii empty = %q, want empty", got)
+	}
+}
+
+func TestASCIIUserNoTheme(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateASCII(r, ASCIITheme{})
+	want := "+--------------------+\n" +
+		"|        user        |\n" +
+		"+--------------------+\n" +
+		"| id : string (PK)   |\n" +
+		"| email : string     |\n" +
+		"+--------------------+\n"
+	mustEqual(t, got, want, "ascii user no theme")
+}
+
+func TestASCIIUserMinimal(t *testing.T) {
+	user := NewTable("user",
+		WithFields(StringField("email"), StringField("name")),
+		WithIndexes(UniqueIndex("u_email", []string{"email"})),
+	)
+	r := newRegistryWith(t, []TableDefinition{user}, nil)
+	got := GenerateASCII(r, MinimalASCIITheme())
+	want := "┌─────────────────────┐\n" +
+		"│         user        │\n" +
+		"├─────────────────────┤\n" +
+		"│ id : string (PK)    │\n" +
+		"│ email : string (UK) │\n" +
+		"│ name : string       │\n" +
+		"└─────────────────────┘\n"
+	mustEqual(t, got, want, "ascii user minimal")
+}
+
+func TestASCIIUserModern(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateASCII(r, ModernASCIITheme())
+	want := "╭─────────────────────╮\n" +
+		"│\x1b[1m         user        \x1b[0m│\n" +
+		"├─────────────────────┤\n" +
+		"│ id : string \x1b[91m🔑 (PK)\x1b[0m │\n" +
+		"│ email : string      │\n" +
+		"╰─────────────────────╯\n"
+	mustEqual(t, got, want, "ascii user modern")
+}
+
+func TestASCIIUserDark(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateASCII(r, DarkASCIITheme())
+	want := "╭─────────────────────╮\n" +
+		"│\x1b[1m         user        \x1b[0m│\n" +
+		"├─────────────────────┤\n" +
+		"│ id : string \x1b[91m🔑 (PK)\x1b[0m │\n" +
+		"│ email : string      │\n" +
+		"╰─────────────────────╯\n"
+	mustEqual(t, got, want, "ascii user dark")
+}
+
+func TestASCIIUserForest(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateASCII(r, ForestASCIITheme())
+	want := "╭─────────────────────╮\n" +
+		"│\x1b[1m         user        \x1b[0m│\n" +
+		"├─────────────────────┤\n" +
+		"│ id : string \x1b[91m🔑 (PK)\x1b[0m │\n" +
+		"│ email : string      │\n" +
+		"╰─────────────────────╯\n"
+	mustEqual(t, got, want, "ascii user forest")
+}
+
+func TestASCIIPostModernFKConstraint(t *testing.T) {
+	post := NewTable("post",
+		WithFields(StringField("title"), RecordField("author", "user")),
+	)
+	r := newRegistryWith(t, []TableDefinition{post}, nil)
+	got := GenerateASCII(r, ModernASCIITheme())
+	want := "╭─────────────────────────╮\n" +
+		"│\x1b[1m           post          \x1b[0m│\n" +
+		"├─────────────────────────┤\n" +
+		"│ id : string \x1b[91m🔑 (PK)\x1b[0m     │\n" +
+		"│ title : string          │\n" +
+		"│ author : record \x1b[94m🔗 (FK)\x1b[0m │\n" +
+		"╰─────────────────────────╯\n"
+	mustEqual(t, got, want, "ascii post modern")
+}
+
+func TestASCIIRelationshipsSection(t *testing.T) {
+	user := NewTable("user", WithFields(StringField("email")))
+	post := NewTable("post", WithFields(StringField("title")))
+	wrote := TypedEdge("wrote", "user", "post")
+	r := newRegistryWith(t, []TableDefinition{user, post}, []EdgeDefinition{wrote})
+	got := GenerateASCII(r, MinimalASCIITheme())
+	if !strings.Contains(got, "Relationships:\n") {
+		t.Errorf("ascii missing Relationships header:\n%s", got)
+	}
+	if !strings.Contains(got, "  user --[wrote]--> post") {
+		t.Errorf("ascii missing edge line:\n%s", got)
+	}
+	if !strings.Contains(got, strings.Repeat("-", 40)) {
+		t.Errorf("ascii missing separator")
+	}
+}
+
+func TestASCIIIncludeFieldsFalse(t *testing.T) {
+	r := newRegistryWith(t, []TableDefinition{userTable()}, nil)
+	got := GenerateASCII(r, MinimalASCIITheme(), WithIncludeFields(false))
+	// Minimal at width 20 (len('user')+4 < 20).
+	want := "┌────────────────────┐\n" +
+		"│        user        │\n" +
+		"└────────────────────┘\n"
+	mustEqual(t, got, want, "ascii no fields")
+}
+
+func TestASCIIIncludeEdgesFalse(t *testing.T) {
+	user := NewTable("user", WithFields(StringField("email")))
+	post := NewTable("post", WithFields(StringField("title")))
+	wrote := TypedEdge("wrote", "user", "post")
+	r := newRegistryWith(t, []TableDefinition{user, post}, []EdgeDefinition{wrote})
+	got := GenerateASCII(r, MinimalASCIITheme(), WithIncludeEdges(false))
+	if strings.Contains(got, "Relationships:") {
+		t.Errorf("ascii should not contain Relationships section:\n%s", got)
+	}
+}
+
+func TestASCIIManyFields(t *testing.T) {
+	// Longer field list to exercise box-width calculation.
+	fields := []FieldDefinition{
+		StringField("first_name"),
+		StringField("last_name"),
+		IntField("age"),
+		BoolField("active"),
+		DatetimeField("created_at"),
+	}
+	user := NewTable("user", WithFields(fields...))
+	r := newRegistryWith(t, []TableDefinition{user}, nil)
+	got := GenerateASCII(r, MinimalASCIITheme())
+	for _, name := range []string{"first_name", "last_name", "age", "active", "created_at"} {
+		if !strings.Contains(got, name) {
+			t.Errorf("ascii many fields missing %q:\n%s", name, got)
+		}
+	}
+	if !strings.Contains(got, "id : string (PK)") {
+		t.Errorf("ascii many fields missing id PK row:\n%s", got)
+	}
+}
+
+// -------------------- Registry plumbing --------------------
+
+func TestGenerateFromMapsMatchesRegistry(t *testing.T) {
+	user := NewTable("user", WithFields(StringField("email")))
+	r := newRegistryWith(t, []TableDefinition{user}, nil)
+	fromRegistry := GenerateMermaid(r, ModernMermaidTheme())
+	fromMaps := GenerateMermaidFromMaps(
+		map[string]TableDefinition{"user": user},
+		map[string]EdgeDefinition{},
+		ModernMermaidTheme(),
+	)
+	mustEqual(t, fromMaps, fromRegistry, "registry vs maps parity")
+}
+
+func TestWithIncludeFlagsApplyOrder(t *testing.T) {
+	// Repeated options should take the last value (standard functional-opt
+	// pattern).
+	o := resolveOptions([]VisualizeOption{
+		WithIncludeFields(true),
+		WithIncludeFields(false),
+		WithIncludeEdges(false),
+		WithIncludeEdges(true),
+	})
+	if o.IncludeFields != false {
+		t.Errorf("IncludeFields = %v, want false", o.IncludeFields)
+	}
+	if o.IncludeEdges != true {
+		t.Errorf("IncludeEdges = %v, want true", o.IncludeEdges)
+	}
+}
+
+func TestResolveOptionsDefaults(t *testing.T) {
+	o := resolveOptions(nil)
+	if !o.IncludeFields {
+		t.Errorf("default IncludeFields = false, want true")
+	}
+	if !o.IncludeEdges {
+		t.Errorf("default IncludeEdges = false, want true")
+	}
+}

--- a/pkg/surql/surql.go
+++ b/pkg/surql/surql.go
@@ -1,0 +1,8 @@
+package surql
+
+// Version is the current surql-go release.
+//
+// The foundation port is under active development; operations that require
+// the SurrealDB client will land incrementally and are tracked against
+// surql-py as the source-of-truth feature set.
+const Version = "0.1.0-dev"

--- a/pkg/surql/types/coerce.go
+++ b/pkg/surql/types/coerce.go
@@ -1,0 +1,96 @@
+package types
+
+import (
+	"strings"
+	"time"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// CoerceDatetime converts a SurrealDB ISO-8601 datetime string into a
+// time.Time in UTC.
+//
+// Supported inputs:
+//   - 2024-01-15T10:30:00Z
+//   - 2024-01-15T10:30:00+00:00
+//   - 2024-01-15T10:30:00.123456789Z  (nanoseconds)
+//   - 2024-01-15T10:30:00             (naive; treated as UTC)
+func CoerceDatetime(value string) (time.Time, error) {
+	// Try RFC 3339 first (handles Z, offsets, and fractional seconds).
+	if t, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return t.UTC(), nil
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t.UTC(), nil
+	}
+	// Naive formats (no timezone).
+	layouts := []string{
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05.999999",
+		"2006-01-02T15:04:05.999",
+		"2006-01-02T15:04:05",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	return time.Time{}, surqlerrors.Newf(
+		surqlerrors.ErrValidation,
+		"could not parse datetime string %q", value,
+	)
+}
+
+// CoerceRecordDatetimes returns a copy of `data` with the listed string
+// fields parsed as UTC datetimes. Missing, null, or non-string fields are
+// left untouched. A parse failure returns the error for the offending
+// field and leaves callers free to recover.
+func CoerceRecordDatetimes(
+	data map[string]any,
+	datetimeFields []string,
+) (map[string]any, error) {
+	out := make(map[string]any, len(data))
+	for k, v := range data {
+		out[k] = v
+	}
+	for _, field := range datetimeFields {
+		raw, ok := out[field]
+		if !ok || raw == nil {
+			continue
+		}
+		s, ok := raw.(string)
+		if !ok {
+			continue
+		}
+		t, err := CoerceDatetime(s)
+		if err != nil {
+			return nil, surqlerrors.Wrapf(
+				surqlerrors.ErrValidation,
+				err,
+				"field %q", field,
+			)
+		}
+		out[field] = t
+	}
+	return out, nil
+}
+
+// normaliseNanos truncates trailing nanos past 9 digits so the RFC3339
+// parser always succeeds (kept internal for symmetry with surql-rs).
+//
+//nolint:unused // retained as a reference helper
+func normaliseNanos(value string) string {
+	idx := strings.Index(value, ".")
+	if idx < 0 {
+		return value
+	}
+	end := idx + 1
+	for end < len(value) && value[end] >= '0' && value[end] <= '9' {
+		end++
+	}
+	frac := value[idx+1 : end]
+	if len(frac) <= 9 {
+		return value
+	}
+	return value[:idx+1] + frac[:9] + value[end:]
+}

--- a/pkg/surql/types/coerce_test.go
+++ b/pkg/surql/types/coerce_test.go
@@ -1,0 +1,101 @@
+package types
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCoerceDatetime_ZSuffix(t *testing.T) {
+	got, err := CoerceDatetime("2024-01-15T10:30:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestCoerceDatetime_Offset(t *testing.T) {
+	got, err := CoerceDatetime("2024-01-15T10:30:00+00:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Hour() != 10 || got.Location() != time.UTC {
+		t.Errorf("got %v (loc=%v)", got, got.Location())
+	}
+}
+
+func TestCoerceDatetime_Nanoseconds(t *testing.T) {
+	got, err := CoerceDatetime("2024-01-15T10:30:00.123456789Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Nanosecond() != 123456789 {
+		t.Errorf("nsec=%d", got.Nanosecond())
+	}
+}
+
+func TestCoerceDatetime_Naive(t *testing.T) {
+	got, err := CoerceDatetime("2024-01-15T10:30:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Location() != time.UTC {
+		t.Errorf("expected UTC, got %v", got.Location())
+	}
+}
+
+func TestCoerceDatetime_RejectsGarbage(t *testing.T) {
+	if _, err := CoerceDatetime("not-a-date"); err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestCoerceRecordDatetimes_ReplacesStringWithTime(t *testing.T) {
+	data := map[string]any{
+		"name":       "Alice",
+		"created_at": "2024-01-15T10:30:00Z",
+	}
+	out, err := CoerceRecordDatetimes(data, []string{"created_at"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := out["created_at"].(time.Time); !ok {
+		t.Errorf("created_at not time.Time: %T", out["created_at"])
+	}
+	if out["name"] != "Alice" {
+		t.Errorf("name corrupted: %v", out["name"])
+	}
+}
+
+func TestCoerceRecordDatetimes_SkipsMissingAndNil(t *testing.T) {
+	data := map[string]any{"deleted_at": nil}
+	out, err := CoerceRecordDatetimes(data, []string{"deleted_at", "not_present"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out["deleted_at"] != nil {
+		t.Errorf("expected nil, got %v", out["deleted_at"])
+	}
+}
+
+func TestCoerceRecordDatetimes_WrapsFieldError(t *testing.T) {
+	data := map[string]any{"created_at": "not-a-date"}
+	_, err := CoerceRecordDatetimes(data, []string{"created_at"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !containsSubstr(err.Error(), "created_at") {
+		t.Errorf("expected field name in error: %q", err.Error())
+	}
+}
+
+func containsSubstr(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/surql/types/operators.go
+++ b/pkg/surql/types/operators.go
@@ -1,0 +1,314 @@
+package types
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Operator is any expression that renders to SurrealQL.
+type Operator interface {
+	ToSurql() string
+}
+
+// quoteValue renders v as a SurrealQL literal.
+//
+// Rules (matching the Python port):
+//   - nil               -> NULL
+//   - bool              -> true / false
+//   - int/uint/float    -> base-10 formatted number
+//   - string            -> 'single-quoted' with \ and ' escaped
+//   - SurrealFn         -> raw expression
+//   - RecordRef         -> type::record(...) raw expression
+//   - []any             -> '[' + quoted elements + ']'
+//   - fmt.Stringer      -> quoted string form
+func quoteValue(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return "NULL"
+	case bool:
+		if x {
+			return "true"
+		}
+		return "false"
+	case int:
+		return strconv.FormatInt(int64(x), 10)
+	case int8, int16, int32, int64:
+		return fmt.Sprintf("%d", x)
+	case uint, uint8, uint16, uint32, uint64:
+		return fmt.Sprintf("%d", x)
+	case float32:
+		return strconv.FormatFloat(float64(x), 'f', -1, 32)
+	case float64:
+		return strconv.FormatFloat(x, 'f', -1, 64)
+	case string:
+		return quoteString(x)
+	case SurrealFn:
+		return x.ToSurql()
+	case RecordRef:
+		return x.ToSurql()
+	case []any:
+		parts := make([]string, len(x))
+		for i, el := range x {
+			parts[i] = quoteValue(el)
+		}
+		return "[" + strings.Join(parts, ", ") + "]"
+	case fmt.Stringer:
+		return quoteString(x.String())
+	default:
+		return quoteString(fmt.Sprint(x))
+	}
+}
+
+func quoteString(s string) string {
+	escaped := strings.ReplaceAll(s, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+	return "'" + escaped + "'"
+}
+
+// --- Comparison operators ---------------------------------------------------
+
+// Eq renders as `field = value`.
+type Eq struct {
+	Field string
+	Value any
+}
+
+// ToSurql implements Operator.
+func (o Eq) ToSurql() string { return fmt.Sprintf("%s = %s", o.Field, quoteValue(o.Value)) }
+
+// Ne renders as `field != value`.
+type Ne struct {
+	Field string
+	Value any
+}
+
+// ToSurql implements Operator.
+func (o Ne) ToSurql() string { return fmt.Sprintf("%s != %s", o.Field, quoteValue(o.Value)) }
+
+// Gt renders as `field > value`.
+type Gt struct {
+	Field string
+	Value any
+}
+
+// ToSurql implements Operator.
+func (o Gt) ToSurql() string { return fmt.Sprintf("%s > %s", o.Field, quoteValue(o.Value)) }
+
+// Gte renders as `field >= value`.
+type Gte struct {
+	Field string
+	Value any
+}
+
+// ToSurql implements Operator.
+func (o Gte) ToSurql() string { return fmt.Sprintf("%s >= %s", o.Field, quoteValue(o.Value)) }
+
+// Lt renders as `field < value`.
+type Lt struct {
+	Field string
+	Value any
+}
+
+// ToSurql implements Operator.
+func (o Lt) ToSurql() string { return fmt.Sprintf("%s < %s", o.Field, quoteValue(o.Value)) }
+
+// Lte renders as `field <= value`.
+type Lte struct {
+	Field string
+	Value any
+}
+
+// ToSurql implements Operator.
+func (o Lte) ToSurql() string { return fmt.Sprintf("%s <= %s", o.Field, quoteValue(o.Value)) }
+
+// Contains renders as `field CONTAINS value`.
+type Contains struct {
+	Field string
+	Value any
+}
+
+// ToSurql implements Operator.
+func (o Contains) ToSurql() string {
+	return fmt.Sprintf("%s CONTAINS %s", o.Field, quoteValue(o.Value))
+}
+
+// ContainsNot renders as `field CONTAINSNOT value`.
+type ContainsNot struct {
+	Field string
+	Value any
+}
+
+// ToSurql implements Operator.
+func (o ContainsNot) ToSurql() string {
+	return fmt.Sprintf("%s CONTAINSNOT %s", o.Field, quoteValue(o.Value))
+}
+
+// --- Array-comparison operators ---------------------------------------------
+
+// ContainsAll renders as `field CONTAINSALL [...]`.
+type ContainsAll struct {
+	Field  string
+	Values []any
+}
+
+// ToSurql implements Operator.
+func (o ContainsAll) ToSurql() string {
+	return fmt.Sprintf("%s CONTAINSALL %s", o.Field, renderList(o.Values))
+}
+
+// ContainsAny renders as `field CONTAINSANY [...]`.
+type ContainsAny struct {
+	Field  string
+	Values []any
+}
+
+// ToSurql implements Operator.
+func (o ContainsAny) ToSurql() string {
+	return fmt.Sprintf("%s CONTAINSANY %s", o.Field, renderList(o.Values))
+}
+
+// Inside renders as `field INSIDE [...]`.
+type Inside struct {
+	Field  string
+	Values []any
+}
+
+// ToSurql implements Operator.
+func (o Inside) ToSurql() string {
+	return fmt.Sprintf("%s INSIDE %s", o.Field, renderList(o.Values))
+}
+
+// NotInside renders as `field NOTINSIDE [...]`.
+type NotInside struct {
+	Field  string
+	Values []any
+}
+
+// ToSurql implements Operator.
+func (o NotInside) ToSurql() string {
+	return fmt.Sprintf("%s NOTINSIDE %s", o.Field, renderList(o.Values))
+}
+
+func renderList(values []any) string {
+	parts := make([]string, len(values))
+	for i, v := range values {
+		parts[i] = quoteValue(v)
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+// --- Null checks ------------------------------------------------------------
+
+// IsNull renders as `field IS NULL`.
+type IsNull struct {
+	Field string
+}
+
+// ToSurql implements Operator.
+func (o IsNull) ToSurql() string { return o.Field + " IS NULL" }
+
+// IsNotNull renders as `field IS NOT NULL`.
+type IsNotNull struct {
+	Field string
+}
+
+// ToSurql implements Operator.
+func (o IsNotNull) ToSurql() string { return o.Field + " IS NOT NULL" }
+
+// --- Logical operators ------------------------------------------------------
+
+// And renders as `(left) AND (right)`.
+type And struct {
+	Left  Operator
+	Right Operator
+}
+
+// ToSurql implements Operator.
+func (o And) ToSurql() string {
+	return fmt.Sprintf("(%s) AND (%s)", o.Left.ToSurql(), o.Right.ToSurql())
+}
+
+// Or renders as `(left) OR (right)`.
+type Or struct {
+	Left  Operator
+	Right Operator
+}
+
+// ToSurql implements Operator.
+func (o Or) ToSurql() string {
+	return fmt.Sprintf("(%s) OR (%s)", o.Left.ToSurql(), o.Right.ToSurql())
+}
+
+// Not renders as `NOT (operand)`.
+type Not struct {
+	Operand Operator
+}
+
+// ToSurql implements Operator.
+func (o Not) ToSurql() string { return "NOT (" + o.Operand.ToSurql() + ")" }
+
+// --- Functional helpers (mirror the Python API) -----------------------------
+
+// EqOp builds an Eq operator.
+func EqOp(field string, value any) Eq { return Eq{Field: field, Value: value} }
+
+// NeOp builds a Ne operator.
+func NeOp(field string, value any) Ne { return Ne{Field: field, Value: value} }
+
+// GtOp builds a Gt operator.
+func GtOp(field string, value any) Gt { return Gt{Field: field, Value: value} }
+
+// GteOp builds a Gte operator.
+func GteOp(field string, value any) Gte { return Gte{Field: field, Value: value} }
+
+// LtOp builds an Lt operator.
+func LtOp(field string, value any) Lt { return Lt{Field: field, Value: value} }
+
+// LteOp builds an Lte operator.
+func LteOp(field string, value any) Lte { return Lte{Field: field, Value: value} }
+
+// ContainsOp builds a Contains operator.
+func ContainsOp(field string, value any) Contains {
+	return Contains{Field: field, Value: value}
+}
+
+// ContainsNotOp builds a ContainsNot operator.
+func ContainsNotOp(field string, value any) ContainsNot {
+	return ContainsNot{Field: field, Value: value}
+}
+
+// ContainsAllOp builds a ContainsAll operator.
+func ContainsAllOp(field string, values []any) ContainsAll {
+	return ContainsAll{Field: field, Values: values}
+}
+
+// ContainsAnyOp builds a ContainsAny operator.
+func ContainsAnyOp(field string, values []any) ContainsAny {
+	return ContainsAny{Field: field, Values: values}
+}
+
+// InsideOp builds an Inside operator.
+func InsideOp(field string, values []any) Inside {
+	return Inside{Field: field, Values: values}
+}
+
+// NotInsideOp builds a NotInside operator.
+func NotInsideOp(field string, values []any) NotInside {
+	return NotInside{Field: field, Values: values}
+}
+
+// IsNullOp builds an IsNull operator.
+func IsNullOp(field string) IsNull { return IsNull{Field: field} }
+
+// IsNotNullOp builds an IsNotNull operator.
+func IsNotNullOp(field string) IsNotNull { return IsNotNull{Field: field} }
+
+// AndOp combines two operators with logical AND.
+func AndOp(left, right Operator) And { return And{Left: left, Right: right} }
+
+// OrOp combines two operators with logical OR.
+func OrOp(left, right Operator) Or { return Or{Left: left, Right: right} }
+
+// NotOp negates an operator.
+func NotOp(o Operator) Not { return Not{Operand: o} }

--- a/pkg/surql/types/operators_test.go
+++ b/pkg/surql/types/operators_test.go
@@ -1,0 +1,155 @@
+package types
+
+import "testing"
+
+func TestEq_String(t *testing.T) {
+	if got := EqOp("name", "Alice").ToSurql(); got != `name = 'Alice'` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestNe_String(t *testing.T) {
+	if got := NeOp("status", "deleted").ToSurql(); got != `status != 'deleted'` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestGt_Int(t *testing.T) {
+	if got := GtOp("age", 18).ToSurql(); got != "age > 18" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestLt_Float(t *testing.T) {
+	if got := LtOp("price", 50.0).ToSurql(); got != "price < 50" {
+		// Go strips trailing zeros via %g-style; accept either 50 or 50.0
+		if got != "price < 50.0" {
+			t.Errorf("got %q", got)
+		}
+	}
+}
+
+func TestGteAndLte(t *testing.T) {
+	if got := GteOp("score", 100).ToSurql(); got != "score >= 100" {
+		t.Errorf("gte: %q", got)
+	}
+	if got := LteOp("quantity", 10).ToSurql(); got != "quantity <= 10" {
+		t.Errorf("lte: %q", got)
+	}
+}
+
+func TestContains(t *testing.T) {
+	got := ContainsOp("email", "@example.com").ToSurql()
+	if got != `email CONTAINS '@example.com'` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestContainsNot(t *testing.T) {
+	got := ContainsNotOp("tags", "spam").ToSurql()
+	if got != `tags CONTAINSNOT 'spam'` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestContainsAll(t *testing.T) {
+	got := ContainsAllOp("tags", []any{"python", "database"}).ToSurql()
+	if got != `tags CONTAINSALL ['python', 'database']` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestContainsAny(t *testing.T) {
+	got := ContainsAnyOp("tags", []any{"python", "javascript"}).ToSurql()
+	if got != `tags CONTAINSANY ['python', 'javascript']` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestInside(t *testing.T) {
+	got := InsideOp("status", []any{"active", "pending"}).ToSurql()
+	if got != `status INSIDE ['active', 'pending']` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestNotInside(t *testing.T) {
+	got := NotInsideOp("status", []any{"deleted", "archived"}).ToSurql()
+	if got != `status NOTINSIDE ['deleted', 'archived']` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestIsNullAndNotNull(t *testing.T) {
+	if got := IsNullOp("deleted_at").ToSurql(); got != "deleted_at IS NULL" {
+		t.Errorf("is null: %q", got)
+	}
+	if got := IsNotNullOp("created_at").ToSurql(); got != "created_at IS NOT NULL" {
+		t.Errorf("is not null: %q", got)
+	}
+}
+
+func TestAnd(t *testing.T) {
+	got := AndOp(GtOp("age", 18), EqOp("status", "active")).ToSurql()
+	if got != `(age > 18) AND (status = 'active')` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestOr(t *testing.T) {
+	got := OrOp(EqOp("type", "admin"), EqOp("type", "moderator")).ToSurql()
+	if got != `(type = 'admin') OR (type = 'moderator')` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestNot(t *testing.T) {
+	got := NotOp(EqOp("status", "deleted")).ToSurql()
+	if got != `NOT (status = 'deleted')` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestNullQuotedAsNULL(t *testing.T) {
+	got := EqOp("deleted_at", nil).ToSurql()
+	if got != "deleted_at = NULL" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestBoolQuotedLowercase(t *testing.T) {
+	if got := EqOp("active", true).ToSurql(); got != "active = true" {
+		t.Errorf("true: %q", got)
+	}
+	if got := EqOp("active", false).ToSurql(); got != "active = false" {
+		t.Errorf("false: %q", got)
+	}
+}
+
+func TestStringEscapesSingleQuote(t *testing.T) {
+	got := EqOp("name", "O'Brien").ToSurql()
+	if got != `name = 'O\'Brien'` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestStringEscapesBackslash(t *testing.T) {
+	got := EqOp("path", `a\b`).ToSurql()
+	if got != `path = 'a\\b'` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSurrealFnValueRendersRaw(t *testing.T) {
+	got := EqOp("created_at", SurqlFn("time::now")).ToSurql()
+	if got != "created_at = time::now()" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRecordRefValueRendersRaw(t *testing.T) {
+	got := EqOp("author", StringRecordRef("user", "alice")).ToSurql()
+	if got != "author = type::record('user', 'alice')" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/pkg/surql/types/record_id.go
+++ b/pkg/surql/types/record_id.go
@@ -1,0 +1,218 @@
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// tablePattern matches valid SurrealDB table names: [A-Za-z_][A-Za-z0-9_]*
+var tablePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// simpleIDPattern matches an id that does NOT require angle brackets.
+var simpleIDPattern = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+
+// RecordIDValue holds either a string or integer record id. Integer ids
+// never require angle-bracket syntax in SurrealDB.
+type RecordIDValue struct {
+	str     string
+	intVal  int64
+	isInt   bool
+	present bool
+}
+
+// StringID constructs a string-valued record id.
+func StringID(s string) RecordIDValue {
+	return RecordIDValue{str: s, present: true}
+}
+
+// IntID constructs an integer-valued record id.
+func IntID(n int64) RecordIDValue {
+	return RecordIDValue{intVal: n, isInt: true, present: true}
+}
+
+// IsInt reports whether the id is integer-valued.
+func (v RecordIDValue) IsInt() bool { return v.isInt }
+
+// String returns the id as a string for rendering.
+func (v RecordIDValue) String() string {
+	if v.isInt {
+		return strconv.FormatInt(v.intVal, 10)
+	}
+	return v.str
+}
+
+// Int returns the underlying integer id (or 0 when the id is a string).
+func (v RecordIDValue) Int() int64 { return v.intVal }
+
+// MarshalJSON encodes the id as its underlying JSON primitive.
+func (v RecordIDValue) MarshalJSON() ([]byte, error) {
+	if v.isInt {
+		return json.Marshal(v.intVal)
+	}
+	return json.Marshal(v.str)
+}
+
+// UnmarshalJSON accepts either a JSON string or integer.
+func (v *RecordIDValue) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		*v = StringID(s)
+		return nil
+	}
+	var n int64
+	if err := json.Unmarshal(data, &n); err != nil {
+		return err
+	}
+	*v = IntID(n)
+	return nil
+}
+
+// RecordID is a type-safe wrapper for SurrealDB record ids (`table:id`).
+type RecordID struct {
+	table string
+	id    RecordIDValue
+}
+
+// NewRecordID builds a RecordID after validating the table name.
+func NewRecordID(table string, id RecordIDValue) (RecordID, error) {
+	if err := validateTable(table); err != nil {
+		return RecordID{}, err
+	}
+	if !id.present {
+		return RecordID{}, surqlerrors.New(surqlerrors.ErrValidation, "record id cannot be empty")
+	}
+	return RecordID{table: table, id: id}, nil
+}
+
+// NewStringRecordID is a convenience constructor for string-valued ids.
+func NewStringRecordID(table, id string) (RecordID, error) {
+	return NewRecordID(table, StringID(id))
+}
+
+// NewIntRecordID is a convenience constructor for integer-valued ids.
+func NewIntRecordID(table string, id int64) (RecordID, error) {
+	return NewRecordID(table, IntID(id))
+}
+
+func validateTable(table string) error {
+	if table == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "Table name cannot be empty")
+	}
+	if !tablePattern.MatchString(table) {
+		return surqlerrors.Newf(
+			surqlerrors.ErrValidation,
+			"Invalid table name: %q. Must contain only alphanumeric characters and underscores, and cannot start with a digit",
+			table,
+		)
+	}
+	return nil
+}
+
+// Table returns the table name.
+func (r RecordID) Table() string { return r.table }
+
+// ID returns the record id value.
+func (r RecordID) ID() RecordIDValue { return r.id }
+
+// String renders as `table:id` or `table:<id>` when the id needs angle brackets.
+func (r RecordID) String() string {
+	if r.needsAngleBrackets() {
+		return fmt.Sprintf("%s:<%s>", r.table, r.id.String())
+	}
+	return fmt.Sprintf("%s:%s", r.table, r.id.String())
+}
+
+// ToSurql renders as the SurrealQL record id literal.
+func (r RecordID) ToSurql() string { return r.String() }
+
+func (r RecordID) needsAngleBrackets() bool {
+	if r.id.isInt {
+		return false
+	}
+	return !simpleIDPattern.MatchString(r.id.str)
+}
+
+// ParseRecordID parses `table:id` (or `table:<id>`). Integer-looking ids
+// become IntID; everything else stays a StringID. Angle brackets, when
+// present, are stripped on parse.
+func ParseRecordID(input string) (RecordID, error) {
+	idx := strings.Index(input, ":")
+	if idx < 0 {
+		return RecordID{}, surqlerrors.Newf(
+			surqlerrors.ErrValidation,
+			"Invalid record ID format: %s. Expected format: table:id",
+			input,
+		)
+	}
+	table := strings.TrimSpace(input[:idx])
+	idStr := strings.TrimSpace(input[idx+1:])
+	if table == "" {
+		return RecordID{}, surqlerrors.Newf(
+			surqlerrors.ErrValidation,
+			"Invalid record ID: table name cannot be empty in %q", input,
+		)
+	}
+	if idStr == "" {
+		return RecordID{}, surqlerrors.Newf(
+			surqlerrors.ErrValidation,
+			"Invalid record ID: id cannot be empty in %q", input,
+		)
+	}
+	if len(idStr) >= 2 && idStr[0] == '<' && idStr[len(idStr)-1] == '>' {
+		idStr = idStr[1 : len(idStr)-1]
+	}
+	if n, err := strconv.ParseInt(idStr, 10, 64); err == nil {
+		return NewIntRecordID(table, n)
+	}
+	return NewStringRecordID(table, idStr)
+}
+
+// MarshalJSON encodes as a plain string (`table:id` / `table:<id>`).
+//
+// Note: callers that pass the result through encoding/json at the top
+// level will receive Go's default HTML-escaped angle brackets (`\u003c` /
+// `\u003e`). To preserve literal `<>` for wire parity with surql-py and
+// surql-ts, use [encoding/json.Encoder] with SetEscapeHTML(false).
+// Both forms decode back into the same RecordID.
+func (r RecordID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.String())
+}
+
+// marshalJSONNoHTMLEscape is kept as a reference for callers who need the
+// unescaped wire form.
+func (r RecordID) marshalJSONNoHTMLEscape() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(r.String()); err != nil {
+		return nil, err
+	}
+	out := buf.Bytes()
+	if n := len(out); n > 0 && out[n-1] == '\n' {
+		out = out[:n-1]
+	}
+	return out, nil
+}
+
+// UnmarshalJSON accepts a string in `table:id` / `table:<id>` form.
+func (r *RecordID) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	parsed, err := ParseRecordID(s)
+	if err != nil {
+		return err
+	}
+	*r = parsed
+	return nil
+}

--- a/pkg/surql/types/record_id_test.go
+++ b/pkg/surql/types/record_id_test.go
@@ -1,0 +1,159 @@
+package types
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestStringID_RendersSimple(t *testing.T) {
+	id, err := NewStringRecordID("user", "alice")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if id.String() != "user:alice" {
+		t.Errorf("got %q", id.String())
+	}
+}
+
+func TestComplexID_UsesAngleBrackets(t *testing.T) {
+	id, err := NewStringRecordID("outlet", "alaskabeacon.com")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if id.String() != "outlet:<alaskabeacon.com>" {
+		t.Errorf("got %q", id.String())
+	}
+}
+
+func TestIntID_NeverBrackets(t *testing.T) {
+	id, err := NewIntRecordID("post", 123)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if id.String() != "post:123" {
+		t.Errorf("got %q", id.String())
+	}
+}
+
+func TestParse_SimpleString(t *testing.T) {
+	id, err := ParseRecordID("user:alice")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if id.Table() != "user" || id.ID().String() != "alice" {
+		t.Errorf("got table=%q id=%q", id.Table(), id.ID().String())
+	}
+}
+
+func TestParse_IntegerID(t *testing.T) {
+	id, err := ParseRecordID("post:42")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !id.ID().IsInt() || id.ID().Int() != 42 {
+		t.Errorf("expected int 42, got %+v", id.ID())
+	}
+}
+
+func TestParse_AngleBrackets(t *testing.T) {
+	id, err := ParseRecordID("outlet:<alaskabeacon.com>")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if id.ID().IsInt() {
+		t.Error("expected string id, got int")
+	}
+	if id.ID().String() != "alaskabeacon.com" {
+		t.Errorf("got %q", id.ID().String())
+	}
+}
+
+func TestParse_Rejects(t *testing.T) {
+	cases := []string{"", "user", ":id", "user:"}
+	for _, c := range cases {
+		if _, err := ParseRecordID(c); err == nil {
+			t.Errorf("expected error for %q", c)
+		} else if !errors.Is(err, surqlerrors.ErrValidation) {
+			t.Errorf("expected validation error for %q, got %v", c, err)
+		}
+	}
+}
+
+func TestNew_RejectsInvalidTable(t *testing.T) {
+	cases := []string{"", "user-name", "1user", "user name"}
+	for _, c := range cases {
+		if _, err := NewStringRecordID(c, "alice"); err == nil {
+			t.Errorf("expected error for table %q", c)
+		}
+	}
+}
+
+func TestJSON_StringRoundtrip(t *testing.T) {
+	id, _ := NewStringRecordID("user", "alice")
+	data, err := json.Marshal(id)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(data) != `"user:alice"` {
+		t.Errorf("got %s", data)
+	}
+	var back RecordID
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.String() != id.String() {
+		t.Errorf("roundtrip mismatch: %q vs %q", back.String(), id.String())
+	}
+}
+
+func TestJSON_ComplexRoundtrip(t *testing.T) {
+	id, _ := NewStringRecordID("outlet", "alaskabeacon.com")
+	data, _ := json.Marshal(id)
+	// json.Marshal HTML-escapes `<`/`>` by default; both the escaped and
+	// literal forms must decode identically.
+	want1 := `"outlet:<alaskabeacon.com>"`
+	want2 := `"outlet:\u003calaskabeacon.com\u003e"`
+	if s := string(data); s != want1 && s != want2 {
+		t.Errorf("got %s (expected %s or %s)", s, want1, want2)
+	}
+	var back RecordID
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.ID().String() != "alaskabeacon.com" {
+		t.Errorf("got %q", back.ID().String())
+	}
+	// Literal form also roundtrips.
+	literal, err := id.marshalJSONNoHTMLEscape()
+	if err != nil {
+		t.Fatalf("no-html marshal: %v", err)
+	}
+	if string(literal) != want1 {
+		t.Errorf("literal form: got %s, want %s", literal, want1)
+	}
+	var back2 RecordID
+	if err := json.Unmarshal(literal, &back2); err != nil {
+		t.Fatalf("unmarshal literal: %v", err)
+	}
+	if back2.ID().String() != "alaskabeacon.com" {
+		t.Errorf("literal roundtrip: got %q", back2.ID().String())
+	}
+}
+
+func TestJSON_IntRoundtrip(t *testing.T) {
+	id, _ := NewIntRecordID("post", 123)
+	data, _ := json.Marshal(id)
+	if string(data) != `"post:123"` {
+		t.Errorf("got %s", data)
+	}
+	var back RecordID
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !back.ID().IsInt() || back.ID().Int() != 123 {
+		t.Errorf("lost int type: %+v", back.ID())
+	}
+}

--- a/pkg/surql/types/record_ref.go
+++ b/pkg/surql/types/record_ref.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RecordRef references a SurrealDB record via `type::record(table, id)`.
+// When emitted in a query body the expression renders verbatim rather
+// than being quoted as a string literal.
+type RecordRef struct {
+	Table    string        `json:"table"`
+	RecordID RecordIDValue `json:"record_id"`
+}
+
+// ToSurql renders as a `type::record()` SurrealQL call.
+func (r RecordRef) ToSurql() string {
+	if r.RecordID.IsInt() {
+		return fmt.Sprintf("type::record('%s', %d)", r.Table, r.RecordID.Int())
+	}
+	escaped := strings.ReplaceAll(r.RecordID.String(), `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+	return fmt.Sprintf("type::record('%s', '%s')", r.Table, escaped)
+}
+
+// String implements fmt.Stringer.
+func (r RecordRef) String() string { return r.ToSurql() }
+
+// NewRecordRef constructs a RecordRef.
+func NewRecordRef(table string, id RecordIDValue) RecordRef {
+	return RecordRef{Table: table, RecordID: id}
+}
+
+// StringRecordRef is a convenience for string-valued record refs.
+func StringRecordRef(table, id string) RecordRef {
+	return RecordRef{Table: table, RecordID: StringID(id)}
+}
+
+// IntRecordRef is a convenience for integer-valued record refs.
+func IntRecordRef(table string, id int64) RecordRef {
+	return RecordRef{Table: table, RecordID: IntID(id)}
+}

--- a/pkg/surql/types/record_ref_test.go
+++ b/pkg/surql/types/record_ref_test.go
@@ -1,0 +1,70 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRecordRef_RendersString(t *testing.T) {
+	got := StringRecordRef("user", "alice").ToSurql()
+	if got != "type::record('user', 'alice')" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRecordRef_RendersInt(t *testing.T) {
+	got := IntRecordRef("post", 123).ToSurql()
+	if got != "type::record('post', 123)" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRecordRef_EscapesSingleQuote(t *testing.T) {
+	got := StringRecordRef("user", "o'brien").ToSurql()
+	want := `type::record('user', 'o\'brien')`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRecordRef_EscapesBackslash(t *testing.T) {
+	got := StringRecordRef("path", `a\b`).ToSurql()
+	want := `type::record('path', 'a\\b')`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRecordRef_StringMatchesToSurql(t *testing.T) {
+	r := StringRecordRef("user", "alice")
+	if r.String() != r.ToSurql() {
+		t.Errorf("String=%q ToSurql=%q", r.String(), r.ToSurql())
+	}
+}
+
+func TestRecordRef_JSONRoundtrip(t *testing.T) {
+	r := StringRecordRef("user", "alice")
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back RecordRef
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.ToSurql() != r.ToSurql() {
+		t.Errorf("roundtrip: got %q vs %q", back.ToSurql(), r.ToSurql())
+	}
+}
+
+func TestRecordRef_JSONRoundtripInt(t *testing.T) {
+	r := IntRecordRef("post", 42)
+	data, _ := json.Marshal(r)
+	var back RecordRef
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !back.RecordID.IsInt() || back.RecordID.Int() != 42 {
+		t.Errorf("lost int id: %+v", back.RecordID)
+	}
+}

--- a/pkg/surql/types/reserved.go
+++ b/pkg/surql/types/reserved.go
@@ -1,0 +1,68 @@
+// Package types provides type-safe primitives for building SurrealDB queries.
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SurrealReservedWords is the canonical set of SurrealDB reserved words
+// used for field-name collision detection.
+var SurrealReservedWords = map[string]struct{}{
+	"select": {}, "from": {}, "where": {}, "group": {}, "order": {},
+	"limit": {}, "start": {}, "fetch": {}, "timeout": {}, "parallel": {},
+	"value": {}, "content": {}, "set": {}, "create": {}, "update": {},
+	"delete": {}, "relate": {}, "insert": {}, "define": {}, "remove": {},
+	"begin": {}, "commit": {}, "cancel": {}, "return": {}, "let": {},
+	"if": {}, "else": {}, "then": {}, "end": {}, "for": {},
+	"break": {}, "continue": {}, "throw": {}, "none": {}, "null": {},
+	"true": {}, "false": {}, "and": {}, "or": {}, "not": {},
+	"is": {}, "contains": {}, "inside": {}, "outside": {}, "intersects": {},
+	"type": {}, "table": {}, "field": {}, "index": {}, "event": {},
+	"namespace": {}, "database": {}, "scope": {}, "token": {}, "info": {},
+	"live": {}, "kill": {}, "sleep": {}, "use": {}, "in": {}, "out": {},
+}
+
+// EdgeAllowedReserved names reserved words that are permitted on edge schemas.
+var EdgeAllowedReserved = map[string]struct{}{
+	"in":  {},
+	"out": {},
+}
+
+// IsReservedWord reports whether name (case-insensitive, leaf of dot-path) is reserved.
+func IsReservedWord(name string) bool {
+	leaf := leafSegment(name)
+	_, ok := SurrealReservedWords[strings.ToLower(leaf)]
+	return ok
+}
+
+// CheckReservedWord returns a warning message when name collides with a
+// SurrealDB reserved word, or the empty string when it is safe. When
+// allowEdgeFields is true, the edge-allowed identifiers (`in`, `out`) are
+// permitted.
+//
+// Dot-notation names have only their leaf segment checked.
+func CheckReservedWord(name string, allowEdgeFields bool) string {
+	leaf := leafSegment(name)
+	lower := strings.ToLower(leaf)
+
+	if _, reserved := SurrealReservedWords[lower]; !reserved {
+		return ""
+	}
+	if allowEdgeFields {
+		if _, ok := EdgeAllowedReserved[lower]; ok {
+			return ""
+		}
+	}
+	return fmt.Sprintf(
+		"Field name %q collides with SurrealDB reserved word %q. This may cause unexpected query behavior.",
+		name, lower,
+	)
+}
+
+func leafSegment(name string) string {
+	if idx := strings.LastIndex(name, "."); idx >= 0 {
+		return name[idx+1:]
+	}
+	return name
+}

--- a/pkg/surql/types/reserved_test.go
+++ b/pkg/surql/types/reserved_test.go
@@ -1,0 +1,76 @@
+package types
+
+import "testing"
+
+func TestIsReservedWord_CaseInsensitive(t *testing.T) {
+	cases := []string{"SELECT", "select", "Where", "FROM"}
+	for _, c := range cases {
+		if !IsReservedWord(c) {
+			t.Errorf("expected %q to be reserved", c)
+		}
+	}
+}
+
+func TestIsReservedWord_SafeNames(t *testing.T) {
+	safe := []string{"username", "user_name", "email", "created_at"}
+	for _, c := range safe {
+		if IsReservedWord(c) {
+			t.Errorf("expected %q to be safe", c)
+		}
+	}
+}
+
+func TestCheckReservedWord_DotNotationLeaf(t *testing.T) {
+	if got := CheckReservedWord("user.name", false); got != "" {
+		t.Errorf("expected safe for user.name, got %q", got)
+	}
+	if got := CheckReservedWord("user.select", false); got == "" {
+		t.Error("expected warning for user.select")
+	}
+}
+
+func TestCheckReservedWord_EdgeAllowed(t *testing.T) {
+	if got := CheckReservedWord("in", true); got != "" {
+		t.Errorf("expected `in` safe with allowEdgeFields, got %q", got)
+	}
+	if got := CheckReservedWord("out", true); got != "" {
+		t.Errorf("expected `out` safe with allowEdgeFields, got %q", got)
+	}
+	if got := CheckReservedWord("in", false); got == "" {
+		t.Error("expected warning for `in` without allowEdgeFields")
+	}
+}
+
+func TestCheckReservedWord_MessageContainsName(t *testing.T) {
+	msg := CheckReservedWord("select", false)
+	if msg == "" {
+		t.Fatal("expected a warning message")
+	}
+	if !containsAll(msg, "select", "reserved word") {
+		t.Errorf("unexpected message: %q", msg)
+	}
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if !contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || indexOf(s, sub) >= 0
+}
+
+func indexOf(s, sub string) int {
+	// small helper; equivalent to strings.Index without importing strings
+	// purely for demonstration — keeps helper file dependency-free.
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/surql/types/surreal_fn.go
+++ b/pkg/surql/types/surreal_fn.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SurrealFn wraps a raw SurrealQL function expression so that, when used as
+// a value in CREATE/UPDATE/UPSERT, it is emitted verbatim (not quoted as a
+// string literal).
+type SurrealFn struct {
+	Expression string `json:"expression"`
+}
+
+// ToSurql renders the function call as raw SurrealQL.
+func (f SurrealFn) ToSurql() string {
+	return f.Expression
+}
+
+// String implements fmt.Stringer.
+func (f SurrealFn) String() string {
+	return f.Expression
+}
+
+// NewSurrealFn constructs a SurrealFn from a rendered expression.
+func NewSurrealFn(expression string) SurrealFn {
+	return SurrealFn{Expression: expression}
+}
+
+// SurqlFn builds a SurrealDB function call value. args are rendered verbatim
+// (via fmt.Sprint) and joined with ", ". When args is empty the call uses
+// empty parentheses.
+func SurqlFn(name string, args ...any) SurrealFn {
+	if len(args) == 0 {
+		return SurrealFn{Expression: name + "()"}
+	}
+	parts := make([]string, len(args))
+	for i, a := range args {
+		parts[i] = fmt.Sprint(a)
+	}
+	return SurrealFn{Expression: fmt.Sprintf("%s(%s)", name, strings.Join(parts, ", "))}
+}

--- a/pkg/surql/types/surreal_fn_test.go
+++ b/pkg/surql/types/surreal_fn_test.go
@@ -1,0 +1,57 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSurqlFn_NoArgs(t *testing.T) {
+	got := SurqlFn("time::now").ToSurql()
+	if got != "time::now()" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSurqlFn_WithArgs(t *testing.T) {
+	got := SurqlFn("time::format", "created_at", "%Y-%m-%d").ToSurql()
+	want := "time::format(created_at, %Y-%m-%d)"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSurqlFn_SingleArg(t *testing.T) {
+	got := SurqlFn("math::sum", "scores").ToSurql()
+	if got != "math::sum(scores)" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSurrealFn_StringMatchesToSurql(t *testing.T) {
+	f := SurqlFn("time::now")
+	if f.String() != f.ToSurql() {
+		t.Errorf("String=%q ToSurql=%q", f.String(), f.ToSurql())
+	}
+}
+
+func TestSurrealFn_JSONRoundtrip(t *testing.T) {
+	f := NewSurrealFn("time::now()")
+	data, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back SurrealFn
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back != f {
+		t.Errorf("roundtrip: got %+v, want %+v", back, f)
+	}
+}
+
+func TestSurqlFn_IntegerArg(t *testing.T) {
+	got := SurqlFn("math::add", 1, 2).ToSurql()
+	if got != "math::add(1, 2)" {
+		t.Errorf("got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

First release of **surql-go**, a 1:1 Go port of [surql-py](https://github.com/Oneiriq/surql-py).

Accumulates 14 merged increments (see CHANGELOG.md for the full list): foundation + errors + types, connection config/auth, query hints/results/expressions/builder/helpers, schema defs/sql/registry/validator/parser/visualizer/themes, migration models/discovery/diff/generator/versioning, and the docs site.

All tests green with \`go test ./... -race\`.

## Follow-ups for 0.2.0
- Runtime SurrealDB client
- Migration executor / history / rollback
- Query CRUD / typed / batch / graph / executor
- Cache (in-memory + optional Redis)
- Orchestration
- CLI binary surface