### PR TITLE
feat(query): port CRUD + typed + executor

### DIFF
--- a/pkg/surql/query/crud.go
+++ b/pkg/surql/query/crud.go
@@ -1,0 +1,421 @@
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/albedosehen/surql-go/pkg/surql/connection"
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/types"
+)
+
+// CreateRecord inserts a new record into table and returns the server
+// response normalised to a single record map.
+func CreateRecord(ctx context.Context, client *connection.DatabaseClient, table string, data map[string]any) (map[string]any, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	if err := validateIdentifier(table, "table name"); err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "data cannot be nil")
+	}
+	res, err := client.Create(ctx, table, data)
+	if err != nil {
+		return nil, err
+	}
+	return normaliseSingle(res), nil
+}
+
+// CreateRecords inserts each element of rows as its own record. The loop
+// matches the surql-py behaviour: a single failure short-circuits the
+// batch.
+func CreateRecords(ctx context.Context, client *connection.DatabaseClient, table string, rows []map[string]any) ([]map[string]any, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	if err := validateIdentifier(table, "table name"); err != nil {
+		return nil, err
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for i, row := range rows {
+		if row == nil {
+			return nil, surqlerrors.Newf(surqlerrors.ErrValidation, "rows[%d] cannot be nil", i)
+		}
+		res, err := client.Create(ctx, table, row)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, normaliseSingle(res))
+	}
+	return out, nil
+}
+
+// GetRecord fetches a single record by id. recordID may be a bare string
+// (combined with table to form `table:id`) or a types.RecordID (used
+// verbatim). Returns (nil, nil) when the record does not exist.
+func GetRecord(ctx context.Context, client *connection.DatabaseClient, table string, recordID any) (map[string]any, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	target, err := buildRecordTarget(table, recordID)
+	if err != nil {
+		return nil, err
+	}
+	res, err := client.Select(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, nil
+	}
+	if m, ok := res.(map[string]any); ok {
+		return m, nil
+	}
+	if arr, ok := res.([]any); ok {
+		if len(arr) == 0 {
+			return nil, nil
+		}
+		if m, ok := arr[0].(map[string]any); ok {
+			return m, nil
+		}
+	}
+	return nil, nil
+}
+
+// UpdateRecord replaces the record identified by recordID with data
+// (PUT semantics).
+func UpdateRecord(ctx context.Context, client *connection.DatabaseClient, table string, recordID any, data map[string]any) (map[string]any, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	target, err := buildRecordTarget(table, recordID)
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "data cannot be nil")
+	}
+	res, err := client.Update(ctx, target, data)
+	if err != nil {
+		return nil, err
+	}
+	return normaliseSingle(res), nil
+}
+
+// MergeRecord performs a partial update on the record identified by
+// recordID, leaving unspecified fields untouched.
+func MergeRecord(ctx context.Context, client *connection.DatabaseClient, table string, recordID any, data map[string]any) (map[string]any, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	target, err := buildRecordTarget(table, recordID)
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "data cannot be nil")
+	}
+	res, err := client.Merge(ctx, target, data)
+	if err != nil {
+		return nil, err
+	}
+	return normaliseSingle(res), nil
+}
+
+// UpsertRecord inserts the record when absent or replaces it when
+// present. Uses the UPSERT builder so the resulting surql statement is
+// validated before submission.
+func UpsertRecord(ctx context.Context, client *connection.DatabaseClient, table string, recordID any, data map[string]any) (map[string]any, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	target, err := buildRecordTarget(table, recordID)
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "data cannot be nil")
+	}
+	q, err := Query{}.Upsert(target, data)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := ExecuteQuery(ctx, client, q)
+	if err != nil {
+		return nil, err
+	}
+	if m := ExtractOne(raw); m != nil {
+		return m, nil
+	}
+	return normaliseSingle(raw), nil
+}
+
+// DeleteRecord removes a single record identified by recordID.
+func DeleteRecord(ctx context.Context, client *connection.DatabaseClient, table string, recordID any) error {
+	if client == nil {
+		return surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	target, err := buildRecordTarget(table, recordID)
+	if err != nil {
+		return err
+	}
+	if _, err := client.Delete(ctx, target); err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteRecords removes every record in table matching condition. Pass a
+// nil condition to delete the whole table.
+//
+// condition may be nil, a raw SurrealQL fragment (string) or any
+// types.Operator implementation.
+func DeleteRecords(ctx context.Context, client *connection.DatabaseClient, table string, condition any) error {
+	if client == nil {
+		return surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	q, err := Query{}.Delete(table)
+	if err != nil {
+		return err
+	}
+	if condition != nil {
+		q, err = q.Where(condition)
+		if err != nil {
+			return err
+		}
+	}
+	if _, err := ExecuteQuery(ctx, client, q); err != nil {
+		return err
+	}
+	return nil
+}
+
+// QueryOptions carries the common filter / pagination inputs for
+// QueryRecords. All fields are optional; leaving them zero yields a
+// `SELECT * FROM table` statement.
+type QueryOptions struct {
+	// Conditions is a list of WHERE fragments or types.Operator values.
+	Conditions []any
+	// OrderBy sets an ORDER BY clause when non-nil (field + direction).
+	OrderBy *OrderField
+	// Limit bounds the number of returned rows when non-nil.
+	Limit *int
+	// Offset skips the first N rows when non-nil.
+	Offset *int
+}
+
+// QueryRecords runs a SELECT against table with the supplied filters and
+// returns the raw record maps.
+func QueryRecords(ctx context.Context, client *connection.DatabaseClient, table string, opts QueryOptions) ([]map[string]any, error) {
+	q, err := buildSelectFromOptions(table, opts)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := ExecuteQuery(ctx, client, q)
+	if err != nil {
+		return nil, err
+	}
+	return ExtractResult(raw), nil
+}
+
+// CountRecords returns `count()` for table, optionally scoped by a
+// condition (string or types.Operator).
+func CountRecords(ctx context.Context, client *connection.DatabaseClient, table string, condition any) (int64, error) {
+	if client == nil {
+		return 0, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	q, err := Query{}.Select([]string{"count()"}).FromTable(table)
+	if err != nil {
+		return 0, err
+	}
+	if condition != nil {
+		q, err = q.Where(condition)
+		if err != nil {
+			return 0, err
+		}
+	}
+	raw, err := ExecuteQuery(ctx, client, q)
+	if err != nil {
+		return 0, err
+	}
+	first := ExtractOne(raw)
+	if first == nil {
+		return 0, nil
+	}
+	if v, ok := first["count"]; ok {
+		return toInt64(v), nil
+	}
+	return 0, nil
+}
+
+// Exists reports whether the record identified by recordID is present.
+func Exists(ctx context.Context, client *connection.DatabaseClient, table string, recordID any) (bool, error) {
+	rec, err := GetRecord(ctx, client, table, recordID)
+	if err != nil {
+		return false, err
+	}
+	return rec != nil, nil
+}
+
+// First returns the first record matching the filter options, or nil.
+// A convenience wrapper that forces `LIMIT 1`.
+func First(ctx context.Context, client *connection.DatabaseClient, table string, opts QueryOptions) (map[string]any, error) {
+	one := 1
+	opts.Limit = &one
+	rows, err := QueryRecords(ctx, client, table, opts)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	return rows[0], nil
+}
+
+// Last returns the last record matching the filter options, or nil. If
+// an OrderBy is supplied its direction is flipped; without one the call
+// devolves to First.
+func Last(ctx context.Context, client *connection.DatabaseClient, table string, opts QueryOptions) (map[string]any, error) {
+	if opts.OrderBy != nil {
+		flipped := OrderField{Field: opts.OrderBy.Field}
+		if opts.OrderBy.Direction == "ASC" {
+			flipped.Direction = "DESC"
+		} else {
+			flipped.Direction = "ASC"
+		}
+		opts.OrderBy = &flipped
+	}
+	return First(ctx, client, table, opts)
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// buildRecordTarget normalises the (table, id) pair into a SurrealDB
+// record target such as `user:alice` or `user:<alice>`. When recordID is
+// a types.RecordID its own string form is used verbatim.
+func buildRecordTarget(table string, recordID any) (string, error) {
+	switch v := recordID.(type) {
+	case nil:
+		return "", surqlerrors.New(surqlerrors.ErrValidation, "record id cannot be nil")
+	case types.RecordID:
+		return v.String(), nil
+	case string:
+		if v == "" {
+			return "", surqlerrors.New(surqlerrors.ErrValidation, "record id cannot be empty")
+		}
+		if err := validateIdentifier(table, "table name"); err != nil {
+			return "", err
+		}
+		return table + ":" + v, nil
+	case fmt.Stringer:
+		s := v.String()
+		if s == "" {
+			return "", surqlerrors.New(surqlerrors.ErrValidation, "record id cannot be empty")
+		}
+		if err := validateIdentifier(table, "table name"); err != nil {
+			return "", err
+		}
+		return table + ":" + s, nil
+	default:
+		return "", surqlerrors.Newf(surqlerrors.ErrValidation,
+			"record id must be string or types.RecordID, got %T", recordID)
+	}
+}
+
+// buildSelectFromOptions materialises a Query from a QueryOptions value.
+func buildSelectFromOptions(table string, opts QueryOptions) (Query, error) {
+	q, err := Query{}.Select(nil).FromTable(table)
+	if err != nil {
+		return Query{}, err
+	}
+	for _, c := range opts.Conditions {
+		q, err = q.Where(c)
+		if err != nil {
+			return Query{}, err
+		}
+	}
+	if opts.OrderBy != nil {
+		q, err = q.OrderBy(opts.OrderBy.Field, opts.OrderBy.Direction)
+		if err != nil {
+			return Query{}, err
+		}
+	}
+	if opts.Limit != nil {
+		q, err = q.Limit(*opts.Limit)
+		if err != nil {
+			return Query{}, err
+		}
+	}
+	if opts.Offset != nil {
+		q, err = q.Offset(*opts.Offset)
+		if err != nil {
+			return Query{}, err
+		}
+	}
+	return q, nil
+}
+
+// normaliseSingle reduces an SDK response to a single map[string]any.
+// SurrealDB occasionally wraps scalars or returns a one-element slice; we
+// pick whichever form is most useful to downstream callers.
+func normaliseSingle(v any) map[string]any {
+	switch x := v.(type) {
+	case nil:
+		return nil
+	case map[string]any:
+		if inner, ok := x["result"]; ok {
+			if nested := normaliseSingle(inner); nested != nil {
+				return nested
+			}
+		}
+		return x
+	case []any:
+		if len(x) == 0 {
+			return nil
+		}
+		return normaliseSingle(x[0])
+	default:
+		return nil
+	}
+}
+
+// toInt64 coerces JSON-ish numerics (float64, json.Number, int, int64,
+// uint*) into an int64; returns 0 for anything else.
+func toInt64(v any) int64 {
+	switch n := v.(type) {
+	case int:
+		return int64(n)
+	case int8:
+		return int64(n)
+	case int16:
+		return int64(n)
+	case int32:
+		return int64(n)
+	case int64:
+		return n
+	case uint:
+		return int64(n)
+	case uint8:
+		return int64(n)
+	case uint16:
+		return int64(n)
+	case uint32:
+		return int64(n)
+	case uint64:
+		return int64(n)
+	case float32:
+		return int64(n)
+	case float64:
+		return int64(n)
+	case json.Number:
+		if i, err := n.Int64(); err == nil {
+			return i
+		}
+	}
+	return 0
+}

--- a/pkg/surql/query/crud.go
+++ b/pkg/surql/query/crud.go
@@ -160,7 +160,14 @@ func DeleteRecord(ctx context.Context, client *connection.DatabaseClient, table 
 	if err != nil {
 		return err
 	}
-	if _, err := client.Delete(ctx, target); err != nil {
+	// Use raw `DELETE <table:id>` -- the SDK's Delete treats its string
+	// target as a table name, which v3+ rejects when given "table:id".
+	// A "table does not exist" error is treated as a successful no-op to
+	// match v2 behaviour and the Python port.
+	if _, err := client.Query(ctx, "DELETE "+target+";"); err != nil {
+		if isTableMissingError(err) {
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/pkg/surql/query/crud.go
+++ b/pkg/surql/query/crud.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/albedosehen/surql-go/pkg/surql/connection"
 	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
@@ -56,6 +57,10 @@ func CreateRecords(ctx context.Context, client *connection.DatabaseClient, table
 // GetRecord fetches a single record by id. recordID may be a bare string
 // (combined with table to form `table:id`) or a types.RecordID (used
 // verbatim). Returns (nil, nil) when the record does not exist.
+//
+// Uses a raw `SELECT * FROM <table:id>` query rather than the SDK's
+// Select shortcut because SurrealDB v3+ treats the SDK's string-target
+// as a table name (rejecting "table:id" as a missing table).
 func GetRecord(ctx context.Context, client *connection.DatabaseClient, table string, recordID any) (map[string]any, error) {
 	if client == nil {
 		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
@@ -64,25 +69,18 @@ func GetRecord(ctx context.Context, client *connection.DatabaseClient, table str
 	if err != nil {
 		return nil, err
 	}
-	res, err := client.Select(ctx, target)
+	res, err := client.Query(ctx, "SELECT * FROM "+target+";")
 	if err != nil {
-		return nil, err
-	}
-	if res == nil {
-		return nil, nil
-	}
-	if m, ok := res.(map[string]any); ok {
-		return m, nil
-	}
-	if arr, ok := res.([]any); ok {
-		if len(arr) == 0 {
+		if isTableMissingError(err) {
 			return nil, nil
 		}
-		if m, ok := arr[0].(map[string]any); ok {
-			return m, nil
-		}
+		return nil, err
 	}
-	return nil, nil
+	rows := ExtractResult(res)
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	return rows[0], nil
 }
 
 // UpdateRecord replaces the record identified by recordID with data
@@ -227,6 +225,10 @@ func CountRecords(ctx context.Context, client *connection.DatabaseClient, table 
 	if client == nil {
 		return 0, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
 	}
+	// SurrealDB: `SELECT count() FROM table` returns one row per record
+	// (each with `count: 1`); `SELECT count() FROM table GROUP ALL` returns
+	// a single aggregated row. Mirror the Python port's behaviour by
+	// always requesting GROUP ALL.
 	q, err := Query{}.Select([]string{"count()"}).FromTable(table)
 	if err != nil {
 		return 0, err
@@ -237,8 +239,12 @@ func CountRecords(ctx context.Context, client *connection.DatabaseClient, table 
 			return 0, err
 		}
 	}
+	q = q.GroupAll()
 	raw, err := ExecuteQuery(ctx, client, q)
 	if err != nil {
+		if isTableMissingError(err) {
+			return 0, nil
+		}
 		return 0, err
 	}
 	first := ExtractOne(raw)
@@ -252,12 +258,26 @@ func CountRecords(ctx context.Context, client *connection.DatabaseClient, table 
 }
 
 // Exists reports whether the record identified by recordID is present.
+// A "table does not exist" error from SurrealDB v3+ is treated as "not
+// present" rather than a hard failure, matching Python's semantic where
+// a missing table counts as 'record absent'.
 func Exists(ctx context.Context, client *connection.DatabaseClient, table string, recordID any) (bool, error) {
 	rec, err := GetRecord(ctx, client, table, recordID)
 	if err != nil {
+		if isTableMissingError(err) {
+			return false, nil
+		}
 		return false, err
 	}
 	return rec != nil, nil
+}
+
+// isTableMissingError reports whether the error is SurrealDB's
+// "table '...' does not exist" response. v2.x treated missing tables as
+// empty results; v3+ returns this error. Callers that want an empty
+// result to be equivalent to "no records" use this check.
+func isTableMissingError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "does not exist")
 }
 
 // First returns the first record matching the filter options, or nil.

--- a/pkg/surql/query/crud_test.go
+++ b/pkg/surql/query/crud_test.go
@@ -1,0 +1,201 @@
+package query
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/albedosehen/surql-go/pkg/surql/types"
+)
+
+func TestBuildRecordTarget_String(t *testing.T) {
+	target, err := buildRecordTarget("user", "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != "user:alice" {
+		t.Errorf("got %q", target)
+	}
+}
+
+func TestBuildRecordTarget_RecordID(t *testing.T) {
+	id, err := types.NewStringRecordID("user", "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := buildRecordTarget("ignored", id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != "user:alice" {
+		t.Errorf("got %q", target)
+	}
+}
+
+func TestBuildRecordTarget_Nil(t *testing.T) {
+	if _, err := buildRecordTarget("user", nil); err == nil {
+		t.Fatal("expected error")
+	} else if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestBuildRecordTarget_EmptyString(t *testing.T) {
+	if _, err := buildRecordTarget("user", ""); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestBuildRecordTarget_InvalidTable(t *testing.T) {
+	if _, err := buildRecordTarget("1bad", "alice"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestBuildRecordTarget_UnsupportedType(t *testing.T) {
+	if _, err := buildRecordTarget("user", 42); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestBuildSelectFromOptions_Minimal(t *testing.T) {
+	q, err := buildSelectFromOptions("user", QueryOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "SELECT * FROM user"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildSelectFromOptions_Full(t *testing.T) {
+	limit, offset := 10, 5
+	opts := QueryOptions{
+		Conditions: []any{"age > 18"},
+		OrderBy:    &OrderField{Field: "created_at", Direction: "DESC"},
+		Limit:      &limit,
+		Offset:     &offset,
+	}
+	q, err := buildSelectFromOptions("user", opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "SELECT * FROM user WHERE (age > 18) ORDER BY created_at DESC LIMIT 10 START 5"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildSelectFromOptions_BadCondition(t *testing.T) {
+	if _, err := buildSelectFromOptions("user", QueryOptions{Conditions: []any{42}}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestCreateRecord_NilClient(t *testing.T) {
+	if _, err := CreateRecord(context.Background(), nil, "user", map[string]any{"n": 1}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestCreateRecord_NilData(t *testing.T) {
+	if _, err := CreateRecord(context.Background(), nil, "user", nil); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestCreateRecord_InvalidTable(t *testing.T) {
+	if _, err := CreateRecord(context.Background(), nil, "1bad", map[string]any{"n": 1}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestDeleteRecord_NilClient(t *testing.T) {
+	if err := DeleteRecord(context.Background(), nil, "user", "alice"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestDeleteRecords_NilClient(t *testing.T) {
+	if err := DeleteRecords(context.Background(), nil, "user", nil); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestNormaliseSingle(t *testing.T) {
+	cases := map[string]struct {
+		in   any
+		want map[string]any
+	}{
+		"nil":      {nil, nil},
+		"map":      {map[string]any{"a": 1}, map[string]any{"a": 1}},
+		"wrapped":  {map[string]any{"result": map[string]any{"b": 2}}, map[string]any{"b": 2}},
+		"slice":    {[]any{map[string]any{"c": 3}}, map[string]any{"c": 3}},
+		"empty":    {[]any{}, nil},
+		"scalar":   {"hi", nil},
+		"nilSlice": {[]any(nil), nil},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := normaliseSingle(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len mismatch: got %v want %v", got, tc.want)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Errorf("%s: got %v want %v", k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestToInt64(t *testing.T) {
+	cases := []struct {
+		in   any
+		want int64
+	}{
+		{int(5), 5},
+		{int32(7), 7},
+		{int64(9), 9},
+		{uint32(3), 3},
+		{float64(4), 4},
+		{float64(4.9), 4},
+		{"abc", 0},
+		{nil, 0},
+	}
+	for _, tc := range cases {
+		if got := toInt64(tc.in); got != tc.want {
+			t.Errorf("toInt64(%v) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestLast_FlipsOrderDirection(t *testing.T) {
+	opts := QueryOptions{OrderBy: &OrderField{Field: "created_at", Direction: "ASC"}}
+	// Last only flips the direction; it still calls First which requires a
+	// client. We just verify the flip by building the query directly.
+	q, err := buildSelectFromOptions("user", QueryOptions{
+		OrderBy: &OrderField{Field: opts.OrderBy.Field, Direction: "DESC"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	surql, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if surql != "SELECT * FROM user ORDER BY created_at DESC" {
+		t.Errorf("got %q", surql)
+	}
+}

--- a/pkg/surql/query/doc.go
+++ b/pkg/surql/query/doc.go
@@ -12,8 +12,13 @@
 //     UPSERT / DELETE / RELATE operations, graph traversal, vector search,
 //     return-format, and optimization hints
 //   - standalone helper constructors (Select, FromTable, Insert, Update,
-//     Upsert, Delete, Relate, VectorSearchQuery, SimilaritySearchQuery).
-//
-// Subsequent increments add typed/batch/graph CRUD helpers and the async
-// executor.
+//     Upsert, Delete, Relate, VectorSearchQuery, SimilaritySearchQuery)
+//   - the query executor (ExecuteQuery, ExecuteRaw, FetchOne, FetchAll,
+//     FetchMany, ExecuteRawTyped) layered on connection.DatabaseClient
+//   - JSON-in/JSON-out record CRUD helpers (CreateRecord, CreateRecords,
+//     GetRecord, UpdateRecord, MergeRecord, UpsertRecord, DeleteRecord,
+//     DeleteRecords, QueryRecords, CountRecords, Exists, First, Last) with a
+//     QueryOptions value type for filters and pagination
+//   - the generic typed variants (CreateTyped, GetTyped, QueryTyped,
+//     UpdateTyped, UpsertTyped) that round-trip through encoding/json.
 package query

--- a/pkg/surql/query/executor.go
+++ b/pkg/surql/query/executor.go
@@ -1,0 +1,130 @@
+package query
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/albedosehen/surql-go/pkg/surql/connection"
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// ExecuteQuery renders q to SurrealQL and executes it against client. The
+// returned value is the raw response envelope produced by DatabaseClient
+// (a []any of per-statement results), suitable for ExtractResult / ExtractOne
+// or for downstream typed decoding.
+//
+// Returns ErrValidation if the query is incomplete, or ErrQuery when the
+// underlying connection surface fails.
+func ExecuteQuery(ctx context.Context, client *connection.DatabaseClient, q Query) (any, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	surql, err := q.ToSurql()
+	if err != nil {
+		return nil, err
+	}
+	return client.Query(ctx, surql)
+}
+
+// ExecuteRaw runs a raw SurrealQL statement with the supplied parameter map.
+// Pass a nil vars map for a parameter-less query.
+func ExecuteRaw(ctx context.Context, client *connection.DatabaseClient, surql string, vars map[string]any) (any, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	if surql == "" {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "surql cannot be empty")
+	}
+	return client.QueryWithVars(ctx, surql, vars)
+}
+
+// FetchOne executes q and decodes the first record into *T. Returns
+// (nil, nil) when the response contains no rows.
+func FetchOne[T any](ctx context.Context, client *connection.DatabaseClient, q Query) (*T, error) {
+	raw, err := ExecuteQuery(ctx, client, q)
+	if err != nil {
+		return nil, err
+	}
+	record := ExtractOne(raw)
+	if record == nil {
+		return nil, nil
+	}
+	out, err := decodeRecord[T](record)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// FetchAll executes q and decodes every record into []T. Returns an empty
+// slice when the response carries no rows.
+func FetchAll[T any](ctx context.Context, client *connection.DatabaseClient, q Query) ([]T, error) {
+	raw, err := ExecuteQuery(ctx, client, q)
+	if err != nil {
+		return nil, err
+	}
+	return decodeRecords[T](ExtractResult(raw))
+}
+
+// FetchMany executes q and wraps the decoded rows in a ListResult, carrying
+// any LimitValue/OffsetValue that were set on the query.
+func FetchMany[T any](ctx context.Context, client *connection.DatabaseClient, q Query) (ListResult[T], error) {
+	items, err := FetchAll[T](ctx, client, q)
+	if err != nil {
+		return ListResult[T]{}, err
+	}
+	var limit, offset *uint64
+	if q.LimitValue != nil {
+		v := uint64(*q.LimitValue)
+		limit = &v
+	}
+	if q.OffsetValue != nil {
+		v := uint64(*q.OffsetValue)
+		offset = &v
+	}
+	return Records[T](items, nil, limit, offset), nil
+}
+
+// ExecuteRawTyped runs a raw SurrealQL query and decodes every row into T.
+func ExecuteRawTyped[T any](ctx context.Context, client *connection.DatabaseClient, surql string, vars map[string]any) ([]T, error) {
+	raw, err := ExecuteRaw(ctx, client, surql, vars)
+	if err != nil {
+		return nil, err
+	}
+	return decodeRecords[T](ExtractResult(raw))
+}
+
+// ---------------------------------------------------------------------------
+// JSON round-trip helpers
+// ---------------------------------------------------------------------------
+
+// decodeRecord round-trips `record` through encoding/json into a fresh T.
+func decodeRecord[T any](record map[string]any) (T, error) {
+	var out T
+	buf, err := json.Marshal(record)
+	if err != nil {
+		return out, surqlerrors.Wrap(surqlerrors.ErrSerialization, "encode record", err)
+	}
+	if err := json.Unmarshal(buf, &out); err != nil {
+		return out, surqlerrors.Wrap(surqlerrors.ErrSerialization, "decode record", err)
+	}
+	return out, nil
+}
+
+// decodeRecords round-trips every element of `records` through
+// encoding/json into []T, returning a non-nil empty slice when records is
+// empty.
+func decodeRecords[T any](records []map[string]any) ([]T, error) {
+	if len(records) == 0 {
+		return []T{}, nil
+	}
+	out := make([]T, 0, len(records))
+	for _, rec := range records {
+		v, err := decodeRecord[T](rec)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}

--- a/pkg/surql/query/executor_test.go
+++ b/pkg/surql/query/executor_test.go
@@ -1,0 +1,88 @@
+package query
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+func TestExecuteQuery_NilClient(t *testing.T) {
+	q, err := Query{}.Select(nil).FromTable("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ExecuteQuery(context.Background(), nil, q); err == nil {
+		t.Fatal("expected error for nil client")
+	} else if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestExecuteQuery_IncompleteQuery(t *testing.T) {
+	// Missing operation -> ToSurql returns validation error, which the
+	// executor must propagate before hitting the client.
+	if _, err := ExecuteQuery(context.Background(), nil, Query{}); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestExecuteRaw_NilClient(t *testing.T) {
+	if _, err := ExecuteRaw(context.Background(), nil, "SELECT 1", nil); err == nil {
+		t.Fatal("expected error for nil client")
+	}
+}
+
+func TestExecuteRaw_EmptySurql(t *testing.T) {
+	// Force the empty-surql branch even with a nil client.
+	// (The nil-client branch runs first; re-route by using a zero *DatabaseClient-shaped*
+	// pointer is not easily available without a live connection. Instead assert
+	// through the exported function where it's the validation order that
+	// matters most: nil client is the first check.)
+	if _, err := ExecuteRaw(context.Background(), nil, "", nil); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestDecodeRecord_RoundTrip(t *testing.T) {
+	type user struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+	in := map[string]any{"name": "Alice", "age": 30}
+	got, err := decodeRecord[user](in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "Alice" || got.Age != 30 {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestDecodeRecords_EmptySliceNonNil(t *testing.T) {
+	out, err := decodeRecords[map[string]any](nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out == nil {
+		t.Fatal("expected non-nil slice")
+	}
+	if len(out) != 0 {
+		t.Errorf("expected empty, got %v", out)
+	}
+}
+
+func TestDecodeRecords_Many(t *testing.T) {
+	type item struct {
+		Value int `json:"value"`
+	}
+	rows := []map[string]any{{"value": 1}, {"value": 2}, {"value": 3}}
+	got, err := decodeRecords[item](rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 || got[0].Value != 1 || got[2].Value != 3 {
+		t.Errorf("got %+v", got)
+	}
+}

--- a/pkg/surql/query/integration_test.go
+++ b/pkg/surql/query/integration_test.go
@@ -1,0 +1,249 @@
+//go:build integration
+// +build integration
+
+package query
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/albedosehen/surql-go/pkg/surql/connection"
+)
+
+// getIntegrationURL reads the SurrealDB URL used by CI's integration job.
+// Tests skip when SURREAL_URL is unset so local `go test -tags=integration`
+// without a server still short-circuits gracefully.
+func getIntegrationURL(t *testing.T) string {
+	t.Helper()
+	url := os.Getenv("SURREAL_URL")
+	if url == "" {
+		t.Skip("SURREAL_URL not set; skipping integration test")
+	}
+	return url
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func newIntegrationClient(t *testing.T) (*connection.DatabaseClient, func()) {
+	t.Helper()
+	cfg := connection.DefaultConfig()
+	cfg.DBURL = getIntegrationURL(t)
+	cfg.DBNS = "surqlgo_test"
+	cfg.DB = "query"
+	cfg.DBRetryMaxAttempts = 3
+	cfg.DBRetryMinWait = 0.5
+	cfg.DBRetryMaxWait = 2.0
+	cfg.DBRetryMultiplier = 2.0
+
+	client, err := connection.NewDatabaseClient(cfg)
+	if err != nil {
+		t.Fatalf("NewDatabaseClient: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	user := envOr("SURREAL_USER", "root")
+	pass := envOr("SURREAL_PASS", "root")
+	if _, err := client.Signin(ctx, connection.NewRootCredentials(user, pass)); err != nil {
+		_ = client.Disconnect()
+		t.Fatalf("Signin: %v", err)
+	}
+
+	return client, func() { _ = client.Disconnect() }
+}
+
+func cleanupTable(t *testing.T, client *connection.DatabaseClient, table string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := client.Query(ctx, "REMOVE TABLE IF EXISTS "+table+";"); err != nil {
+		t.Fatalf("pre-test cleanup (%s): %v", table, err)
+	}
+}
+
+type integrationUser struct {
+	Name  string `json:"name"`
+	Age   int    `json:"age"`
+	Email string `json:"email,omitempty"`
+}
+
+func TestIntegration_CreateAndGetRecord(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+	cleanupTable(t, client, "surqlgo_query_user")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	created, err := CreateRecord(ctx, client, "surqlgo_query_user", map[string]any{
+		"name": "alice",
+		"age":  30,
+	})
+	if err != nil {
+		t.Fatalf("CreateRecord: %v", err)
+	}
+	if created == nil {
+		t.Fatal("CreateRecord returned nil record")
+	}
+	if created["name"] != "alice" {
+		t.Errorf("name = %v", created["name"])
+	}
+}
+
+func TestIntegration_QueryRecordsAndCount(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+	cleanupTable(t, client, "surqlgo_query_cnt")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for _, name := range []string{"alice", "bob", "carol"} {
+		if _, err := CreateRecord(ctx, client, "surqlgo_query_cnt", map[string]any{
+			"name": name,
+		}); err != nil {
+			t.Fatalf("CreateRecord(%s): %v", name, err)
+		}
+	}
+
+	rows, err := QueryRecords(ctx, client, "surqlgo_query_cnt", QueryOptions{})
+	if err != nil {
+		t.Fatalf("QueryRecords: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Errorf("want 3 rows, got %d", len(rows))
+	}
+
+	n, err := CountRecords(ctx, client, "surqlgo_query_cnt", nil)
+	if err != nil {
+		t.Fatalf("CountRecords: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("want 3 count, got %d", n)
+	}
+}
+
+func TestIntegration_ExistsAndDelete(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+	cleanupTable(t, client, "surqlgo_query_del")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if _, err := client.Query(ctx, "CREATE surqlgo_query_del:alice SET name = 'alice';"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	present, err := Exists(ctx, client, "surqlgo_query_del", "alice")
+	if err != nil {
+		t.Fatalf("Exists: %v", err)
+	}
+	if !present {
+		t.Fatal("expected record to exist")
+	}
+
+	if err := DeleteRecord(ctx, client, "surqlgo_query_del", "alice"); err != nil {
+		t.Fatalf("DeleteRecord: %v", err)
+	}
+
+	present, err = Exists(ctx, client, "surqlgo_query_del", "alice")
+	if err != nil {
+		t.Fatalf("Exists after delete: %v", err)
+	}
+	if present {
+		t.Fatal("expected record to be deleted")
+	}
+}
+
+func TestIntegration_FetchOneAndFetchAll(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+	cleanupTable(t, client, "surqlgo_query_fetch")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for i, name := range []string{"alice", "bob"} {
+		if _, err := CreateRecord(ctx, client, "surqlgo_query_fetch", map[string]any{
+			"name": name,
+			"age":  20 + i,
+		}); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	q, err := Query{}.Select(nil).FromTable("surqlgo_query_fetch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	all, err := FetchAll[integrationUser](ctx, client, q)
+	if err != nil {
+		t.Fatalf("FetchAll: %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("want 2 rows, got %d", len(all))
+	}
+
+	one, err := FetchOne[integrationUser](ctx, client, q)
+	if err != nil {
+		t.Fatalf("FetchOne: %v", err)
+	}
+	if one == nil {
+		t.Fatal("expected record")
+	}
+}
+
+func TestIntegration_CreateTypedAndGetTyped(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+	cleanupTable(t, client, "surqlgo_typed_user")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	payload := integrationUser{Name: "alice", Age: 30, Email: "alice@example.com"}
+	created, err := CreateTyped[integrationUser](ctx, client, "surqlgo_typed_user", payload)
+	if err != nil {
+		t.Fatalf("CreateTyped: %v", err)
+	}
+	if created.Name != "alice" || created.Age != 30 {
+		t.Errorf("got %+v", created)
+	}
+}
+
+func TestIntegration_ExecuteRawTyped(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+	cleanupTable(t, client, "surqlgo_typed_raw")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if _, err := client.Query(ctx, "CREATE surqlgo_typed_raw:alice SET name = 'alice', age = 40;"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	rows, err := ExecuteRawTyped[integrationUser](
+		ctx, client,
+		"SELECT name, age FROM surqlgo_typed_raw WHERE age > $min;",
+		map[string]any{"min": 30},
+	)
+	if err != nil {
+		t.Fatalf("ExecuteRawTyped: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Name != "alice" {
+		t.Errorf("got %+v", rows)
+	}
+}

--- a/pkg/surql/query/typed.go
+++ b/pkg/surql/query/typed.go
@@ -1,0 +1,110 @@
+package query
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/albedosehen/surql-go/pkg/surql/connection"
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// CreateTyped creates a record from data and returns a validated T. The
+// value is serialised through encoding/json before submission and the
+// response is decoded back into a fresh T, guaranteeing tag-driven field
+// mapping in both directions.
+func CreateTyped[T any](ctx context.Context, client *connection.DatabaseClient, table string, data T) (T, error) {
+	var zero T
+	payload, err := toJSONMap(data)
+	if err != nil {
+		return zero, err
+	}
+	res, err := CreateRecord(ctx, client, table, payload)
+	if err != nil {
+		return zero, err
+	}
+	return decodeRecord[T](res)
+}
+
+// GetTyped fetches a record and validates it into T. Returns (zero, nil,
+// false, nil) when the record does not exist; callers should check the
+// boolean before using the value.
+func GetTyped[T any](ctx context.Context, client *connection.DatabaseClient, table string, recordID any) (T, bool, error) {
+	var zero T
+	rec, err := GetRecord(ctx, client, table, recordID)
+	if err != nil {
+		return zero, false, err
+	}
+	if rec == nil {
+		return zero, false, nil
+	}
+	out, err := decodeRecord[T](rec)
+	if err != nil {
+		return zero, false, err
+	}
+	return out, true, nil
+}
+
+// QueryTyped runs a raw SurrealQL statement and decodes every row into T.
+func QueryTyped[T any](ctx context.Context, client *connection.DatabaseClient, surql string, vars map[string]any) ([]T, error) {
+	return ExecuteRawTyped[T](ctx, client, surql, vars)
+}
+
+// UpdateTyped replaces the record identified by recordID with data (PUT
+// semantics) and returns the server's post-update record validated into T.
+func UpdateTyped[T any](ctx context.Context, client *connection.DatabaseClient, table string, recordID any, data T) (T, error) {
+	var zero T
+	payload, err := toJSONMap(data)
+	if err != nil {
+		return zero, err
+	}
+	res, err := UpdateRecord(ctx, client, table, recordID, payload)
+	if err != nil {
+		return zero, err
+	}
+	return decodeRecord[T](res)
+}
+
+// UpsertTyped inserts or replaces the record identified by recordID and
+// returns the resulting record validated into T.
+func UpsertTyped[T any](ctx context.Context, client *connection.DatabaseClient, table string, recordID any, data T) (T, error) {
+	var zero T
+	payload, err := toJSONMap(data)
+	if err != nil {
+		return zero, err
+	}
+	res, err := UpsertRecord(ctx, client, table, recordID, payload)
+	if err != nil {
+		return zero, err
+	}
+	return decodeRecord[T](res)
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// toJSONMap serialises v through encoding/json and decodes it into a
+// map[string]any so that downstream CRUD helpers (which speak map) see
+// exactly the JSON payload the wire would carry.
+func toJSONMap[T any](v T) (map[string]any, error) {
+	// map[string]any short-circuit: preserves nil vs empty semantics.
+	switch m := any(v).(type) {
+	case map[string]any:
+		if m == nil {
+			return nil, surqlerrors.New(surqlerrors.ErrValidation, "data cannot be nil")
+		}
+		return m, nil
+	}
+	buf, err := json.Marshal(v)
+	if err != nil {
+		return nil, surqlerrors.Wrap(surqlerrors.ErrSerialization, "encode payload", err)
+	}
+	if len(buf) == 0 || string(buf) == "null" {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "data cannot be nil")
+	}
+	out := map[string]any{}
+	if err := json.Unmarshal(buf, &out); err != nil {
+		return nil, surqlerrors.Wrap(surqlerrors.ErrSerialization, "decode payload to map", err)
+	}
+	return out, nil
+}

--- a/pkg/surql/query/typed_test.go
+++ b/pkg/surql/query/typed_test.go
@@ -1,0 +1,79 @@
+package query
+
+import "testing"
+
+type sampleUser struct {
+	Name  string `json:"name"`
+	Age   int    `json:"age"`
+	Email string `json:"email,omitempty"`
+}
+
+func TestToJSONMap_Struct(t *testing.T) {
+	u := sampleUser{Name: "Alice", Age: 30, Email: "alice@example.com"}
+	m, err := toJSONMap(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m["name"] != "Alice" || m["email"] != "alice@example.com" {
+		t.Errorf("got %+v", m)
+	}
+	// encoding/json decodes numeric fields as float64.
+	if v, ok := m["age"].(float64); !ok || v != 30 {
+		t.Errorf("expected age=30, got %v (%T)", m["age"], m["age"])
+	}
+}
+
+func TestToJSONMap_StructOmitEmpty(t *testing.T) {
+	u := sampleUser{Name: "Alice", Age: 30}
+	m, err := toJSONMap(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m["email"]; ok {
+		t.Error("omitempty should elide email")
+	}
+}
+
+func TestToJSONMap_Map(t *testing.T) {
+	in := map[string]any{"name": "Alice"}
+	m, err := toJSONMap(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Same map instance returned (documented short-circuit).
+	if m["name"] != "Alice" {
+		t.Errorf("got %+v", m)
+	}
+}
+
+func TestToJSONMap_NilMap(t *testing.T) {
+	var in map[string]any
+	if _, err := toJSONMap(in); err == nil {
+		t.Fatal("expected error for nil map")
+	}
+}
+
+func TestToJSONMap_NilPointer(t *testing.T) {
+	var p *sampleUser
+	if _, err := toJSONMap(p); err == nil {
+		t.Fatal("expected error for nil pointer (encodes as null)")
+	}
+}
+
+func TestToJSONMap_NonObject(t *testing.T) {
+	// Numbers / slices do not unmarshal into map[string]any.
+	if _, err := toJSONMap(42); err == nil {
+		t.Fatal("expected error for non-object payload")
+	}
+}
+
+func TestDecodeRecord_Typed(t *testing.T) {
+	record := map[string]any{"name": "Bob", "age": float64(25)}
+	got, err := decodeRecord[sampleUser](record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "Bob" || got.Age != 25 {
+		t.Errorf("got %+v", got)
+	}
+}


### PR DESCRIPTION
Closes #39.

## Summary
Port the surql-py query execution layer against the freshly-landed DatabaseClient.

- **\`query/executor.go\`**: \`ExecuteQuery\`, \`ExecuteRaw\`, generic \`FetchOne[T]\` / \`FetchAll[T]\` / \`FetchMany[T]\` (honours \`Query.LimitValue\`/\`OffsetValue\`), \`ExecuteRawTyped[T]\`. Shared \`decodeRecord[T]\` / \`decodeRecords[T]\` helpers.
- **\`query/crud.go\`**: JSON-map CRUD — \`CreateRecord\`, \`CreateRecords\`, \`GetRecord\`, \`UpdateRecord\`, \`MergeRecord\`, \`UpsertRecord\`, \`DeleteRecord\`, \`DeleteRecords\`, \`QueryRecords\`, \`CountRecords\`, \`Exists\`, \`First\`, \`Last\`. \`QueryOptions\` value for filters/pagination; \`buildRecordTarget\` accepts \`string\` or \`types.RecordID\`.
- **\`query/typed.go\`**: generic \`CreateTyped\`, \`GetTyped\` (returns \`(T, bool, error)\` — explicit exists flag since Python's \`T | None\` doesn't map 1:1 to Go generics), \`QueryTyped\`, \`UpdateTyped\`, \`UpsertTyped\`. \`toJSONMap[T]\` shim short-circuits \`map[string]any\`.
- **\`UpsertRecord\`** goes through \`Query.Upsert\` (not \`db.Update\`) so SurrealQL validation runs.

## Test plan
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean (and \`-tags=integration\`)
- [x] \`go test ./... -race\` — query pkg green in 1.49s
- [x] Integration tests behind \`//go:build integration\` cover create/get, count, exists/delete, FetchOne/All, CreateTyped, ExecuteRawTyped; skip cleanly without \`SURREAL_URL\`
- [ ] CI green