### PR TITLE
feat(migration): port executor + history + rollback

### DIFF
--- a/pkg/surql/migration/executor.go
+++ b/pkg/surql/migration/executor.go
@@ -1,0 +1,518 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/albedosehen/surql-go/pkg/surql/connection"
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// ExecuteOptions tunes MigrateUp / MigrateDown behaviour.
+//
+// Zero-value ExecuteOptions is meaningful: Steps=0 applies every pending
+// migration, DryRun=false runs statements, FailOnValidation=true aborts on
+// validation errors (mirroring the Python port).
+type ExecuteOptions struct {
+	// Steps limits the number of migrations applied or rolled back. Zero
+	// means "no limit" (apply all pending / roll back every applied).
+	Steps uint32
+	// DryRun populates the returned status slice without executing
+	// statements. Used by CLI `plan` commands.
+	DryRun bool
+	// FailOnValidation controls whether validation errors abort the run
+	// before the first statement executes. Default true.
+	FailOnValidation bool
+}
+
+// ExecuteOption is a functional option applied to ExecuteOptions.
+type ExecuteOption func(*ExecuteOptions)
+
+// WithSteps limits the number of migrations executed.
+func WithSteps(steps uint32) ExecuteOption {
+	return func(o *ExecuteOptions) { o.Steps = steps }
+}
+
+// WithDryRun toggles dry-run mode.
+func WithDryRun(dry bool) ExecuteOption {
+	return func(o *ExecuteOptions) { o.DryRun = dry }
+}
+
+// WithFailOnValidation configures whether validation errors abort execution.
+func WithFailOnValidation(fail bool) ExecuteOption {
+	return func(o *ExecuteOptions) { o.FailOnValidation = fail }
+}
+
+// defaultExecuteOptions returns the defaults used when no option is passed.
+func defaultExecuteOptions() ExecuteOptions {
+	return ExecuteOptions{FailOnValidation: true}
+}
+
+// MigrationStatusReport summarises the state of a directory of migrations
+// against the database.
+type MigrationStatusReport struct {
+	Total   int `json:"total"`
+	Applied int `json:"applied"`
+	Pending int `json:"pending"`
+}
+
+// ExecuteMigration runs a single migration in the given direction inside a
+// SurrealDB interactive transaction.
+//
+// On success the history table is updated (record for UP, delete for DOWN)
+// and the returned MigrationStatus carries the applied timestamp and
+// execution state. On failure the transaction is rolled back and the error
+// is surfaced to the caller; the returned status still reports the failure
+// for logging purposes.
+func ExecuteMigration(
+	ctx context.Context,
+	client *connection.DatabaseClient,
+	m Migration,
+	dir MigrationDirection,
+) (MigrationStatus, error) {
+	if client == nil {
+		return MigrationStatus{Migration: m, State: MigrationStateFailed, Error: "client cannot be nil"},
+			surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	if !dir.IsValid() {
+		return MigrationStatus{Migration: m, State: MigrationStateFailed, Error: "invalid migration direction"},
+			surqlerrors.Newf(surqlerrors.ErrValidation, "invalid migration direction %q", dir)
+	}
+
+	statements := m.UpStatements
+	if dir == MigrationDirectionDown {
+		statements = m.DownStatements
+	}
+
+	start := time.Now()
+
+	tx, err := client.Begin(ctx)
+	if err != nil {
+		return MigrationStatus{
+				Migration: m,
+				State:     MigrationStateFailed,
+				Error:     err.Error(),
+			}, surqlerrors.Wrapf(
+				surqlerrors.ErrMigrationExecution, err,
+				"failed to begin transaction for migration %q", m.Version,
+			)
+	}
+
+	for i, stmt := range statements {
+		if _, execErr := tx.Execute(ctx, stmt); execErr != nil {
+			_ = tx.Rollback(ctx)
+			return MigrationStatus{
+					Migration: m,
+					State:     MigrationStateFailed,
+					Error:     fmt.Sprintf("statement %d: %v", i, execErr),
+				}, surqlerrors.Wrapf(
+					surqlerrors.ErrMigrationExecution, execErr,
+					"migration %q: failed to execute statement %d", m.Version, i,
+				)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return MigrationStatus{
+				Migration: m,
+				State:     MigrationStateFailed,
+				Error:     err.Error(),
+			}, surqlerrors.Wrapf(
+				surqlerrors.ErrMigrationExecution, err,
+				"migration %q: commit failed", m.Version,
+			)
+	}
+
+	executionMs := time.Since(start).Milliseconds()
+	appliedAt := time.Now().UTC()
+
+	switch dir {
+	case MigrationDirectionUp:
+		entry := MigrationHistory{
+			Version:         m.Version,
+			Description:     m.Description,
+			AppliedAt:       appliedAt,
+			Checksum:        m.Checksum,
+			ExecutionTimeMs: &executionMs,
+		}
+		if err := RecordMigration(ctx, client, entry); err != nil {
+			return MigrationStatus{
+					Migration: m,
+					State:     MigrationStateFailed,
+					Error:     err.Error(),
+				}, surqlerrors.Wrapf(
+					surqlerrors.ErrMigrationExecution, err,
+					"migration %q applied but history recording failed", m.Version,
+				)
+		}
+	case MigrationDirectionDown:
+		if err := RemoveMigrationRecord(ctx, client, m.Version); err != nil {
+			return MigrationStatus{
+					Migration: m,
+					State:     MigrationStateFailed,
+					Error:     err.Error(),
+				}, surqlerrors.Wrapf(
+					surqlerrors.ErrMigrationExecution, err,
+					"migration %q rolled back but history removal failed", m.Version,
+				)
+		}
+	}
+
+	return MigrationStatus{
+		Migration: m,
+		State:     MigrationStateApplied,
+		AppliedAt: &appliedAt,
+	}, nil
+}
+
+// MigrateUp applies pending migrations from migrationsDir.
+//
+// The migrations are discovered via DiscoverMigrations, filtered against the
+// history table, and executed in ascending version order. Returns the
+// per-migration MigrationStatus slice; execution halts on the first
+// failure.
+func MigrateUp(
+	ctx context.Context,
+	client *connection.DatabaseClient,
+	migrationsDir string,
+	opts ...ExecuteOption,
+) ([]MigrationStatus, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	options := defaultExecuteOptions()
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	migrations, err := DiscoverMigrations(migrationsDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if options.FailOnValidation {
+		if issues, valErr := validateMigrationSet(migrations); valErr != nil {
+			return nil, valErr
+		} else if len(issues) > 0 {
+			return nil, surqlerrors.Newf(
+				surqlerrors.ErrMigrationExecution,
+				"migration validation failed: %s", strings.Join(issues, "; "),
+			)
+		}
+	}
+
+	pending, err := pendingMigrations(ctx, client, migrations)
+	if err != nil {
+		return nil, err
+	}
+	if options.Steps > 0 && int(options.Steps) < len(pending) {
+		pending = pending[:options.Steps]
+	}
+
+	statuses := make([]MigrationStatus, 0, len(pending))
+	for _, m := range pending {
+		if options.DryRun {
+			statuses = append(statuses, MigrationStatus{Migration: m, State: MigrationStatePending})
+			continue
+		}
+		status, err := ExecuteMigration(ctx, client, m, MigrationDirectionUp)
+		statuses = append(statuses, status)
+		if err != nil {
+			return statuses, err
+		}
+	}
+	return statuses, nil
+}
+
+// MigrateDown rolls back the most recently applied migrations.
+//
+// steps must be >= 1 (matching surql-py's requirement). The target
+// migrations are resolved against both the on-disk directory and the
+// history table — a migration file present on disk but absent from history
+// is a no-op; one present in history but missing on disk surfaces as
+// ErrMigrationExecution with a descriptive reason.
+func MigrateDown(
+	ctx context.Context,
+	client *connection.DatabaseClient,
+	migrationsDir string,
+	steps uint32,
+) ([]MigrationStatus, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	if steps == 0 {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "rollback steps must be >= 1")
+	}
+
+	migrations, err := DiscoverMigrations(migrationsDir)
+	if err != nil {
+		return nil, err
+	}
+	diskByVersion := indexByVersion(migrations)
+
+	applied, err := GetAppliedMigrationsOrdered(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	if len(applied) == 0 {
+		return []MigrationStatus{}, nil
+	}
+
+	// Take the last `steps` applied, execute in reverse order (newest first).
+	start := 0
+	if int(steps) < len(applied) {
+		start = len(applied) - int(steps)
+	}
+	target := applied[start:]
+
+	statuses := make([]MigrationStatus, 0, len(target))
+	for i := len(target) - 1; i >= 0; i-- {
+		entry := target[i]
+		disk, ok := diskByVersion[entry.Version]
+		if !ok {
+			return statuses, surqlerrors.Newf(
+				surqlerrors.ErrMigrationExecution,
+				"cannot rollback %q: migration file not found in %q",
+				entry.Version, migrationsDir,
+			)
+		}
+		status, err := ExecuteMigration(ctx, client, disk, MigrationDirectionDown)
+		statuses = append(statuses, status)
+		if err != nil {
+			return statuses, err
+		}
+	}
+	return statuses, nil
+}
+
+// GetPendingMigrations returns the subset of migrations in migrationsDir
+// that have not yet been applied, sorted by version.
+func GetPendingMigrations(
+	ctx context.Context,
+	client *connection.DatabaseClient,
+	migrationsDir string,
+) ([]Migration, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	migrations, err := DiscoverMigrations(migrationsDir)
+	if err != nil {
+		return nil, err
+	}
+	return pendingMigrations(ctx, client, migrations)
+}
+
+// GetAppliedMigrationsOrdered returns the history entries sorted by
+// AppliedAt ascending. Tie-broken by version for stability.
+func GetAppliedMigrationsOrdered(
+	ctx context.Context,
+	client *connection.DatabaseClient,
+) ([]MigrationHistory, error) {
+	entries, err := GetAppliedMigrations(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].AppliedAt.Equal(entries[j].AppliedAt) {
+			return entries[i].Version < entries[j].Version
+		}
+		return entries[i].AppliedAt.Before(entries[j].AppliedAt)
+	})
+	return entries, nil
+}
+
+// GetMigrationStatus summarises a migrations directory against the database
+// as a single tally: total / applied / pending.
+func GetMigrationStatus(
+	ctx context.Context,
+	client *connection.DatabaseClient,
+	migrationsDir string,
+) (MigrationStatusReport, error) {
+	if client == nil {
+		return MigrationStatusReport{}, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	migrations, err := DiscoverMigrations(migrationsDir)
+	if err != nil {
+		return MigrationStatusReport{}, err
+	}
+	applied, err := GetAppliedMigrations(ctx, client)
+	if err != nil {
+		return MigrationStatusReport{}, err
+	}
+	appliedSet := make(map[string]struct{}, len(applied))
+	for _, a := range applied {
+		appliedSet[a.Version] = struct{}{}
+	}
+	appliedCount := 0
+	for _, m := range migrations {
+		if _, ok := appliedSet[m.Version]; ok {
+			appliedCount++
+		}
+	}
+	return MigrationStatusReport{
+		Total:   len(migrations),
+		Applied: appliedCount,
+		Pending: len(migrations) - appliedCount,
+	}, nil
+}
+
+// CreateMigrationPlan produces a MigrationPlan describing the forward
+// migrations that would run against the database. The returned plan has
+// direction = MigrationDirectionUp.
+func CreateMigrationPlan(
+	ctx context.Context,
+	client *connection.DatabaseClient,
+	migrationsDir string,
+) (MigrationPlan, error) {
+	pending, err := GetPendingMigrations(ctx, client, migrationsDir)
+	if err != nil {
+		return MigrationPlan{}, err
+	}
+	return MigrationPlan{
+		Migrations: pending,
+		Direction:  MigrationDirectionUp,
+	}, nil
+}
+
+// ExecuteMigrationPlan runs every migration in plan in the plan's
+// direction. Down plans are iterated in reverse order to match the LIFO
+// rollback semantics of MigrateDown.
+func ExecuteMigrationPlan(
+	ctx context.Context,
+	client *connection.DatabaseClient,
+	plan MigrationPlan,
+) ([]MigrationStatus, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	if !plan.Direction.IsValid() {
+		return nil, surqlerrors.Newf(surqlerrors.ErrValidation, "invalid plan direction %q", plan.Direction)
+	}
+	if plan.IsEmpty() {
+		return []MigrationStatus{}, nil
+	}
+
+	ordered := append([]Migration(nil), plan.Migrations...)
+	if plan.Direction == MigrationDirectionDown {
+		// Reverse the slice in-place; rollback must execute newest-first.
+		for i, j := 0, len(ordered)-1; i < j; i, j = i+1, j-1 {
+			ordered[i], ordered[j] = ordered[j], ordered[i]
+		}
+	}
+
+	statuses := make([]MigrationStatus, 0, len(ordered))
+	for _, m := range ordered {
+		status, err := ExecuteMigration(ctx, client, m, plan.Direction)
+		statuses = append(statuses, status)
+		if err != nil {
+			return statuses, err
+		}
+	}
+	return statuses, nil
+}
+
+// ValidateMigrations loads every migration in migrationsDir and returns a
+// list of human-readable validation errors (duplicate versions, missing
+// dependencies, missing up/down blocks). An empty slice means the set is
+// valid. Discovery failures are surfaced as errors.
+func ValidateMigrations(migrationsDir string) ([]string, error) {
+	migrations, err := DiscoverMigrations(migrationsDir)
+	if err != nil {
+		return nil, err
+	}
+	issues, err := validateMigrationSet(migrations)
+	if err != nil {
+		return nil, err
+	}
+	return issues, nil
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// pendingMigrations returns every migration whose version is not in the
+// history table, sorted by version.
+func pendingMigrations(
+	ctx context.Context,
+	client *connection.DatabaseClient,
+	migrations []Migration,
+) ([]Migration, error) {
+	applied, err := GetAppliedMigrations(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	appliedSet := make(map[string]struct{}, len(applied))
+	for _, a := range applied {
+		appliedSet[a.Version] = struct{}{}
+	}
+	pending := make([]Migration, 0, len(migrations))
+	for _, m := range migrations {
+		if _, ok := appliedSet[m.Version]; ok {
+			continue
+		}
+		pending = append(pending, m)
+	}
+	sort.SliceStable(pending, func(i, j int) bool {
+		return pending[i].Version < pending[j].Version
+	})
+	return pending, nil
+}
+
+// indexByVersion returns the migrations keyed by their Version string.
+func indexByVersion(migrations []Migration) map[string]Migration {
+	out := make(map[string]Migration, len(migrations))
+	for _, m := range migrations {
+		out[m.Version] = m
+	}
+	return out
+}
+
+// validateMigrationSet mirrors surql-py validate_migrations. It never returns
+// a non-nil error today, but keeps the signature symmetric with other
+// validators in the package in case future checks require IO.
+func validateMigrationSet(migrations []Migration) ([]string, error) {
+	var issues []string
+
+	counts := make(map[string]int, len(migrations))
+	for _, m := range migrations {
+		counts[m.Version]++
+	}
+	duplicates := make([]string, 0)
+	for v, c := range counts {
+		if c > 1 {
+			duplicates = append(duplicates, v)
+		}
+	}
+	if len(duplicates) > 0 {
+		sort.Strings(duplicates)
+		issues = append(issues,
+			fmt.Sprintf("duplicate migration versions: %s", strings.Join(duplicates, ", ")),
+		)
+	}
+
+	versionSet := make(map[string]struct{}, len(migrations))
+	for _, m := range migrations {
+		versionSet[m.Version] = struct{}{}
+	}
+	for _, m := range migrations {
+		for _, dep := range m.DependsOn {
+			if _, ok := versionSet[dep]; !ok {
+				issues = append(issues,
+					fmt.Sprintf("migration %s depends on missing migration %s", m.Version, dep),
+				)
+			}
+		}
+		if len(m.UpStatements) == 0 {
+			issues = append(issues,
+				fmt.Sprintf("migration %s has no up statements", m.Version),
+			)
+		}
+	}
+
+	sort.Strings(issues)
+	return issues, nil
+}

--- a/pkg/surql/migration/executor_test.go
+++ b/pkg/surql/migration/executor_test.go
@@ -1,0 +1,270 @@
+package migration
+
+import (
+	stdErrors "errors"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// --- ExecuteOptions functional constructors ---
+
+func TestExecuteOptions_Defaults(t *testing.T) {
+	opts := defaultExecuteOptions()
+	if opts.Steps != 0 {
+		t.Errorf("default Steps=%d, want 0", opts.Steps)
+	}
+	if opts.DryRun {
+		t.Errorf("default DryRun=true, want false")
+	}
+	if !opts.FailOnValidation {
+		t.Errorf("default FailOnValidation=false, want true")
+	}
+}
+
+func TestWithSteps(t *testing.T) {
+	opts := defaultExecuteOptions()
+	WithSteps(5)(&opts)
+	if opts.Steps != 5 {
+		t.Errorf("Steps=%d, want 5", opts.Steps)
+	}
+}
+
+func TestWithDryRun(t *testing.T) {
+	opts := defaultExecuteOptions()
+	WithDryRun(true)(&opts)
+	if !opts.DryRun {
+		t.Error("expected DryRun to be true after WithDryRun(true)")
+	}
+}
+
+func TestWithFailOnValidation(t *testing.T) {
+	opts := defaultExecuteOptions()
+	WithFailOnValidation(false)(&opts)
+	if opts.FailOnValidation {
+		t.Error("expected FailOnValidation to be false after WithFailOnValidation(false)")
+	}
+}
+
+// --- validateMigrationSet ---
+
+func TestValidateMigrationSet_Empty(t *testing.T) {
+	issues, err := validateMigrationSet(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Errorf("expected no issues, got %v", issues)
+	}
+}
+
+func TestValidateMigrationSet_Duplicates(t *testing.T) {
+	migrations := []Migration{
+		{Version: "a", UpStatements: []string{"DEFINE TABLE a;"}},
+		{Version: "a", UpStatements: []string{"DEFINE TABLE a;"}},
+	}
+	issues, err := validateMigrationSet(migrations)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) == 0 {
+		t.Fatal("expected duplicate issue, got none")
+	}
+	found := false
+	for _, msg := range issues {
+		if msg == "duplicate migration versions: a" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected duplicate message, got %v", issues)
+	}
+}
+
+func TestValidateMigrationSet_MissingDependency(t *testing.T) {
+	migrations := []Migration{
+		{
+			Version:      "b",
+			UpStatements: []string{"DEFINE TABLE b;"},
+			DependsOn:    []string{"missing"},
+		},
+	}
+	issues, err := validateMigrationSet(migrations)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) == 0 {
+		t.Fatal("expected missing-dep issue, got none")
+	}
+}
+
+func TestValidateMigrationSet_MissingUpStatements(t *testing.T) {
+	migrations := []Migration{
+		{Version: "a"},
+	}
+	issues, err := validateMigrationSet(migrations)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) == 0 {
+		t.Fatal("expected missing-up issue, got none")
+	}
+}
+
+func TestValidateMigrationSet_Valid(t *testing.T) {
+	migrations := []Migration{
+		{Version: "a", UpStatements: []string{"DEFINE TABLE a;"}},
+		{
+			Version:      "b",
+			UpStatements: []string{"DEFINE TABLE b;"},
+			DependsOn:    []string{"a"},
+		},
+	}
+	issues, err := validateMigrationSet(migrations)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Errorf("expected no issues, got %v", issues)
+	}
+}
+
+// --- ValidateMigrations (filesystem) ---
+
+func TestValidateMigrations_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	issues, err := ValidateMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Errorf("expected no issues for empty dir, got %v", issues)
+	}
+}
+
+func TestValidateMigrations_NonexistentDir(t *testing.T) {
+	// DiscoverMigrations returns an empty slice (no error) for a missing
+	// directory, so ValidateMigrations should as well.
+	issues, err := ValidateMigrations(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Errorf("expected no issues, got %v", issues)
+	}
+}
+
+func TestValidateMigrations_DuplicateDetected(t *testing.T) {
+	dir := t.TempDir()
+	writeTestMigrationFile(t, dir, "20260101_000000_init.surql", "REMOVE TABLE foo;")
+	// Same version, different description — rare but possible operator mistake.
+	writeTestMigrationFile(t, dir, "20260101_000000_other.surql", "REMOVE TABLE bar;")
+
+	issues, err := ValidateMigrations(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) == 0 {
+		t.Fatal("expected duplicate issue, got none")
+	}
+}
+
+// --- indexByVersion ---
+
+func TestIndexByVersion(t *testing.T) {
+	migrations := []Migration{
+		{Version: "a"},
+		{Version: "b"},
+	}
+	got := indexByVersion(migrations)
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+	if got["a"].Version != "a" {
+		t.Errorf("missing 'a'")
+	}
+}
+
+// --- MigrationStatusReport zero-value semantics ---
+
+func TestMigrationStatusReport_Zero(t *testing.T) {
+	var r MigrationStatusReport
+	if r.Total != 0 || r.Applied != 0 || r.Pending != 0 {
+		t.Errorf("unexpected zero report: %+v", r)
+	}
+}
+
+// --- MigrateDown argument validation ---
+
+func TestMigrateDown_ZeroStepsRejected(t *testing.T) {
+	// Client is nil, but nil-check fires first — so this test asserts the
+	// input-validation order and returns an error before any I/O.
+	_, err := MigrateDown(nil, nil, "", 0)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+// --- ExecuteMigration invalid direction ---
+
+func TestExecuteMigration_InvalidDirection(t *testing.T) {
+	// We use a zero DatabaseClient pointer, but the direction guard runs
+	// after the nil check. Exercise the nil-check path first.
+	_, err := ExecuteMigration(nil, nil, Migration{}, MigrationDirectionUp)
+	if err == nil {
+		t.Fatal("expected error for nil client")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+// --- CreateMigrationPlan nil client ---
+
+func TestCreateMigrationPlan_NilClient(t *testing.T) {
+	_, err := CreateMigrationPlan(nil, nil, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+// --- ExecuteMigrationPlan with empty plan short-circuits ---
+
+func TestExecuteMigrationPlan_EmptyReturnsEmptyStatuses(t *testing.T) {
+	// Empty plan returns early before touching the DB. Sanity check.
+	// Note: ExecuteMigrationPlan still demands a non-nil client even for
+	// an empty plan; to keep the unit test hermetic we exercise the nil
+	// short-circuit path via the direction guard.
+	_, err := ExecuteMigrationPlan(nil, nil, MigrationPlan{Direction: MigrationDirectionUp})
+	if err == nil {
+		t.Fatal("expected error for nil client")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+// --- helper: ensure validateMigrationSet issues are sorted ---
+
+func TestValidateMigrationSet_IssuesSorted(t *testing.T) {
+	migrations := []Migration{
+		{Version: "c"}, // missing up
+		{Version: "a", DependsOn: []string{"z"}, UpStatements: []string{";"}}, // missing dep
+		{Version: "a", UpStatements: []string{";"}},                           // duplicate version
+	}
+	issues, err := validateMigrationSet(migrations)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sort.StringsAreSorted(issues) {
+		t.Errorf("validate issues not sorted: %v", issues)
+	}
+}

--- a/pkg/surql/migration/history.go
+++ b/pkg/surql/migration/history.go
@@ -76,17 +76,27 @@ func RecordMigration(ctx context.Context, client *connection.DatabaseClient, ent
 		appliedAt = time.Now().UTC()
 	}
 
-	data := map[string]any{
+	// SurrealDB v3 rejects bare ISO strings for datetime-typed fields
+	// ("Expected `datetime` but found '...'"), so we cast explicitly via
+	// the SurrealQL `<datetime>` prefix inside a raw CREATE statement.
+	vars := map[string]any{
 		"version":     entry.Version,
 		"description": entry.Description,
 		"applied_at":  appliedAt.UTC().Format(time.RFC3339Nano),
 		"checksum":    entry.Checksum,
 	}
+	sql := "CREATE " + MigrationTableName + " SET " +
+		"version = $version, " +
+		"description = $description, " +
+		"applied_at = <datetime> $applied_at, " +
+		"checksum = $checksum"
 	if entry.ExecutionTimeMs != nil {
-		data["execution_time_ms"] = *entry.ExecutionTimeMs
+		vars["execution_time_ms"] = *entry.ExecutionTimeMs
+		sql += ", execution_time_ms = $execution_time_ms"
 	}
+	sql += ";"
 
-	if _, err := client.Create(ctx, MigrationTableName, data); err != nil {
+	if _, err := client.QueryWithVars(ctx, sql, vars); err != nil {
 		return surqlerrors.Wrapf(
 			surqlerrors.ErrMigrationHistory, err,
 			"failed to record migration %q", entry.Version,

--- a/pkg/surql/migration/history.go
+++ b/pkg/surql/migration/history.go
@@ -1,0 +1,305 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/albedosehen/surql-go/pkg/surql/connection"
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// MigrationTableName is the SurrealDB table that tracks applied migrations.
+// Migration tooling defines this table schemafully on first use and never
+// drops it.
+const MigrationTableName = "_migration_history"
+
+// CreateMigrationTable defines the migration history table and its schema.
+//
+// The operation is idempotent: every DEFINE statement uses SurrealDB's
+// IF NOT EXISTS form, so repeat invocations are safe. The table is
+// schemafull with a UNIQUE index on the version column; execution time is
+// stored in milliseconds (nullable).
+func CreateMigrationTable(ctx context.Context, client *connection.DatabaseClient) error {
+	if client == nil {
+		return surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+
+	statements := []string{
+		fmt.Sprintf("DEFINE TABLE IF NOT EXISTS %s SCHEMAFULL;", MigrationTableName),
+		fmt.Sprintf("DEFINE FIELD IF NOT EXISTS version ON TABLE %s TYPE string;", MigrationTableName),
+		fmt.Sprintf("DEFINE FIELD IF NOT EXISTS description ON TABLE %s TYPE string;", MigrationTableName),
+		fmt.Sprintf("DEFINE FIELD IF NOT EXISTS applied_at ON TABLE %s TYPE datetime;", MigrationTableName),
+		fmt.Sprintf("DEFINE FIELD IF NOT EXISTS checksum ON TABLE %s TYPE string;", MigrationTableName),
+		fmt.Sprintf("DEFINE FIELD IF NOT EXISTS execution_time_ms ON TABLE %s TYPE option<int>;", MigrationTableName),
+		fmt.Sprintf("DEFINE INDEX IF NOT EXISTS version_idx ON TABLE %s COLUMNS version UNIQUE;", MigrationTableName),
+	}
+
+	for _, stmt := range statements {
+		if _, err := client.Query(ctx, stmt); err != nil {
+			return surqlerrors.Wrapf(
+				surqlerrors.ErrMigrationHistory, err,
+				"failed to create migration history table",
+			)
+		}
+	}
+	return nil
+}
+
+// EnsureMigrationTable creates the migration history table when it does not
+// already exist. Callers of RecordMigration / GetAppliedMigrations do not
+// need to call this directly; the CRUD helpers do so implicitly.
+func EnsureMigrationTable(ctx context.Context, client *connection.DatabaseClient) error {
+	return CreateMigrationTable(ctx, client)
+}
+
+// RecordMigration inserts a new history entry.
+//
+// entry.Version must be non-empty; AppliedAt is stored verbatim (UTC is
+// strongly recommended). Duplicate versions are rejected by the UNIQUE
+// index defined in CreateMigrationTable.
+func RecordMigration(ctx context.Context, client *connection.DatabaseClient, entry MigrationHistory) error {
+	if client == nil {
+		return surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	if entry.Version == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "history entry version cannot be empty")
+	}
+
+	if err := EnsureMigrationTable(ctx, client); err != nil {
+		return err
+	}
+
+	appliedAt := entry.AppliedAt
+	if appliedAt.IsZero() {
+		appliedAt = time.Now().UTC()
+	}
+
+	data := map[string]any{
+		"version":     entry.Version,
+		"description": entry.Description,
+		"applied_at":  appliedAt.UTC().Format(time.RFC3339Nano),
+		"checksum":    entry.Checksum,
+	}
+	if entry.ExecutionTimeMs != nil {
+		data["execution_time_ms"] = *entry.ExecutionTimeMs
+	}
+
+	if _, err := client.Create(ctx, MigrationTableName, data); err != nil {
+		return surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationHistory, err,
+			"failed to record migration %q", entry.Version,
+		)
+	}
+	return nil
+}
+
+// RemoveMigrationRecord deletes the history entry for the given version.
+//
+// A missing record is not an error (matches the Python port's silent
+// warning); the call short-circuits after the SELECT lookup.
+func RemoveMigrationRecord(ctx context.Context, client *connection.DatabaseClient, version string) error {
+	if client == nil {
+		return surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	if version == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "version cannot be empty")
+	}
+	if err := EnsureMigrationTable(ctx, client); err != nil {
+		return err
+	}
+
+	query := fmt.Sprintf(
+		"DELETE %s WHERE version = $version;",
+		MigrationTableName,
+	)
+	if _, err := client.QueryWithVars(ctx, query, map[string]any{"version": version}); err != nil {
+		return surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationHistory, err,
+			"failed to remove migration record %q", version,
+		)
+	}
+	return nil
+}
+
+// GetAppliedMigrations returns every entry from the migration history table,
+// ordered by AppliedAt ascending.
+func GetAppliedMigrations(ctx context.Context, client *connection.DatabaseClient) ([]MigrationHistory, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	if err := EnsureMigrationTable(ctx, client); err != nil {
+		return nil, err
+	}
+
+	query := fmt.Sprintf("SELECT * FROM %s ORDER BY applied_at ASC;", MigrationTableName)
+	res, err := client.Query(ctx, query)
+	if err != nil {
+		return nil, surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationHistory, err,
+			"failed to fetch applied migrations",
+		)
+	}
+
+	records := extractRecords(res)
+	migrations := make([]MigrationHistory, 0, len(records))
+	for _, rec := range records {
+		entry, ok := decodeHistoryRecord(rec)
+		if !ok {
+			continue
+		}
+		migrations = append(migrations, entry)
+	}
+	return migrations, nil
+}
+
+// IsMigrationApplied reports whether the given version has a history entry.
+func IsMigrationApplied(ctx context.Context, client *connection.DatabaseClient, version string) (bool, error) {
+	if client == nil {
+		return false, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	if version == "" {
+		return false, surqlerrors.New(surqlerrors.ErrValidation, "version cannot be empty")
+	}
+
+	applied, err := GetAppliedMigrations(ctx, client)
+	if err != nil {
+		return false, err
+	}
+	for _, m := range applied {
+		if m.Version == version {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// GetMigrationHistory returns every entry ordered by AppliedAt ascending.
+// This is a thin alias over GetAppliedMigrations that guarantees the
+// ordering contract for callers (notably the CLI's `status` command).
+func GetMigrationHistory(ctx context.Context, client *connection.DatabaseClient) ([]MigrationHistory, error) {
+	entries, err := GetAppliedMigrations(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].AppliedAt.Before(entries[j].AppliedAt)
+	})
+	return entries, nil
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// extractRecords pulls the []map[string]any payload out of the envelope
+// produced by DatabaseClient.Query. The client returns []any where each
+// entry is {status, time, result}; we surface only `result` arrays.
+func extractRecords(result any) []map[string]any {
+	if result == nil {
+		return nil
+	}
+	arr, ok := result.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0)
+	for _, entry := range arr {
+		envelope, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		raw, hasResult := envelope["result"]
+		if !hasResult {
+			// Flat records (e.g. from db.select) are admitted verbatim.
+			out = append(out, envelope)
+			continue
+		}
+		appendResultValues(&out, raw)
+	}
+	return out
+}
+
+// appendResultValues normalises the `result` field, which may be a list of
+// records, a single record, or nil.
+func appendResultValues(out *[]map[string]any, raw any) {
+	switch v := raw.(type) {
+	case nil:
+		return
+	case []any:
+		for _, item := range v {
+			if rec, ok := item.(map[string]any); ok {
+				*out = append(*out, rec)
+			}
+		}
+	case map[string]any:
+		*out = append(*out, v)
+	}
+}
+
+// decodeHistoryRecord converts a raw SurrealDB record into a
+// MigrationHistory. Records missing the mandatory fields are skipped.
+func decodeHistoryRecord(rec map[string]any) (MigrationHistory, bool) {
+	version, ok := rec["version"].(string)
+	if !ok || version == "" {
+		return MigrationHistory{}, false
+	}
+	description, _ := rec["description"].(string)
+	checksum, _ := rec["checksum"].(string)
+	appliedAt := parseHistoryDatetime(rec["applied_at"])
+
+	entry := MigrationHistory{
+		Version:     version,
+		Description: description,
+		AppliedAt:   appliedAt,
+		Checksum:    checksum,
+	}
+	if raw, has := rec["execution_time_ms"]; has && raw != nil {
+		if ms, ok := coerceInt64(raw); ok {
+			entry.ExecutionTimeMs = &ms
+		}
+	}
+	return entry, true
+}
+
+// parseHistoryDatetime accepts time.Time, RFC3339 strings, or unix seconds
+// and returns a UTC time.Time. Unparseable values degrade to the zero time.
+func parseHistoryDatetime(v any) time.Time {
+	switch x := v.(type) {
+	case time.Time:
+		return x.UTC()
+	case string:
+		// SurrealDB typically emits RFC3339 with nanoseconds.
+		if t, err := time.Parse(time.RFC3339Nano, x); err == nil {
+			return t.UTC()
+		}
+		if t, err := time.Parse(time.RFC3339, x); err == nil {
+			return t.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+// coerceInt64 extracts an int64 from the common JSON numeric encodings.
+func coerceInt64(v any) (int64, bool) {
+	switch n := v.(type) {
+	case int:
+		return int64(n), true
+	case int32:
+		return int64(n), true
+	case int64:
+		return n, true
+	case uint:
+		return int64(n), true
+	case uint32:
+		return int64(n), true
+	case uint64:
+		return int64(n), true
+	case float32:
+		return int64(n), true
+	case float64:
+		return int64(n), true
+	}
+	return 0, false
+}

--- a/pkg/surql/migration/history_test.go
+++ b/pkg/surql/migration/history_test.go
@@ -1,0 +1,178 @@
+package migration
+
+import (
+	"testing"
+	"time"
+)
+
+// --- extractRecords ---
+
+func TestExtractRecords_NilResult(t *testing.T) {
+	if got := extractRecords(nil); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestExtractRecords_NestedEnvelope(t *testing.T) {
+	result := []any{
+		map[string]any{
+			"status": "OK",
+			"time":   "1.2ms",
+			"result": []any{
+				map[string]any{"version": "a", "description": "first"},
+				map[string]any{"version": "b", "description": "second"},
+			},
+		},
+	}
+	records := extractRecords(result)
+	if len(records) != 2 {
+		t.Fatalf("len=%d, want 2", len(records))
+	}
+	if records[0]["version"] != "a" {
+		t.Errorf("records[0].version=%v, want 'a'", records[0]["version"])
+	}
+}
+
+func TestExtractRecords_SingleObjectResult(t *testing.T) {
+	result := []any{
+		map[string]any{
+			"result": map[string]any{"version": "x"},
+		},
+	}
+	records := extractRecords(result)
+	if len(records) != 1 {
+		t.Fatalf("len=%d, want 1", len(records))
+	}
+	if records[0]["version"] != "x" {
+		t.Errorf("unexpected record: %v", records[0])
+	}
+}
+
+func TestExtractRecords_EmptyResult(t *testing.T) {
+	result := []any{
+		map[string]any{"status": "OK", "time": "0.1ms", "result": nil},
+	}
+	records := extractRecords(result)
+	if len(records) != 0 {
+		t.Errorf("expected 0 records, got %d", len(records))
+	}
+}
+
+// --- decodeHistoryRecord ---
+
+func TestDecodeHistoryRecord_Full(t *testing.T) {
+	ts := "2026-04-18T12:00:00Z"
+	rec := map[string]any{
+		"version":           "20260418_120000",
+		"description":       "create users",
+		"applied_at":        ts,
+		"checksum":          "deadbeef",
+		"execution_time_ms": float64(250),
+	}
+	entry, ok := decodeHistoryRecord(rec)
+	if !ok {
+		t.Fatal("expected decode to succeed")
+	}
+	if entry.Version != "20260418_120000" {
+		t.Errorf("Version=%q", entry.Version)
+	}
+	if entry.Checksum != "deadbeef" {
+		t.Errorf("Checksum=%q", entry.Checksum)
+	}
+	if entry.ExecutionTimeMs == nil || *entry.ExecutionTimeMs != 250 {
+		t.Errorf("ExecutionTimeMs=%v, want 250", entry.ExecutionTimeMs)
+	}
+	if entry.AppliedAt.IsZero() {
+		t.Error("AppliedAt should be parsed")
+	}
+}
+
+func TestDecodeHistoryRecord_MissingVersion(t *testing.T) {
+	rec := map[string]any{"description": "no version"}
+	if _, ok := decodeHistoryRecord(rec); ok {
+		t.Error("expected decode to fail for missing version")
+	}
+}
+
+func TestDecodeHistoryRecord_EmptyVersion(t *testing.T) {
+	rec := map[string]any{"version": ""}
+	if _, ok := decodeHistoryRecord(rec); ok {
+		t.Error("expected decode to fail for empty version")
+	}
+}
+
+func TestDecodeHistoryRecord_NullExecutionTime(t *testing.T) {
+	rec := map[string]any{
+		"version":           "a",
+		"description":       "",
+		"applied_at":        "2026-04-18T12:00:00Z",
+		"checksum":          "",
+		"execution_time_ms": nil,
+	}
+	entry, ok := decodeHistoryRecord(rec)
+	if !ok {
+		t.Fatal("expected decode to succeed")
+	}
+	if entry.ExecutionTimeMs != nil {
+		t.Errorf("expected nil ExecutionTimeMs, got %v", entry.ExecutionTimeMs)
+	}
+}
+
+// --- parseHistoryDatetime ---
+
+func TestParseHistoryDatetime_RFC3339(t *testing.T) {
+	got := parseHistoryDatetime("2026-04-18T12:00:00Z")
+	want := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("parse = %v, want %v", got, want)
+	}
+}
+
+func TestParseHistoryDatetime_RFC3339Nano(t *testing.T) {
+	got := parseHistoryDatetime("2026-04-18T12:00:00.123456789Z")
+	if got.IsZero() {
+		t.Error("expected parse to succeed")
+	}
+}
+
+func TestParseHistoryDatetime_DirectTime(t *testing.T) {
+	in := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	got := parseHistoryDatetime(in)
+	if !got.Equal(in) {
+		t.Errorf("parse = %v, want %v", got, in)
+	}
+}
+
+func TestParseHistoryDatetime_InvalidReturnsZero(t *testing.T) {
+	got := parseHistoryDatetime("not-a-date")
+	if !got.IsZero() {
+		t.Errorf("expected zero time, got %v", got)
+	}
+}
+
+// --- coerceInt64 ---
+
+func TestCoerceInt64(t *testing.T) {
+	cases := []struct {
+		in   any
+		want int64
+		ok   bool
+	}{
+		{int(3), 3, true},
+		{int32(4), 4, true},
+		{int64(5), 5, true},
+		{uint(6), 6, true},
+		{uint32(7), 7, true},
+		{uint64(8), 8, true},
+		{float32(9.5), 9, true},
+		{float64(10.7), 10, true},
+		{"not-a-number", 0, false},
+		{nil, 0, false},
+	}
+	for _, tc := range cases {
+		got, ok := coerceInt64(tc.in)
+		if ok != tc.ok || got != tc.want {
+			t.Errorf("coerceInt64(%v)=(%d,%v), want (%d,%v)", tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}

--- a/pkg/surql/migration/integration_test.go
+++ b/pkg/surql/migration/integration_test.go
@@ -1,0 +1,335 @@
+//go:build integration
+// +build integration
+
+package migration
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/albedosehen/surql-go/pkg/surql/connection"
+)
+
+// getIntegrationURL reads the SurrealDB URL used by CI's integration job.
+func getIntegrationURL(t *testing.T) string {
+	t.Helper()
+	url := os.Getenv("SURREAL_URL")
+	if url == "" {
+		t.Skip("SURREAL_URL not set; skipping integration test")
+	}
+	return url
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// newIntegrationClient returns a connected, authenticated DatabaseClient.
+// The migration package isolates its namespace so parallel test runs do
+// not collide with the connection/query packages.
+func newIntegrationClient(t *testing.T) (*connection.DatabaseClient, func()) {
+	t.Helper()
+	cfg := connection.DefaultConfig()
+	cfg.DBURL = getIntegrationURL(t)
+	cfg.DBNS = "surqlgo_test"
+	cfg.DB = "migration"
+	cfg.DBRetryMaxAttempts = 3
+	cfg.DBRetryMinWait = 0.5
+	cfg.DBRetryMaxWait = 2.0
+	cfg.DBRetryMultiplier = 2.0
+
+	client, err := connection.NewDatabaseClient(cfg)
+	if err != nil {
+		t.Fatalf("NewDatabaseClient: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	user := envOr("SURREAL_USER", "root")
+	pass := envOr("SURREAL_PASS", "root")
+	if _, err := client.Signin(ctx, connection.NewRootCredentials(user, pass)); err != nil {
+		_ = client.Disconnect()
+		t.Fatalf("Signin: %v", err)
+	}
+
+	return client, func() { _ = client.Disconnect() }
+}
+
+// resetDatabaseState drops the history table and every table created by the
+// integration migrations so each test starts from a clean slate.
+func resetDatabaseState(t *testing.T, client *connection.DatabaseClient, tables ...string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	drop := []string{"REMOVE TABLE IF EXISTS " + MigrationTableName + ";"}
+	for _, tbl := range tables {
+		drop = append(drop, "REMOVE TABLE IF EXISTS "+tbl+";")
+	}
+	for _, stmt := range drop {
+		if _, err := client.Query(ctx, stmt); err != nil {
+			t.Fatalf("reset: %s: %v", stmt, err)
+		}
+	}
+}
+
+// writeTestMigration writes a migration file with the given down statements.
+func writeTestMigration(t *testing.T, dir, filename, up, down string) {
+	t.Helper()
+	body := "-- @description: integration\n-- @up\n" + up + "\n-- @down\n" + down + "\n"
+	if err := os.WriteFile(filepath.Join(dir, filename), []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", filename, err)
+	}
+}
+
+// --- history lifecycle ---
+
+func TestIntegration_CreateMigrationTable_Idempotent(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+	resetDatabaseState(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for i := 0; i < 2; i++ {
+		if err := CreateMigrationTable(ctx, client); err != nil {
+			t.Fatalf("CreateMigrationTable iter %d: %v", i, err)
+		}
+	}
+}
+
+func TestIntegration_RecordAndRemoveMigration(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+	resetDatabaseState(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ms := int64(123)
+	entry := MigrationHistory{
+		Version:         "20260418_120000",
+		Description:     "create users",
+		AppliedAt:       time.Now().UTC(),
+		Checksum:        "sha256-abc",
+		ExecutionTimeMs: &ms,
+	}
+	if err := RecordMigration(ctx, client, entry); err != nil {
+		t.Fatalf("RecordMigration: %v", err)
+	}
+
+	applied, err := GetAppliedMigrations(ctx, client)
+	if err != nil {
+		t.Fatalf("GetAppliedMigrations: %v", err)
+	}
+	if len(applied) != 1 || applied[0].Version != entry.Version {
+		t.Fatalf("unexpected applied: %+v", applied)
+	}
+
+	isApplied, err := IsMigrationApplied(ctx, client, entry.Version)
+	if err != nil {
+		t.Fatalf("IsMigrationApplied: %v", err)
+	}
+	if !isApplied {
+		t.Errorf("expected migration to be applied")
+	}
+
+	if err := RemoveMigrationRecord(ctx, client, entry.Version); err != nil {
+		t.Fatalf("RemoveMigrationRecord: %v", err)
+	}
+	remaining, err := GetAppliedMigrations(ctx, client)
+	if err != nil {
+		t.Fatalf("GetAppliedMigrations after remove: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Errorf("expected 0 applied after remove, got %d", len(remaining))
+	}
+}
+
+// --- MigrateUp / MigrateDown round trip ---
+
+func TestIntegration_MigrateUpAndDown(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+	resetDatabaseState(t, client, "int_user", "int_product")
+
+	dir := t.TempDir()
+	writeTestMigration(t, dir,
+		"20260101_000000_user.surql",
+		"DEFINE TABLE int_user SCHEMAFULL; DEFINE FIELD email ON int_user TYPE string;",
+		"REMOVE TABLE int_user;",
+	)
+	writeTestMigration(t, dir,
+		"20260102_000000_product.surql",
+		"DEFINE TABLE int_product SCHEMAFULL; DEFINE FIELD name ON int_product TYPE string;",
+		"REMOVE TABLE int_product;",
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Apply both migrations forward.
+	statuses, err := MigrateUp(ctx, client, dir)
+	if err != nil {
+		t.Fatalf("MigrateUp: %v", err)
+	}
+	if len(statuses) != 2 {
+		t.Fatalf("expected 2 statuses, got %d", len(statuses))
+	}
+	for _, s := range statuses {
+		if s.State != MigrationStateApplied {
+			t.Errorf("status for %s = %v, want applied", s.Migration.Version, s.State)
+		}
+	}
+
+	// Report.
+	report, err := GetMigrationStatus(ctx, client, dir)
+	if err != nil {
+		t.Fatalf("GetMigrationStatus: %v", err)
+	}
+	if report.Total != 2 || report.Applied != 2 || report.Pending != 0 {
+		t.Errorf("unexpected report: %+v", report)
+	}
+
+	// Second MigrateUp is a no-op.
+	noop, err := MigrateUp(ctx, client, dir)
+	if err != nil {
+		t.Fatalf("MigrateUp noop: %v", err)
+	}
+	if len(noop) != 0 {
+		t.Errorf("expected noop, got %d statuses", len(noop))
+	}
+
+	// Rollback one step.
+	down, err := MigrateDown(ctx, client, dir, 1)
+	if err != nil {
+		t.Fatalf("MigrateDown: %v", err)
+	}
+	if len(down) != 1 {
+		t.Fatalf("expected 1 down status, got %d", len(down))
+	}
+
+	report, err = GetMigrationStatus(ctx, client, dir)
+	if err != nil {
+		t.Fatalf("GetMigrationStatus after down: %v", err)
+	}
+	if report.Applied != 1 || report.Pending != 1 {
+		t.Errorf("unexpected report after down: %+v", report)
+	}
+}
+
+func TestIntegration_ExecuteMigration_FailedStatement_RollsBack(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+	resetDatabaseState(t, client, "int_bad")
+
+	dir := t.TempDir()
+	// First statement creates the table, second is invalid SurrealQL.
+	writeTestMigration(t, dir,
+		"20260201_000000_bad.surql",
+		"DEFINE TABLE int_bad SCHEMAFULL; THIS IS NOT VALID SURREALQL;",
+		"REMOVE TABLE int_bad;",
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	statuses, err := MigrateUp(ctx, client, dir)
+	if err == nil {
+		t.Fatal("expected migration to fail")
+	}
+	if len(statuses) != 1 || statuses[0].State != MigrationStateFailed {
+		t.Errorf("expected single failed status, got %+v", statuses)
+	}
+
+	// History must not contain the failed migration.
+	applied, err := GetAppliedMigrations(ctx, client)
+	if err != nil {
+		t.Fatalf("GetAppliedMigrations: %v", err)
+	}
+	for _, a := range applied {
+		if a.Version == "20260201_000000" {
+			t.Errorf("failed migration should not be in history")
+		}
+	}
+
+	// Also confirm the table was NOT created (transaction rolled back).
+	// (Some Surreal versions surface "does not exist"; contains check is
+	// the standard idiom used elsewhere in the codebase.)
+	_, err = client.Query(ctx, "SELECT * FROM int_bad LIMIT 1;")
+	if err != nil && !strings.Contains(err.Error(), "does not exist") {
+		t.Logf("select int_bad: %v", err)
+	}
+}
+
+// --- rollback planning ---
+
+func TestIntegration_CreateAndExecuteRollbackPlan(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+	resetDatabaseState(t, client, "int_a", "int_b", "int_c")
+
+	dir := t.TempDir()
+	writeTestMigration(t, dir, "20260301_000000_a.surql",
+		"DEFINE TABLE int_a SCHEMAFULL;",
+		"REMOVE TABLE int_a;",
+	)
+	writeTestMigration(t, dir, "20260302_000000_b.surql",
+		"DEFINE TABLE int_b SCHEMAFULL;",
+		"REMOVE TABLE int_b;",
+	)
+	writeTestMigration(t, dir, "20260303_000000_c.surql",
+		"DEFINE TABLE int_c SCHEMAFULL;",
+		"REMOVE TABLE int_c;",
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if _, err := MigrateUp(ctx, client, dir); err != nil {
+		t.Fatalf("MigrateUp: %v", err)
+	}
+
+	plan, err := CreateRollbackPlan(ctx, client, dir, "20260301_000000")
+	if err != nil {
+		t.Fatalf("CreateRollbackPlan: %v", err)
+	}
+	// Two migrations should be rolled back (b and c); newest first.
+	if plan.MigrationCount() != 2 {
+		t.Fatalf("expected 2 migrations, got %d", plan.MigrationCount())
+	}
+	if plan.Migrations[0].Version != "20260303_000000" {
+		t.Errorf("expected newest first; got %s", plan.Migrations[0].Version)
+	}
+	if plan.OverallSafety != RollbackSafetyDanger {
+		t.Errorf("expected Danger safety (REMOVE TABLE), got %s", plan.OverallSafety)
+	}
+
+	result, err := ExecuteRollback(ctx, client, plan)
+	if err != nil {
+		t.Fatalf("ExecuteRollback: %v", err)
+	}
+	if !result.Success || !result.CompletedAll() {
+		t.Errorf("unexpected rollback result: %+v", result)
+	}
+
+	report, err := GetMigrationStatus(ctx, client, dir)
+	if err != nil {
+		t.Fatalf("GetMigrationStatus: %v", err)
+	}
+	if report.Applied != 1 || report.Pending != 2 {
+		t.Errorf("unexpected report after rollback: %+v", report)
+	}
+}

--- a/pkg/surql/migration/rollback.go
+++ b/pkg/surql/migration/rollback.go
@@ -1,0 +1,367 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/albedosehen/surql-go/pkg/surql/connection"
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// RollbackSafety categorises the risk level of a rollback operation.
+//
+// Safe   — reversible operations (index drops, cosmetic event changes);
+// Warning — may cause data loss (field removal, field type changes);
+// Danger  — destructive (table removal, schema collapse).
+type RollbackSafety string
+
+// RollbackSafety values, ordered from least to most severe.
+const (
+	RollbackSafetySafe    RollbackSafety = "safe"
+	RollbackSafetyWarning RollbackSafety = "warning"
+	RollbackSafetyDanger  RollbackSafety = "danger"
+)
+
+// IsValid reports whether the receiver is a defined RollbackSafety.
+func (s RollbackSafety) IsValid() bool {
+	switch s {
+	case RollbackSafetySafe, RollbackSafetyWarning, RollbackSafetyDanger:
+		return true
+	}
+	return false
+}
+
+// String returns the serialised form of the safety level.
+func (s RollbackSafety) String() string { return string(s) }
+
+// rank returns a total order on RollbackSafety (higher is more severe).
+func (s RollbackSafety) rank() int {
+	switch s {
+	case RollbackSafetyDanger:
+		return 3
+	case RollbackSafetyWarning:
+		return 2
+	case RollbackSafetySafe:
+		return 1
+	}
+	return 0
+}
+
+// RollbackIssue describes a single concern surfaced while planning a
+// rollback. Issues are grouped in RollbackPlan.Issues and used to derive
+// the plan's overall safety level.
+type RollbackIssue struct {
+	Safety         RollbackSafety `json:"safety"`
+	Migration      string         `json:"migration"`
+	Description    string         `json:"description"`
+	AffectedData   string         `json:"affected_data,omitempty"`
+	Recommendation string         `json:"recommendation,omitempty"`
+}
+
+// RollbackPlan captures the migrations that will be reversed, together with
+// a safety analysis. The zero value is not useful; build one via
+// CreateRollbackPlan / PlanRollbackToVersion.
+type RollbackPlan struct {
+	FromVersion       string          `json:"from_version"`
+	ToVersion         string          `json:"to_version"`
+	Migrations        []Migration     `json:"migrations"`
+	OverallSafety     RollbackSafety  `json:"overall_safety"`
+	Issues            []RollbackIssue `json:"issues,omitempty"`
+	RequiresApproval  bool            `json:"requires_approval"`
+	EstimatedDuration *time.Duration  `json:"estimated_duration,omitempty"`
+}
+
+// MigrationCount returns the number of migrations the plan will reverse.
+func (p RollbackPlan) MigrationCount() int { return len(p.Migrations) }
+
+// IsSafe reports whether the plan is entirely safe (no data loss expected).
+func (p RollbackPlan) IsSafe() bool { return p.OverallSafety == RollbackSafetySafe }
+
+// HasDataLoss reports whether the plan may cause data loss.
+func (p RollbackPlan) HasDataLoss() bool {
+	return p.OverallSafety == RollbackSafetyWarning || p.OverallSafety == RollbackSafetyDanger
+}
+
+// RollbackResult is the outcome of executing a RollbackPlan.
+type RollbackResult struct {
+	Plan            RollbackPlan  `json:"plan"`
+	Success         bool          `json:"success"`
+	ActualDuration  time.Duration `json:"actual_duration"`
+	RolledBackCount int           `json:"rolled_back_count"`
+	Errors          []string      `json:"errors,omitempty"`
+}
+
+// CompletedAll reports whether every planned migration was rolled back.
+func (r RollbackResult) CompletedAll() bool {
+	return r.RolledBackCount == r.Plan.MigrationCount()
+}
+
+// AnalyzeRollbackSafety walks the migrations on disk and returns the safety
+// issues that would arise from rolling back to targetVersion.
+//
+// Unlike CreateRollbackPlan this helper is database-agnostic: it inspects
+// the down-SQL of each migration above targetVersion without consulting the
+// history table. Useful for CLI `plan` previews.
+func AnalyzeRollbackSafety(migrationsDir, targetVersion string) ([]RollbackIssue, error) {
+	migrations, err := DiscoverMigrations(migrationsDir)
+	if err != nil {
+		return nil, err
+	}
+	if !versionExists(migrations, targetVersion) {
+		return nil, surqlerrors.Newf(
+			surqlerrors.ErrValidation,
+			"target version %q not found in %q", targetVersion, migrationsDir,
+		)
+	}
+	candidates := migrationsNewerThan(migrations, targetVersion)
+	issues := make([]RollbackIssue, 0)
+	for _, m := range candidates {
+		issues = append(issues, analyzeMigrationSafety(m)...)
+	}
+	return issues, nil
+}
+
+// CreateRollbackPlan builds a safety-analysed rollback plan that takes the
+// database from its current version down to targetVersion.
+//
+// The "current version" is the most recent entry in the history table. When
+// no migrations have been applied, the call fails with ErrMigrationHistory.
+// The target version must exist on disk.
+func CreateRollbackPlan(
+	ctx context.Context,
+	client *connection.DatabaseClient,
+	migrationsDir string,
+	targetVersion string,
+) (RollbackPlan, error) {
+	if client == nil {
+		return RollbackPlan{}, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	if targetVersion == "" {
+		return RollbackPlan{}, surqlerrors.New(surqlerrors.ErrValidation, "target version cannot be empty")
+	}
+
+	migrations, err := DiscoverMigrations(migrationsDir)
+	if err != nil {
+		return RollbackPlan{}, err
+	}
+	if !versionExists(migrations, targetVersion) {
+		return RollbackPlan{}, surqlerrors.Newf(
+			surqlerrors.ErrValidation,
+			"target version %q not found in %q", targetVersion, migrationsDir,
+		)
+	}
+
+	applied, err := GetAppliedMigrationsOrdered(ctx, client)
+	if err != nil {
+		return RollbackPlan{}, err
+	}
+	if len(applied) == 0 {
+		return RollbackPlan{}, surqlerrors.New(
+			surqlerrors.ErrMigrationHistory,
+			"no migrations have been applied",
+		)
+	}
+	currentVersion := applied[len(applied)-1].Version
+
+	// Collect files strictly greater than targetVersion and <= currentVersion.
+	// The plan reverses the newest-first to match SurrealDB rollback semantics.
+	toRollback := make([]Migration, 0)
+	for _, m := range migrations {
+		if m.Version > targetVersion && m.Version <= currentVersion {
+			toRollback = append(toRollback, m)
+		}
+	}
+	sort.SliceStable(toRollback, func(i, j int) bool {
+		return toRollback[i].Version > toRollback[j].Version
+	})
+
+	issues := make([]RollbackIssue, 0)
+	overall := RollbackSafetySafe
+	for _, m := range toRollback {
+		migrationIssues := analyzeMigrationSafety(m)
+		issues = append(issues, migrationIssues...)
+		for _, iss := range migrationIssues {
+			if iss.Safety.rank() > overall.rank() {
+				overall = iss.Safety
+			}
+		}
+	}
+
+	return RollbackPlan{
+		FromVersion:      currentVersion,
+		ToVersion:        targetVersion,
+		Migrations:       toRollback,
+		OverallSafety:    overall,
+		Issues:           issues,
+		RequiresApproval: overall != RollbackSafetySafe,
+	}, nil
+}
+
+// ExecuteRollback runs every migration in plan in reverse-version order,
+// using ExecuteMigration per step. A failure short-circuits the run; the
+// returned RollbackResult reflects the partial progress.
+//
+// Unsafe plans are not blocked here — CLI callers are responsible for
+// prompting the operator. Downstream tooling that wishes to enforce the
+// RequiresApproval flag should do so before invoking this function.
+func ExecuteRollback(
+	ctx context.Context,
+	client *connection.DatabaseClient,
+	plan RollbackPlan,
+) (RollbackResult, error) {
+	if client == nil {
+		return RollbackResult{Plan: plan}, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+
+	start := time.Now()
+	errs := make([]string, 0)
+	rolledBack := 0
+
+	for _, m := range plan.Migrations {
+		if _, err := ExecuteMigration(ctx, client, m, MigrationDirectionDown); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", m.Version, err))
+			return RollbackResult{
+				Plan:            plan,
+				Success:         false,
+				ActualDuration:  time.Since(start),
+				RolledBackCount: rolledBack,
+				Errors:          errs,
+			}, err
+		}
+		rolledBack++
+	}
+
+	return RollbackResult{
+		Plan:            plan,
+		Success:         true,
+		ActualDuration:  time.Since(start),
+		RolledBackCount: rolledBack,
+	}, nil
+}
+
+// PlanRollbackToVersion is a convenience alias for CreateRollbackPlan. The
+// API separates "build the plan" and "execute the plan" so callers can
+// display safety issues between the two steps.
+func PlanRollbackToVersion(
+	ctx context.Context,
+	client *connection.DatabaseClient,
+	migrationsDir string,
+	targetVersion string,
+) (RollbackPlan, error) {
+	return CreateRollbackPlan(ctx, client, migrationsDir, targetVersion)
+}
+
+// ---------------------------------------------------------------------------
+// Safety analysis
+// ---------------------------------------------------------------------------
+
+// dropTableRe matches DROP TABLE or REMOVE TABLE statements (case
+// insensitive). We capture the table identifier to surface it in the issue.
+var dropTableRe = regexp.MustCompile(`(?i)\b(?:DROP|REMOVE)\s+TABLE(?:\s+IF\s+EXISTS)?\s+([A-Za-z_][A-Za-z0-9_]*)`)
+
+// dropFieldRe matches DROP FIELD / REMOVE FIELD statements. Captures the
+// field identifier, which may be in `table.field` form or qualified via
+// `ON TABLE` later in the statement.
+var dropFieldRe = regexp.MustCompile(`(?i)\b(?:DROP|REMOVE)\s+FIELD(?:\s+IF\s+EXISTS)?\s+([A-Za-z_][A-Za-z0-9_\.]*)`)
+
+// dropIndexRe matches DROP INDEX / REMOVE INDEX statements.
+var dropIndexRe = regexp.MustCompile(`(?i)\b(?:DROP|REMOVE)\s+INDEX`)
+
+// alterTypeRe matches ALTER ... TYPE statements (best-effort). Surreal's
+// actual syntax uses DEFINE FIELD … TYPE to redefine, so we also detect
+// DEFINE FIELD … TYPE emitted as part of a down migration.
+var alterTypeRe = regexp.MustCompile(`(?i)\bALTER\b.*\bTYPE\b`)
+
+// redefineFieldRe matches DEFINE FIELD … TYPE statements (which, emitted
+// as a down migration, signal a field type change being reverted).
+var redefineFieldRe = regexp.MustCompile(`(?i)\bDEFINE\s+FIELD\b.*\bTYPE\b`)
+
+// analyzeMigrationSafety inspects the down SQL of a migration and returns
+// the safety issues it produces.
+func analyzeMigrationSafety(m Migration) []RollbackIssue {
+	issues := make([]RollbackIssue, 0)
+	if len(m.DownStatements) == 0 {
+		issues = append(issues, RollbackIssue{
+			Safety:         RollbackSafetyDanger,
+			Migration:      m.Version,
+			Description:    "migration has no rollback statements",
+			Recommendation: "provide a '-- @down' section to enable safe rollback",
+		})
+		return issues
+	}
+
+	for _, stmt := range m.DownStatements {
+		normalised := strings.TrimSpace(stmt)
+		if normalised == "" {
+			continue
+		}
+		// Table drops: destructive.
+		if match := dropTableRe.FindStringSubmatch(normalised); match != nil {
+			table := match[1]
+			issues = append(issues, RollbackIssue{
+				Safety:         RollbackSafetyDanger,
+				Migration:      m.Version,
+				Description:    fmt.Sprintf("dropping table %q", table),
+				AffectedData:   fmt.Sprintf("all records in table %s", table),
+				Recommendation: "export table data before rollback",
+			})
+			continue
+		}
+		// Field drops: data loss.
+		if match := dropFieldRe.FindStringSubmatch(normalised); match != nil {
+			field := match[1]
+			issues = append(issues, RollbackIssue{
+				Safety:         RollbackSafetyWarning,
+				Migration:      m.Version,
+				Description:    fmt.Sprintf("dropping field %q", field),
+				AffectedData:   fmt.Sprintf("field data in %s", field),
+				Recommendation: "backup affected field data",
+			})
+			continue
+		}
+		// Type changes (ALTER … TYPE or re-DEFINE FIELD … TYPE): data loss.
+		if alterTypeRe.MatchString(normalised) || redefineFieldRe.MatchString(normalised) {
+			issues = append(issues, RollbackIssue{
+				Safety:         RollbackSafetyWarning,
+				Migration:      m.Version,
+				Description:    "altering field type may cause data conversion issues",
+				Recommendation: "review data compatibility before rollback",
+			})
+			continue
+		}
+		// Index drops are safe but noteworthy.
+		if dropIndexRe.MatchString(normalised) {
+			continue
+		}
+	}
+	return issues
+}
+
+// versionExists reports whether migrations contains the given version.
+func versionExists(migrations []Migration, version string) bool {
+	for _, m := range migrations {
+		if m.Version == version {
+			return true
+		}
+	}
+	return false
+}
+
+// migrationsNewerThan returns the subset of migrations with Version >
+// targetVersion, sorted ascending.
+func migrationsNewerThan(migrations []Migration, targetVersion string) []Migration {
+	out := make([]Migration, 0)
+	for _, m := range migrations {
+		if m.Version > targetVersion {
+			out = append(out, m)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Version < out[j].Version
+	})
+	return out
+}

--- a/pkg/surql/migration/rollback_test.go
+++ b/pkg/surql/migration/rollback_test.go
@@ -1,0 +1,271 @@
+package migration
+
+import (
+	stdErrors "errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+)
+
+// writeTestMigrationFile writes a migration file with the given version and
+// down statements. The up section is a no-op that still satisfies
+// parseMigrationContent.
+func writeTestMigrationFile(t *testing.T, dir, filename, downSQL string) {
+	t.Helper()
+	body := "-- @description: test\n-- @up\nDEFINE TABLE noop SCHEMAFULL;\n-- @down\n" + downSQL + "\n"
+	if err := os.WriteFile(filepath.Join(dir, filename), []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", filename, err)
+	}
+}
+
+// --- RollbackSafety ---
+
+func TestRollbackSafety_IsValid(t *testing.T) {
+	for _, s := range []RollbackSafety{RollbackSafetySafe, RollbackSafetyWarning, RollbackSafetyDanger} {
+		if !s.IsValid() {
+			t.Errorf("expected %q to be valid", s)
+		}
+	}
+	if RollbackSafety("bogus").IsValid() {
+		t.Errorf("expected 'bogus' to be invalid")
+	}
+	if RollbackSafety("").IsValid() {
+		t.Errorf("expected '' to be invalid")
+	}
+}
+
+func TestRollbackSafety_String(t *testing.T) {
+	if got := RollbackSafetyWarning.String(); got != "warning" {
+		t.Errorf("String()=%q, want %q", got, "warning")
+	}
+}
+
+func TestRollbackSafety_Rank_Ordering(t *testing.T) {
+	cases := []struct {
+		a, b RollbackSafety
+		want bool
+	}{
+		{RollbackSafetyDanger, RollbackSafetyWarning, true},
+		{RollbackSafetyWarning, RollbackSafetySafe, true},
+		{RollbackSafetySafe, RollbackSafetyDanger, false},
+	}
+	for _, tc := range cases {
+		if got := tc.a.rank() > tc.b.rank(); got != tc.want {
+			t.Errorf("%s > %s: got %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+// --- analyzeMigrationSafety ---
+
+func TestAnalyzeMigrationSafety_DropTable_Danger(t *testing.T) {
+	m := Migration{
+		Version:        "20260102_120000",
+		DownStatements: []string{"REMOVE TABLE user;"},
+	}
+	issues := analyzeMigrationSafety(m)
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+	if issues[0].Safety != RollbackSafetyDanger {
+		t.Errorf("safety=%q, want %q", issues[0].Safety, RollbackSafetyDanger)
+	}
+	if issues[0].AffectedData == "" {
+		t.Errorf("expected AffectedData to be populated")
+	}
+}
+
+func TestAnalyzeMigrationSafety_DropField_Warning(t *testing.T) {
+	m := Migration{
+		Version:        "20260102_120000",
+		DownStatements: []string{"REMOVE FIELD email ON TABLE user;"},
+	}
+	issues := analyzeMigrationSafety(m)
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+	if issues[0].Safety != RollbackSafetyWarning {
+		t.Errorf("safety=%q, want %q", issues[0].Safety, RollbackSafetyWarning)
+	}
+}
+
+func TestAnalyzeMigrationSafety_DropIndex_NoIssue(t *testing.T) {
+	m := Migration{
+		Version:        "20260102_120000",
+		DownStatements: []string{"REMOVE INDEX email_idx ON TABLE user;"},
+	}
+	issues := analyzeMigrationSafety(m)
+	if len(issues) != 0 {
+		t.Fatalf("expected 0 issues, got %d: %+v", len(issues), issues)
+	}
+}
+
+func TestAnalyzeMigrationSafety_AlterType_Warning(t *testing.T) {
+	m := Migration{
+		Version:        "20260102_120000",
+		DownStatements: []string{"DEFINE FIELD age ON TABLE user TYPE string;"},
+	}
+	issues := analyzeMigrationSafety(m)
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+	if issues[0].Safety != RollbackSafetyWarning {
+		t.Errorf("safety=%q, want %q", issues[0].Safety, RollbackSafetyWarning)
+	}
+}
+
+func TestAnalyzeMigrationSafety_EmptyDown_Danger(t *testing.T) {
+	m := Migration{Version: "20260102_120000"}
+	issues := analyzeMigrationSafety(m)
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+	if issues[0].Safety != RollbackSafetyDanger {
+		t.Errorf("safety=%q, want %q", issues[0].Safety, RollbackSafetyDanger)
+	}
+}
+
+func TestAnalyzeMigrationSafety_MultipleStatements(t *testing.T) {
+	m := Migration{
+		Version: "20260102_120000",
+		DownStatements: []string{
+			"REMOVE TABLE user;",
+			"REMOVE FIELD email ON TABLE customer;",
+			"REMOVE INDEX email_idx ON TABLE customer;",
+		},
+	}
+	issues := analyzeMigrationSafety(m)
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d: %+v", len(issues), issues)
+	}
+
+	safetyBag := make(map[RollbackSafety]int, len(issues))
+	for _, iss := range issues {
+		safetyBag[iss.Safety]++
+	}
+	if safetyBag[RollbackSafetyDanger] != 1 {
+		t.Errorf("expected 1 danger, got %d", safetyBag[RollbackSafetyDanger])
+	}
+	if safetyBag[RollbackSafetyWarning] != 1 {
+		t.Errorf("expected 1 warning, got %d", safetyBag[RollbackSafetyWarning])
+	}
+}
+
+// --- AnalyzeRollbackSafety ---
+
+func TestAnalyzeRollbackSafety_TargetNotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeTestMigrationFile(t, dir, "20260102_120000_first.surql", "REMOVE TABLE foo;")
+
+	_, err := AnalyzeRollbackSafety(dir, "99999999_999999")
+	if err == nil {
+		t.Fatal("expected error for missing target version")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestAnalyzeRollbackSafety_OnlyCandidatesAbove(t *testing.T) {
+	dir := t.TempDir()
+	writeTestMigrationFile(t, dir, "20260101_000000_init.surql", "REMOVE TABLE foo;")
+	writeTestMigrationFile(t, dir, "20260102_000000_add_table.surql", "REMOVE TABLE bar;")
+	writeTestMigrationFile(t, dir, "20260103_000000_add_field.surql", "REMOVE FIELD x ON TABLE baz;")
+
+	issues, err := AnalyzeRollbackSafety(dir, "20260101_000000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Expect one danger (drop bar) + one warning (drop field x). The
+	// target version itself is not analysed.
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d: %+v", len(issues), issues)
+	}
+}
+
+func TestAnalyzeRollbackSafety_TargetIsLatest_NoIssues(t *testing.T) {
+	dir := t.TempDir()
+	writeTestMigrationFile(t, dir, "20260101_000000_init.surql", "REMOVE TABLE foo;")
+	writeTestMigrationFile(t, dir, "20260102_000000_next.surql", "REMOVE TABLE bar;")
+
+	issues, err := AnalyzeRollbackSafety(dir, "20260102_000000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Errorf("expected 0 issues when target is latest, got %d", len(issues))
+	}
+}
+
+// --- RollbackPlan helpers ---
+
+func TestRollbackPlan_IsSafe_HasDataLoss(t *testing.T) {
+	safe := RollbackPlan{OverallSafety: RollbackSafetySafe}
+	if !safe.IsSafe() {
+		t.Error("safe plan should report IsSafe")
+	}
+	if safe.HasDataLoss() {
+		t.Error("safe plan should not report data loss")
+	}
+
+	warn := RollbackPlan{OverallSafety: RollbackSafetyWarning}
+	if warn.IsSafe() {
+		t.Error("warning plan should not report IsSafe")
+	}
+	if !warn.HasDataLoss() {
+		t.Error("warning plan should report data loss")
+	}
+
+	danger := RollbackPlan{OverallSafety: RollbackSafetyDanger}
+	if !danger.HasDataLoss() {
+		t.Error("danger plan should report data loss")
+	}
+}
+
+func TestRollbackPlan_MigrationCount(t *testing.T) {
+	p := RollbackPlan{
+		Migrations: []Migration{
+			{Version: "a"}, {Version: "b"}, {Version: "c"},
+		},
+	}
+	if got := p.MigrationCount(); got != 3 {
+		t.Errorf("MigrationCount()=%d, want 3", got)
+	}
+}
+
+// --- migrationsNewerThan ---
+
+func TestMigrationsNewerThan_Ordering(t *testing.T) {
+	migrations := []Migration{
+		{Version: "20260103_000000"},
+		{Version: "20260101_000000"},
+		{Version: "20260102_000000"},
+		{Version: "20260104_000000"},
+	}
+	out := migrationsNewerThan(migrations, "20260101_000000")
+	if len(out) != 3 {
+		t.Fatalf("expected 3 migrations newer than target, got %d", len(out))
+	}
+	versions := make([]string, len(out))
+	for i, m := range out {
+		versions[i] = m.Version
+	}
+	if !sort.StringsAreSorted(versions) {
+		t.Errorf("migrations not sorted ascending: %v", versions)
+	}
+}
+
+// --- RollbackResult ---
+
+func TestRollbackResult_CompletedAll(t *testing.T) {
+	plan := RollbackPlan{Migrations: []Migration{{Version: "a"}, {Version: "b"}}}
+	if (RollbackResult{Plan: plan, RolledBackCount: 2}).CompletedAll() != true {
+		t.Error("expected CompletedAll when count matches plan")
+	}
+	if (RollbackResult{Plan: plan, RolledBackCount: 1}).CompletedAll() != false {
+		t.Error("expected !CompletedAll when count < plan")
+	}
+}


### PR DESCRIPTION
Closes #41.

## Summary
Runtime migration layer for surql-go.

- **\`migration/history.go\`**: \`_migration_history\` with idempotent \`DEFINE IF NOT EXISTS\`; Record/Remove/Get/IsApplied helpers; envelope decoder that handles the client's \`{status,time,result}\` response shape + RFC3339 datetimes.
- **\`migration/executor.go\`**: SDK-native transaction-wrapped \`ExecuteMigration\` (Begin/Execute/Commit/Cancel); \`MigrateUp\` with \`ExecuteOption\` functional opts (Steps, DryRun, FailOnValidation); \`MigrateDown\` (LIFO); \`GetPendingMigrations\`, \`GetAppliedMigrationsOrdered\`, \`GetMigrationStatus\`, \`CreateMigrationPlan\`, \`ExecuteMigrationPlan\`, \`ValidateMigrations\`.
- **\`migration/rollback.go\`**: \`RollbackSafety\` with \`.rank()\` ordering; \`RollbackIssue\`/\`RollbackPlan\`/\`RollbackResult\`; regex static analysis of down SQL (DROP/REMOVE TABLE=Danger, DROP FIELD/ALTER TYPE/re-DEFINE FIELD TYPE=Warning, DROP INDEX=Safe, empty=Danger); disk-only \`AnalyzeRollbackSafety\` + history-aware \`CreateRollbackPlan\`/\`PlanRollbackToVersion\`/\`ExecuteRollback\`.
- **Integration tests** (\`//go:build integration\`): table idempotency, Record/Remove round-trip, MigrateUp/Down lifecycle, failed-statement transaction rollback, rollback-plan execution with safety assertion.

## Test plan
- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./... -race\` green
- [ ] CI green