### PR TITLE
chore: rename module path to github.com/Oneiriq/surql-go + bump Version to 0.1.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,7 @@ formatters:
   settings:
     goimports:
       local-prefixes:
-        - github.com/albedosehen/surql-go
+        - github.com/Oneiriq/surql-go
   exclusions:
     generated: lax
     paths:

--- a/cmd/surql/main.go
+++ b/cmd/surql/main.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/albedosehen/surql-go/pkg/surql"
+	"github.com/Oneiriq/surql-go/pkg/surql"
 )
 
 // build-time populated by goreleaser via -ldflags.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/albedosehen/surql-go
+module github.com/Oneiriq/surql-go
 
 go 1.26.1
 

--- a/pkg/surql/connection/client.go
+++ b/pkg/surql/connection/client.go
@@ -9,7 +9,7 @@ import (
 
 	surrealdb "github.com/surrealdb/surrealdb.go"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // DatabaseClient is a high-level wrapper around the official SurrealDB Go SDK

--- a/pkg/surql/connection/client_test.go
+++ b/pkg/surql/connection/client_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 func TestNewDatabaseClient_ValidatesConfig(t *testing.T) {

--- a/pkg/surql/connection/config.go
+++ b/pkg/surql/connection/config.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // EnvPrefix is the environment variable prefix used by LoadConfigFromEnv.

--- a/pkg/surql/connection/config_test.go
+++ b/pkg/surql/connection/config_test.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 func TestDefaultsAreValid(t *testing.T) {

--- a/pkg/surql/connection/streaming.go
+++ b/pkg/surql/connection/streaming.go
@@ -8,7 +8,7 @@ import (
 	sdkconn "github.com/surrealdb/surrealdb.go/pkg/connection"
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // LiveNotification is the event emitted by a LiveQuery subscription. It is a

--- a/pkg/surql/connection/streaming_test.go
+++ b/pkg/surql/connection/streaming_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 func TestLive_RejectsHTTP(t *testing.T) {

--- a/pkg/surql/connection/transaction.go
+++ b/pkg/surql/connection/transaction.go
@@ -6,7 +6,7 @@ import (
 
 	surrealdb "github.com/surrealdb/surrealdb.go"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // TransactionState enumerates the lifecycle states of a Transaction.

--- a/pkg/surql/connection/transaction_test.go
+++ b/pkg/surql/connection/transaction_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 func TestTransactionState_String(t *testing.T) {

--- a/pkg/surql/migration/diff.go
+++ b/pkg/surql/migration/diff.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
-	"github.com/albedosehen/surql-go/pkg/surql/schema"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/schema"
 )
 
 // safeDefaultPattern mirrors the Python _SAFE_DEFAULT_PATTERN. It matches

--- a/pkg/surql/migration/diff_test.go
+++ b/pkg/surql/migration/diff_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
-	"github.com/albedosehen/surql-go/pkg/surql/schema"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/schema"
 )
 
 // --- helpers -----------------------------------------------------------------

--- a/pkg/surql/migration/discovery.go
+++ b/pkg/surql/migration/discovery.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // Section markers used inside migration files.

--- a/pkg/surql/migration/discovery_test.go
+++ b/pkg/surql/migration/discovery_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // writeFile is a small test helper that creates a file with the given body.

--- a/pkg/surql/migration/executor.go
+++ b/pkg/surql/migration/executor.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/albedosehen/surql-go/pkg/surql/connection"
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/connection"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // ExecuteOptions tunes MigrateUp / MigrateDown behaviour.

--- a/pkg/surql/migration/executor_test.go
+++ b/pkg/surql/migration/executor_test.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // --- ExecuteOptions functional constructors ---

--- a/pkg/surql/migration/generator.go
+++ b/pkg/surql/migration/generator.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
-	"github.com/albedosehen/surql-go/pkg/surql/schema"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/schema"
 )
 
 // timestampLayout is the UTC timestamp layout used for migration versions.

--- a/pkg/surql/migration/generator_test.go
+++ b/pkg/surql/migration/generator_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
-	"github.com/albedosehen/surql-go/pkg/surql/schema"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/schema"
 )
 
 // withFrozenClock overrides the generator's clock for the duration of a test.

--- a/pkg/surql/migration/history.go
+++ b/pkg/surql/migration/history.go
@@ -6,8 +6,8 @@ import (
 	"sort"
 	"time"
 
-	"github.com/albedosehen/surql-go/pkg/surql/connection"
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/connection"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // MigrationTableName is the SurrealDB table that tracks applied migrations.

--- a/pkg/surql/migration/hooks.go
+++ b/pkg/surql/migration/hooks.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // DriftSeverity categorises a single DriftIssue. The zero value

--- a/pkg/surql/migration/hooks_test.go
+++ b/pkg/surql/migration/hooks_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
-	"github.com/albedosehen/surql-go/pkg/surql/schema"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/schema"
 )
 
 // --- DriftSeverity ---

--- a/pkg/surql/migration/integration_test.go
+++ b/pkg/surql/migration/integration_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/albedosehen/surql-go/pkg/surql/connection"
+	"github.com/Oneiriq/surql-go/pkg/surql/connection"
 )
 
 // getIntegrationURL reads the SurrealDB URL used by CI's integration job.

--- a/pkg/surql/migration/rollback.go
+++ b/pkg/surql/migration/rollback.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/albedosehen/surql-go/pkg/surql/connection"
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/connection"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // RollbackSafety categorises the risk level of a rollback operation.

--- a/pkg/surql/migration/rollback_test.go
+++ b/pkg/surql/migration/rollback_test.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // writeTestMigrationFile writes a migration file with the given version and

--- a/pkg/surql/migration/versioning.go
+++ b/pkg/surql/migration/versioning.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
-	"github.com/albedosehen/surql-go/pkg/surql/schema"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/schema"
 )
 
 // snapshotFileSuffix is the filename suffix used for persisted snapshots.

--- a/pkg/surql/migration/versioning_test.go
+++ b/pkg/surql/migration/versioning_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
-	"github.com/albedosehen/surql-go/pkg/surql/schema"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/schema"
 )
 
 // withSnapshotClock overrides snapshotClock for the duration of the test.

--- a/pkg/surql/query/builder.go
+++ b/pkg/surql/query/builder.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
-	"github.com/albedosehen/surql-go/pkg/surql/types"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/types"
 )
 
 // Operation tags the high-level SurrealQL statement a Query produces.

--- a/pkg/surql/query/builder_test.go
+++ b/pkg/surql/query/builder_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
-	"github.com/albedosehen/surql-go/pkg/surql/types"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/types"
 )
 
 // mustFrom is a shorthand for `Query{}.Select(fields).FromTable(t)` that

--- a/pkg/surql/query/crud.go
+++ b/pkg/surql/query/crud.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/albedosehen/surql-go/pkg/surql/connection"
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
-	"github.com/albedosehen/surql-go/pkg/surql/types"
+	"github.com/Oneiriq/surql-go/pkg/surql/connection"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/types"
 )
 
 // CreateRecord inserts a new record into table and returns the server

--- a/pkg/surql/query/crud_test.go
+++ b/pkg/surql/query/crud_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
-	"github.com/albedosehen/surql-go/pkg/surql/types"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/types"
 )
 
 func TestBuildRecordTarget_String(t *testing.T) {

--- a/pkg/surql/query/executor.go
+++ b/pkg/surql/query/executor.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/albedosehen/surql-go/pkg/surql/connection"
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/connection"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // ExecuteQuery renders q to SurrealQL and executes it against client. The

--- a/pkg/surql/query/executor_test.go
+++ b/pkg/surql/query/executor_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 func TestExecuteQuery_NilClient(t *testing.T) {

--- a/pkg/surql/query/expressions.go
+++ b/pkg/surql/query/expressions.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/albedosehen/surql-go/pkg/surql/types"
+	"github.com/Oneiriq/surql-go/pkg/surql/types"
 )
 
 // ExpressionKind tags an Expression by category (field / value / function /

--- a/pkg/surql/query/helpers.go
+++ b/pkg/surql/query/helpers.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"strings"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // ReturnFormat selects the data returned by a mutation.

--- a/pkg/surql/query/helpers_test.go
+++ b/pkg/surql/query/helpers_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 func TestHelper_Select(t *testing.T) {

--- a/pkg/surql/query/hints.go
+++ b/pkg/surql/query/hints.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // HintType is the category of a query hint, used to dedupe when MergeHints

--- a/pkg/surql/query/hints_test.go
+++ b/pkg/surql/query/hints_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 func TestIndexHint_RendersUseAndForce(t *testing.T) {

--- a/pkg/surql/query/integration_test.go
+++ b/pkg/surql/query/integration_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/albedosehen/surql-go/pkg/surql/connection"
+	"github.com/Oneiriq/surql-go/pkg/surql/connection"
 )
 
 // getIntegrationURL reads the SurrealDB URL used by CI's integration job.

--- a/pkg/surql/query/results.go
+++ b/pkg/surql/query/results.go
@@ -3,7 +3,7 @@ package query
 import (
 	"encoding/json"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // QueryResult is the generic query execution wrapper.

--- a/pkg/surql/query/typed.go
+++ b/pkg/surql/query/typed.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/albedosehen/surql-go/pkg/surql/connection"
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/connection"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // CreateTyped creates a record from data and returns a validated T. The

--- a/pkg/surql/schema/access.go
+++ b/pkg/surql/schema/access.go
@@ -3,7 +3,7 @@ package schema
 import (
 	"strings"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // AccessType enumerates the access control types supported by DEFINE ACCESS.

--- a/pkg/surql/schema/access_test.go
+++ b/pkg/surql/schema/access_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 func TestAccessType_IsValid(t *testing.T) {

--- a/pkg/surql/schema/edge.go
+++ b/pkg/surql/schema/edge.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"strings"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // EdgeMode enumerates edge table modes.

--- a/pkg/surql/schema/edge_test.go
+++ b/pkg/surql/schema/edge_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 func TestEdgeMode_IsValid(t *testing.T) {

--- a/pkg/surql/schema/fields.go
+++ b/pkg/surql/schema/fields.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"strings"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
-	"github.com/albedosehen/surql-go/pkg/surql/types"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/types"
 )
 
 // FieldType enumerates the SurrealDB field types supported in DEFINE FIELD.

--- a/pkg/surql/schema/fields_test.go
+++ b/pkg/surql/schema/fields_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 func TestFieldType_IsValid(t *testing.T) {

--- a/pkg/surql/schema/parser.go
+++ b/pkg/surql/schema/parser.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // DatabaseInfo is the parsed shape of an INFO FOR DB response. Tables, Edges,

--- a/pkg/surql/schema/parser_test.go
+++ b/pkg/surql/schema/parser_test.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // ---------------------------------------------------------------------------

--- a/pkg/surql/schema/registry.go
+++ b/pkg/surql/schema/registry.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"sync"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // SchemaRegistry is a thread-safe registry for code-defined table and edge

--- a/pkg/surql/schema/registry_test.go
+++ b/pkg/surql/schema/registry_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 func TestNewSchemaRegistry_Empty(t *testing.T) {

--- a/pkg/surql/schema/sql.go
+++ b/pkg/surql/schema/sql.go
@@ -3,7 +3,7 @@ package schema
 import (
 	"strings"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // GenerateTableSQL emits the full list of DEFINE statements for a table: the

--- a/pkg/surql/schema/sql_test.go
+++ b/pkg/surql/schema/sql_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // ---------- GenerateTableSQL ----------

--- a/pkg/surql/schema/table.go
+++ b/pkg/surql/schema/table.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // TableMode enumerates the table schema modes.

--- a/pkg/surql/schema/table_test.go
+++ b/pkg/surql/schema/table_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 func TestTableMode_IsValid(t *testing.T) {

--- a/pkg/surql/schema/themes.go
+++ b/pkg/surql/schema/themes.go
@@ -3,7 +3,7 @@ package schema
 import (
 	"sort"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // ColorScheme is the base color palette used across visualization themes.

--- a/pkg/surql/schema/validator.go
+++ b/pkg/surql/schema/validator.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // ValidationSeverity enumerates the severity of a ValidationResult.

--- a/pkg/surql/schema/validator_test.go
+++ b/pkg/surql/schema/validator_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // ValidationSeverity.

--- a/pkg/surql/schema/visualize_test.go
+++ b/pkg/surql/schema/visualize_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // -------------------- Helpers --------------------

--- a/pkg/surql/surql.go
+++ b/pkg/surql/surql.go
@@ -5,4 +5,4 @@ package surql
 // The foundation port is under active development; operations that require
 // the SurrealDB client will land incrementally and are tracked against
 // surql-py as the source-of-truth feature set.
-const Version = "0.1.0-dev"
+const Version = "0.1.0"

--- a/pkg/surql/types/coerce.go
+++ b/pkg/surql/types/coerce.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // CoerceDatetime converts a SurrealDB ISO-8601 datetime string into a

--- a/pkg/surql/types/record_id.go
+++ b/pkg/surql/types/record_id.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 // tablePattern matches valid SurrealDB table names: [A-Za-z_][A-Za-z0-9_]*

--- a/pkg/surql/types/record_id_test.go
+++ b/pkg/surql/types/record_id_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	surqlerrors "github.com/albedosehen/surql-go/pkg/surql/errors"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
 )
 
 func TestStringID_RendersSimple(t *testing.T) {


### PR DESCRIPTION
Closes #51. Rename module path to match the repo's new home under Oneiriq; bump Version constant from 0.1.0-dev to 0.1.0 in prep for the v0.1.0 tag. All 63 files updated via sed; `go mod tidy`/`go build`/`go vet`/`go test -race` green.