### PR TITLE
chore(release): hotfix v0.1.0 goreleaser owner

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,5 +30,5 @@ checksum:
 
 release:
   github:
-    owner: albedosehen
+    owner: Oneiriq
     name: surql-go


### PR DESCRIPTION
Bundles the goreleaser owner fix (Oneiriq, not albedosehen) so the release workflow can upload artefacts to the new repo URL. Closes #54.