### PR TITLE
chore: revert Version to 0.1.0-dev pending parity + v3 audit

### DIFF
--- a/pkg/surql/surql.go
+++ b/pkg/surql/surql.go
@@ -5,4 +5,4 @@ package surql
 // The foundation port is under active development; operations that require
 // the SurrealDB client will land incrementally and are tracked against
 // surql-py as the source-of-truth feature set.
-const Version = "0.1.0"
+const Version = "0.1.0-dev"


### PR DESCRIPTION
Pulls back the premature Version bump. v0.1.0 tag + release were deleted; re-tagged only after 1:1 feature parity across all four libraries and a completed SurrealDB v3 compatibility pass.