### PR TITLE
fix(query): strengthen isTableMissingError with v3 regression test

### DIFF
--- a/pkg/surql/query/crud.go
+++ b/pkg/surql/query/crud.go
@@ -279,12 +279,36 @@ func Exists(ctx context.Context, client *connection.DatabaseClient, table string
 	return rec != nil, nil
 }
 
-// isTableMissingError reports whether the error is SurrealDB's
-// "table '...' does not exist" response. v2.x treated missing tables as
-// empty results; v3+ returns this error. Callers that want an empty
-// result to be equivalent to "no records" use this check.
+// tableMissingNeedles is the set of case-insensitive substrings that
+// SurrealDB surfaces when a table-level operation targets a table that
+// has not been materialised. v3.0.x returns "The table '...' does not
+// exist"; the trailing "does not exist" fragment is kept as a
+// forward-compat fallback in case future versions rephrase the message.
+// "table not found" is included defensively for the same reason.
+var tableMissingNeedles = []string{
+	"does not exist",  // v3.0.x: "The table '...' does not exist"
+	"table not found", // hypothetical future wording
+}
+
+// isTableMissingError reports whether err is SurrealDB's "table does
+// not exist" response. v2.x treated missing tables as empty results;
+// v3+ returns an error. Callers that want an empty result to be
+// equivalent to "no records" use this check.
+//
+// The match is case-insensitive against the substrings listed in
+// tableMissingNeedles. See pkg/surql/query/crud_integration_test.go for
+// the regression test pinning us to the v3 server wording.
 func isTableMissingError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "does not exist")
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, needle := range tableMissingNeedles {
+		if strings.Contains(msg, needle) {
+			return true
+		}
+	}
+	return false
 }
 
 // First returns the first record matching the filter options, or nil.

--- a/pkg/surql/query/crud_integration_test.go
+++ b/pkg/surql/query/crud_integration_test.go
@@ -1,0 +1,104 @@
+//go:build integration
+// +build integration
+
+package query
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestIntegration_TableMissingErrorShape pins the server wording that
+// isTableMissingError depends on. v2.x returned an empty result for
+// queries against a never-materialised table; v3.0.x returns a
+// QueryError whose message is "The table '<name>' does not exist".
+//
+// The helper must classify the error as "table missing" and the raw
+// error text must contain the exact v3 phrase. If SurrealDB changes
+// either the prefix or the "does not exist" tail this test fails
+// loudly, signalling that the runtime fallbacks in crud.go (GetRecord,
+// DeleteRecord, CountRecords, Exists) need a new needle.
+func TestIntegration_TableMissingErrorShape(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const missing = "surqlgo_does_not_exist_xyz"
+
+	// Probe the raw query path: this is what GetRecord / DeleteRecord /
+	// CountRecords ultimately hit. We do NOT pre-create and remove the
+	// table here because REMOVE TABLE IF EXISTS silently succeeds for a
+	// never-materialised table; we want the server's genuine "missing"
+	// error path.
+	_, err := client.Query(ctx, "SELECT * FROM "+missing+";")
+	if err == nil {
+		t.Fatalf("expected error for SELECT from %q, got nil", missing)
+	}
+
+	// The runtime helper must classify this as a table-missing error.
+	if !isTableMissingError(err) {
+		t.Fatalf("isTableMissingError=false for %q", err.Error())
+	}
+
+	// Pin to the exact v3 wording. Case-sensitive here: we want to
+	// detect *any* drift -- capitalisation, quote style, or preposition.
+	msg := err.Error()
+	if !strings.Contains(msg, "The table '"+missing+"' does not exist") {
+		t.Fatalf("v3 server wording changed; got %q, expected substring %q",
+			msg, "The table '"+missing+"' does not exist")
+	}
+
+	// Also assert the two halves independently so the failure mode is
+	// clear when only one end of the phrase shifts.
+	if !strings.Contains(msg, "The table '") {
+		t.Errorf("missing v3 prefix %q in %q", "The table '", msg)
+	}
+	if !strings.Contains(msg, "does not exist") {
+		t.Errorf("missing v3 suffix %q in %q", "does not exist", msg)
+	}
+}
+
+// TestIntegration_TableMissingErrorHelpersNoOp confirms that the public
+// helpers which branch on isTableMissingError degrade to the
+// v2-compatible "empty" answer when the table is missing on v3+.
+func TestIntegration_TableMissingErrorHelpersNoOp(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const missing = "surqlgo_missing_helpers_xyz"
+
+	rec, err := GetRecord(ctx, client, missing, "alice")
+	if err != nil {
+		t.Fatalf("GetRecord: %v", err)
+	}
+	if rec != nil {
+		t.Errorf("GetRecord want nil, got %+v", rec)
+	}
+
+	ok, err := Exists(ctx, client, missing, "alice")
+	if err != nil {
+		t.Fatalf("Exists: %v", err)
+	}
+	if ok {
+		t.Error("Exists want false")
+	}
+
+	n, err := CountRecords(ctx, client, missing, nil)
+	if err != nil {
+		t.Fatalf("CountRecords: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("CountRecords want 0, got %d", n)
+	}
+
+	if err := DeleteRecord(ctx, client, missing, "alice"); err != nil {
+		t.Fatalf("DeleteRecord: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Replace single-substring match in `isTableMissingError` with a
  case-insensitive needle list (`does not exist`, `table not found`)
  so we don't regress when the SurrealDB server error wording shifts
  across v3 minor releases.
- Pin the exact v3.0.5 wording (`The table '<name>' does not exist`)
  with a dedicated `//go:build integration` regression test.
- Assert `GetRecord` / `Exists` / `CountRecords` / `DeleteRecord` all
  continue to degrade to the v2-compatible no-op against missing
  tables.

## Why

The v3 compatibility audit (`surql-v3-audit.md`) flagged the single-
needle substring match as brittle. Without a pinned regression test
we had no signal on server-side wording changes — a future SurrealDB
release swapping \`does not exist\` for \`not defined\` would silently
make missing tables propagate as raw errors instead of empty results.

## Test plan

- [x] \`gofmt -l .\` empty
- [x] \`go vet ./...\` clean
- [x] \`go test ./... -race\` — 947 PASS / 0 FAIL / 0 SKIP
- [x] \`go test -tags=integration ./...\` against
      \`surrealdb/surrealdb:v3.0.5\` — 946 PASS + 1 SKIP
      (upstream surrealdb.go#398), 0 FAIL

Closes #60.