### PR TITLE
feat(connection): add context + registry + AuthManager + StreamingManager + missing client methods

### DIFF
--- a/pkg/surql/connection/auth_manager.go
+++ b/pkg/surql/connection/auth_manager.go
@@ -1,0 +1,138 @@
+package connection
+
+import (
+	"context"
+	"sync"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+// AuthManager is a thin orchestrator over a DatabaseClient's
+// signin/signup/authenticate/invalidate lifecycle. It tracks the most recent
+// token and auth level so downstream helpers can inspect auth state without
+// threading it through the call stack. Mirrors surql-py's
+// `connection.auth.AuthManager`.
+//
+// All methods are safe for concurrent use. The underlying client drives the
+// actual I/O; this type only manages cached auth bookkeeping under its own
+// mutex so the client's lock isn't held across higher-level orchestration.
+type AuthManager struct {
+	client *DatabaseClient
+
+	mu       sync.RWMutex
+	token    string
+	authType AuthType
+}
+
+// NewAuthManager wraps client so consumers can call Signin/Signup/etc. off
+// the manager. The client must be non-nil and should generally be connected
+// before orchestrating auth; callers remain responsible for Connect/Disconnect.
+func NewAuthManager(client *DatabaseClient) (*AuthManager, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	return &AuthManager{client: client}, nil
+}
+
+// Signin authenticates the underlying client with the supplied credentials
+// and caches the resulting JWT + auth level. Returns the TokenAuth yielded
+// by the client for callers that want to persist it externally.
+func (a *AuthManager) Signin(ctx context.Context, creds Credentials) (TokenAuth, error) {
+	if creds == nil {
+		return TokenAuth{}, surqlerrors.New(surqlerrors.ErrValidation, "credentials cannot be nil")
+	}
+	token, err := a.client.Signin(ctx, creds)
+	if err != nil {
+		return TokenAuth{}, err
+	}
+	a.mu.Lock()
+	a.token = token.Token
+	a.authType = creds.AuthType()
+	a.mu.Unlock()
+	return token, nil
+}
+
+// Signup registers a new record-level user with the supplied scope
+// credentials and caches the resulting JWT. The auth level is always
+// AuthScope because signup is only valid at scope/record level.
+func (a *AuthManager) Signup(ctx context.Context, creds ScopeCredentials) (TokenAuth, error) {
+	token, err := a.client.Signup(ctx, creds)
+	if err != nil {
+		return TokenAuth{}, err
+	}
+	a.mu.Lock()
+	a.token = token.Token
+	a.authType = AuthScope
+	a.mu.Unlock()
+	return token, nil
+}
+
+// Authenticate binds an existing JWT to the underlying session. The cached
+// token is updated so subsequent CurrentToken calls reflect the new value,
+// but the cached auth type is left untouched because the JWT alone does not
+// tell us which level minted it.
+func (a *AuthManager) Authenticate(ctx context.Context, token string) error {
+	if token == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "token cannot be empty")
+	}
+	if err := a.client.Authenticate(ctx, token); err != nil {
+		return err
+	}
+	a.mu.Lock()
+	a.token = token
+	a.mu.Unlock()
+	return nil
+}
+
+// Invalidate drops the current session's authentication state on both
+// client and server, and clears the cached token/auth type.
+func (a *AuthManager) Invalidate(ctx context.Context) error {
+	if err := a.client.Invalidate(ctx); err != nil {
+		return err
+	}
+	a.mu.Lock()
+	a.token = ""
+	a.authType = ""
+	a.mu.Unlock()
+	return nil
+}
+
+// Refresh re-authenticates the current session using the cached token. It
+// is a thin convenience over Authenticate for long-running consumers that
+// periodically need to nudge the session. Returns ErrContext when no
+// token has been cached yet (i.e. the manager was never signed in).
+func (a *AuthManager) Refresh(ctx context.Context) error {
+	a.mu.RLock()
+	token := a.token
+	a.mu.RUnlock()
+	if token == "" {
+		return surqlerrors.New(
+			surqlerrors.ErrContext,
+			"no cached token to refresh; sign in first",
+		)
+	}
+	return a.client.Authenticate(ctx, token)
+}
+
+// CurrentToken returns the most recently cached JWT (empty string when the
+// manager is unauthenticated).
+func (a *AuthManager) CurrentToken() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.token
+}
+
+// AuthType returns the cached auth level of the most recent successful
+// Signin/Signup call (empty string when unauthenticated).
+func (a *AuthManager) AuthType() AuthType {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.authType
+}
+
+// IsAuthenticated reports whether a cached token is present.
+func (a *AuthManager) IsAuthenticated() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.token != ""
+}

--- a/pkg/surql/connection/auth_manager_test.go
+++ b/pkg/surql/connection/auth_manager_test.go
@@ -1,0 +1,118 @@
+package connection
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+func TestNewAuthManager_RejectsNilClient(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewAuthManager(nil)
+	if err == nil {
+		t.Fatal("NewAuthManager(nil) should error")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("err = %v; want ErrValidation", err)
+	}
+}
+
+func TestAuthManager_ZeroStateIsUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	// The client is only used for real signin; we test the pure-state
+	// branches by providing a stub DatabaseClient (non-nil).
+	mgr, err := NewAuthManager(&DatabaseClient{})
+	if err != nil {
+		t.Fatalf("NewAuthManager: %v", err)
+	}
+	if mgr.IsAuthenticated() {
+		t.Fatal("zero-state AuthManager should not be authenticated")
+	}
+	if got := mgr.CurrentToken(); got != "" {
+		t.Fatalf("CurrentToken = %q; want empty", got)
+	}
+	if got := mgr.AuthType(); got != "" {
+		t.Fatalf("AuthType = %q; want empty", got)
+	}
+}
+
+func TestAuthManager_SigninRejectsNilCredentials(t *testing.T) {
+	t.Parallel()
+
+	mgr, err := NewAuthManager(&DatabaseClient{})
+	if err != nil {
+		t.Fatalf("NewAuthManager: %v", err)
+	}
+	_, err = mgr.Signin(context.Background(), nil)
+	if err == nil {
+		t.Fatal("Signin(nil) should error")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("err = %v; want ErrValidation", err)
+	}
+}
+
+func TestAuthManager_AuthenticateRejectsEmptyToken(t *testing.T) {
+	t.Parallel()
+
+	mgr, err := NewAuthManager(&DatabaseClient{})
+	if err != nil {
+		t.Fatalf("NewAuthManager: %v", err)
+	}
+	err = mgr.Authenticate(context.Background(), "")
+	if err == nil {
+		t.Fatal("Authenticate(empty) should error")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("err = %v; want ErrValidation", err)
+	}
+}
+
+func TestAuthManager_RefreshRequiresCachedToken(t *testing.T) {
+	t.Parallel()
+
+	mgr, err := NewAuthManager(&DatabaseClient{})
+	if err != nil {
+		t.Fatalf("NewAuthManager: %v", err)
+	}
+	err = mgr.Refresh(context.Background())
+	if err == nil {
+		t.Fatal("Refresh without a cached token should error")
+	}
+	if !errors.Is(err, surqlerrors.ErrContext) {
+		t.Fatalf("err = %v; want ErrContext", err)
+	}
+}
+
+func TestAuthManager_ConnectionFailuresPropagate(t *testing.T) {
+	t.Parallel()
+
+	// A disconnected client makes every delegated call return
+	// ErrConnection without any network I/O, which is exactly what we want
+	// for unit testing the AuthManager orchestration surface.
+	mgr, err := NewAuthManager(&DatabaseClient{})
+	if err != nil {
+		t.Fatalf("NewAuthManager: %v", err)
+	}
+
+	creds := NewRootCredentials("root", "root")
+	if _, err := mgr.Signin(context.Background(), creds); !errors.Is(err, surqlerrors.ErrConnection) {
+		t.Fatalf("Signin on disconnected client err = %v; want ErrConnection", err)
+	}
+	if _, err := mgr.Signup(
+		context.Background(),
+		NewScopeCredentials("ns", "db", "user"),
+	); !errors.Is(err, surqlerrors.ErrConnection) {
+		t.Fatalf("Signup on disconnected client err = %v; want ErrConnection", err)
+	}
+	if err := mgr.Authenticate(context.Background(), "token"); !errors.Is(err, surqlerrors.ErrConnection) {
+		t.Fatalf("Authenticate on disconnected client err = %v; want ErrConnection", err)
+	}
+	if err := mgr.Invalidate(context.Background()); !errors.Is(err, surqlerrors.ErrConnection) {
+		t.Fatalf("Invalidate on disconnected client err = %v; want ErrConnection", err)
+	}
+}

--- a/pkg/surql/connection/client.go
+++ b/pkg/surql/connection/client.go
@@ -344,6 +344,44 @@ func (c *DatabaseClient) Delete(ctx context.Context, target string) (any, error)
 	return *res, nil
 }
 
+// Info returns the authenticated session record — equivalent to SurrealQL's
+// `RETURN $auth`. For root / namespace / database sessions this resolves to
+// nil; for scope / record sessions it carries the record's contents.
+//
+// The SDK's dedicated `db.Info` RPC is *not* used here because
+// surrealdb.go v1.4.0 panics with a nil-pointer dereference when the server
+// returns a null result (non-scope sessions). Using a raw query ensures we
+// never leak that panic to callers. Py's `client.info` is implemented the
+// same way.
+func (c *DatabaseClient) Info(ctx context.Context) (map[string]any, error) {
+	raw, err := c.Query(ctx, "RETURN $auth;")
+	if err != nil {
+		return nil, surqlerrors.Wrap(surqlerrors.ErrConnection, "info failed", err)
+	}
+	// Unwrap the per-statement envelope produced by Query: []any of
+	// {status, time, result}. A null result (root/ns/db sessions) becomes
+	// a (nil, nil) return — matches py and keeps the zero-auth case cheap.
+	arr, ok := raw.([]any)
+	if !ok || len(arr) == 0 {
+		return nil, nil
+	}
+	envelope, ok := arr[0].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	result, has := envelope["result"]
+	if !has || result == nil {
+		return nil, nil
+	}
+	if m, ok := result.(map[string]any); ok {
+		return m, nil
+	}
+	// Scalar or slice result — surface under the conventional "value" key
+	// so callers have a deterministic shape to inspect. Mirrors the
+	// pushValue helper in pkg/surql/query/results.go.
+	return map[string]any{"value": result}, nil
+}
+
 // Health performs a lightweight RPC (SDK version probe) to check the
 // connection is responsive. Returns (true, nil) on success.
 func (c *DatabaseClient) Health(ctx context.Context) (bool, error) {

--- a/pkg/surql/connection/context.go
+++ b/pkg/surql/connection/context.go
@@ -1,0 +1,129 @@
+package connection
+
+import (
+	"context"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+// clientCtxKey is the unexported type used as a context value key so only this
+// package can read or write the ambient *DatabaseClient. Mirrors the
+// contextvars-based API of surql-py's `connection.context` module, but uses
+// idiomatic context.Context propagation — the caller owns the scope.
+type clientCtxKey struct{}
+
+// clientKey is the singleton key value used with context.WithValue.
+var clientKey = clientCtxKey{}
+
+// SetDB returns a new context carrying client as the ambient DatabaseClient.
+// Matches surql-py's `set_db`, except callers must thread the returned
+// context through the goroutines that need it — Go has no goroutine-local
+// storage.
+func SetDB(ctx context.Context, client *DatabaseClient) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, clientKey, client)
+}
+
+// GetDB returns the ambient DatabaseClient attached to ctx, and whether one
+// was present. Matches surql-py's `get_db`, but returns the boolean flag
+// rather than raising — callers decide whether absence is fatal.
+func GetDB(ctx context.Context) (*DatabaseClient, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	client, ok := ctx.Value(clientKey).(*DatabaseClient)
+	if !ok || client == nil {
+		return nil, false
+	}
+	return client, true
+}
+
+// MustGetDB returns the ambient DatabaseClient or an ErrContext error when no
+// client is attached. This is the closest equivalent to surql-py's raising
+// `get_db()` — useful for helper functions that want to fail loudly rather
+// than swallow a missing ambient connection.
+func MustGetDB(ctx context.Context) (*DatabaseClient, error) {
+	if client, ok := GetDB(ctx); ok {
+		return client, nil
+	}
+	return nil, surqlerrors.New(
+		surqlerrors.ErrContext,
+		"no active database connection; use ConnectionScope or SetDB first",
+	)
+}
+
+// HasDB reports whether ctx carries an ambient DatabaseClient. Matches
+// surql-py's `has_db`.
+func HasDB(ctx context.Context) bool {
+	_, ok := GetDB(ctx)
+	return ok
+}
+
+// ClearDB returns a derived context with the ambient DatabaseClient removed.
+// Matches surql-py's `clear_db`. The original ctx is untouched (contexts are
+// immutable).
+func ClearDB(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	// context.WithValue with nil typed value ensures GetDB returns (nil, false).
+	return context.WithValue(ctx, clientKey, (*DatabaseClient)(nil))
+}
+
+// ConnectionScope establishes a fresh DatabaseClient from cfg, connects it,
+// attaches it to the returned context, and returns a cleanup function.
+//
+// The cleanup disconnects the client and releases the context scope. It is
+// safe to call cleanup multiple times; only the first call performs I/O.
+// Errors from Connect propagate to the caller; a non-nil cleanup is only
+// returned on success.
+//
+// Usage:
+//
+//	ctx, cleanup, err := connection.ConnectionScope(ctx, cfg)
+//	if err != nil { ... }
+//	defer cleanup()
+//
+// Mirrors surql-py's `connection_scope` async context manager.
+func ConnectionScope(ctx context.Context, cfg ConnectionConfig) (context.Context, func(), error) {
+	client, err := NewDatabaseClient(cfg)
+	if err != nil {
+		return ctx, nil, err
+	}
+	if err := client.Connect(ctx); err != nil {
+		return ctx, nil, err
+	}
+	scoped := SetDB(ctx, client)
+	cleanup := disconnectOnce(client)
+	return scoped, cleanup, nil
+}
+
+// ConnectionOverride temporarily swaps the ambient DatabaseClient for the
+// provided one. The returned restore function removes the override and
+// returns the context to its prior state. Useful for tests or transient
+// redirection of downstream helpers that consume GetDB.
+//
+// The returned context carries the override; the original is unchanged.
+// Mirrors surql-py's `connection_override`.
+func ConnectionOverride(ctx context.Context, client *DatabaseClient) (context.Context, func()) {
+	overridden := SetDB(ctx, client)
+	// Nothing to restore on the shared context — Go contexts are immutable,
+	// so the cleanup is a no-op. The name exists so call sites can mirror
+	// the py surface and clearly delimit override scope.
+	return overridden, func() {}
+}
+
+// disconnectOnce builds a one-shot cleanup function that disconnects client
+// exactly once regardless of how many times it is invoked.
+func disconnectOnce(client *DatabaseClient) func() {
+	done := false
+	return func() {
+		if done {
+			return
+		}
+		done = true
+		_ = client.Disconnect()
+	}
+}

--- a/pkg/surql/connection/context_test.go
+++ b/pkg/surql/connection/context_test.go
@@ -1,0 +1,122 @@
+package connection
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+func TestSetDB_and_GetDB(t *testing.T) {
+	t.Parallel()
+
+	client := &DatabaseClient{}
+	ctx := SetDB(context.Background(), client)
+
+	got, ok := GetDB(ctx)
+	if !ok {
+		t.Fatal("GetDB should find the client set by SetDB")
+	}
+	if got != client {
+		t.Fatalf("GetDB = %p, want %p", got, client)
+	}
+}
+
+func TestGetDB_MissingReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"background", context.Background()},
+		{"nil context", nil},
+		{"cleared", ClearDB(SetDB(context.Background(), &DatabaseClient{}))},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, ok := GetDB(tc.ctx)
+			if ok {
+				t.Errorf("GetDB ok = true, want false")
+			}
+			if client != nil {
+				t.Errorf("GetDB client = %v, want nil", client)
+			}
+		})
+	}
+}
+
+func TestSetDB_NilContextFallback(t *testing.T) {
+	t.Parallel()
+
+	client := &DatabaseClient{}
+	ctx := SetDB(nil, client) //nolint:staticcheck // explicit nil is the point
+	got, ok := GetDB(ctx)
+	if !ok || got != client {
+		t.Fatalf("SetDB with nil ctx should fall back to Background; got=%v ok=%v", got, ok)
+	}
+}
+
+func TestHasDB(t *testing.T) {
+	t.Parallel()
+
+	if HasDB(context.Background()) {
+		t.Fatal("HasDB on bare ctx should be false")
+	}
+	if !HasDB(SetDB(context.Background(), &DatabaseClient{})) {
+		t.Fatal("HasDB after SetDB should be true")
+	}
+}
+
+func TestMustGetDB(t *testing.T) {
+	t.Parallel()
+
+	if _, err := MustGetDB(context.Background()); err == nil {
+		t.Fatal("MustGetDB on bare ctx should error")
+	} else if !errors.Is(err, surqlerrors.ErrContext) {
+		t.Fatalf("MustGetDB error = %v; want ErrContext", err)
+	}
+
+	client := &DatabaseClient{}
+	ctx := SetDB(context.Background(), client)
+	got, err := MustGetDB(ctx)
+	if err != nil {
+		t.Fatalf("MustGetDB unexpected err: %v", err)
+	}
+	if got != client {
+		t.Fatalf("MustGetDB client = %p, want %p", got, client)
+	}
+}
+
+func TestConnectionOverride_RestoresScope(t *testing.T) {
+	t.Parallel()
+
+	base := &DatabaseClient{}
+	ctx := SetDB(context.Background(), base)
+
+	override := &DatabaseClient{}
+	overridden, restore := ConnectionOverride(ctx, override)
+	got, _ := GetDB(overridden)
+	if got != override {
+		t.Fatalf("override ctx should carry override client; got=%p want=%p", got, override)
+	}
+	// Original context should still carry the base client because Go
+	// contexts are immutable.
+	if orig, _ := GetDB(ctx); orig != base {
+		t.Fatalf("original ctx lost its client after override: got=%p want=%p", orig, base)
+	}
+	restore()
+}
+
+func TestClearDB_ReturnsBackgroundWhenNil(t *testing.T) {
+	t.Parallel()
+
+	ctx := ClearDB(nil) //nolint:staticcheck // explicit nil is the point
+	if ctx == nil {
+		t.Fatal("ClearDB(nil) must return a non-nil context")
+	}
+	if HasDB(ctx) {
+		t.Fatal("ClearDB(nil) should carry no client")
+	}
+}

--- a/pkg/surql/connection/extensions_integration_test.go
+++ b/pkg/surql/connection/extensions_integration_test.go
@@ -1,0 +1,174 @@
+//go:build integration
+// +build integration
+
+package connection
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestIntegration_ConnectionScope(t *testing.T) {
+	url := getIntegrationURL(t)
+
+	cfg := DefaultConfig()
+	cfg.DBURL = url
+	cfg.DBNS = "surqlgo_test"
+	cfg.DB = "connection_scope"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	scoped, cleanup, err := ConnectionScope(ctx, cfg)
+	if err != nil {
+		t.Fatalf("ConnectionScope: %v", err)
+	}
+	defer cleanup()
+
+	client, ok := GetDB(scoped)
+	if !ok {
+		t.Fatal("scope ctx should carry a DatabaseClient")
+	}
+	if !client.IsConnected() {
+		t.Fatal("scope client should be connected")
+	}
+
+	// Sanity: the scoped client responds to a health probe.
+	ok2, err := client.Health(ctx)
+	if err != nil || !ok2 {
+		t.Fatalf("Health: ok=%v err=%v", ok2, err)
+	}
+
+	// cleanup() should disconnect and subsequent calls should be no-ops.
+	cleanup()
+	if client.IsConnected() {
+		t.Fatal("cleanup should disconnect the scoped client")
+	}
+}
+
+func TestIntegration_Registry_LiveClient(t *testing.T) {
+	url := getIntegrationURL(t)
+
+	r := NewRegistry()
+
+	cfg := DefaultConfig()
+	cfg.DBURL = url
+	cfg.DBNS = "surqlgo_test"
+	cfg.DB = "registry"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	client, err := r.Register(ctx, "primary", cfg, nil)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	defer func() { _ = r.Clear(ctx) }()
+
+	if !client.IsConnected() {
+		t.Fatal("registered client should be connected when Connect!=false")
+	}
+	if got, err := r.Get(""); err != nil || got != client {
+		t.Fatalf("Get default: got=%p err=%v want=%p", got, err, client)
+	}
+
+	if err := r.Unregister(ctx, "primary", true); err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+	if client.IsConnected() {
+		t.Fatal("Unregister with disconnect should close the client")
+	}
+}
+
+func TestIntegration_AuthManager_SigninRoot(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+
+	mgr, err := NewAuthManager(client)
+	if err != nil {
+		t.Fatalf("NewAuthManager: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	user := envOr("SURREAL_USER", "root")
+	pass := envOr("SURREAL_PASS", "root")
+
+	if _, err := mgr.Signin(ctx, NewRootCredentials(user, pass)); err != nil {
+		t.Fatalf("Signin: %v", err)
+	}
+	if !mgr.IsAuthenticated() {
+		t.Fatal("manager should be authenticated after Signin")
+	}
+	if got := mgr.AuthType(); got != AuthRoot {
+		t.Fatalf("AuthType = %q; want root", got)
+	}
+	if mgr.CurrentToken() == "" {
+		t.Fatal("CurrentToken should be populated after Signin")
+	}
+
+	// Refresh should succeed with the cached token.
+	if err := mgr.Refresh(ctx); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+}
+
+func TestIntegration_ClientInfo(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Root sessions return nil (or empty) for Info; scope sessions return
+	// the record. Here we just assert the RPC doesn't error — content is
+	// out of scope for parity.
+	if _, err := client.Info(ctx); err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+}
+
+func TestIntegration_StreamingManager_Lifecycle(t *testing.T) {
+	// surrealdb.go v1.4.0 panics with "send on closed channel" during
+	// teardown: Kill closes the notification channel while the SDK's
+	// readLoop goroutine is still writing to it. Same symptom as issue #59
+	// / the TestIntegration_LiveQueryReceivesChange skip.
+	t.Skip("surrealdb.go v1.4.0 has a shutdown race in CloseLiveNotifications; re-enable once fixed upstream")
+
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+
+	mgr, err := NewStreamingManager(client)
+	if err != nil {
+		t.Fatalf("NewStreamingManager: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	table := "surqlgo_stream_mgr"
+	cleanupTable(t, client, table)
+	if _, err := client.Query(ctx, "DEFINE TABLE "+table+";"); err != nil {
+		t.Fatalf("DEFINE TABLE: %v", err)
+	}
+
+	live, err := mgr.Spawn(ctx, table, false)
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if mgr.Count() != 1 {
+		t.Fatalf("Count after Spawn = %d; want 1", mgr.Count())
+	}
+	if live.ID() == "" {
+		t.Fatal("Live query should have an ID")
+	}
+
+	if err := mgr.DrainAll(ctx); err != nil {
+		t.Fatalf("DrainAll: %v", err)
+	}
+	if mgr.Count() != 0 {
+		t.Fatalf("Count after DrainAll = %d; want 0", mgr.Count())
+	}
+}

--- a/pkg/surql/connection/registry.go
+++ b/pkg/surql/connection/registry.go
@@ -1,0 +1,289 @@
+package connection
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+// Registry is a thread-safe map of named DatabaseClient connections. It
+// mirrors surql-py's `ConnectionRegistry` singleton but is a plain struct
+// behind an RWMutex — Go does not need async primitives for this.
+//
+// The zero value is not usable; consumers interact with the package-level
+// default via GetRegistry, or construct ad-hoc registries with
+// NewRegistry for isolation in tests.
+type Registry struct {
+	mu          sync.RWMutex
+	connections map[string]*DatabaseClient
+	configs     map[string]ConnectionConfig
+	defaultName string
+}
+
+// NewRegistry constructs an empty Registry. Most callers should use
+// GetRegistry to share the package-level singleton; NewRegistry is handy in
+// tests that want a pristine namespace.
+func NewRegistry() *Registry {
+	return &Registry{
+		connections: map[string]*DatabaseClient{},
+		configs:     map[string]ConnectionConfig{},
+	}
+}
+
+// defaultRegistry is the package-level singleton returned by GetRegistry.
+var defaultRegistry = NewRegistry()
+
+// GetRegistry returns the shared Registry used by the library's global
+// connection namespace. Mirrors surql-py's `get_registry()`.
+func GetRegistry() *Registry {
+	return defaultRegistry
+}
+
+// RegisterOptions tunes the behaviour of Register.
+//
+// Defaults (zero value):
+//   - Connect:    true  — dial the database immediately.
+//   - SetDefault: false — only the first registered connection becomes default.
+//
+// Pointers are used so callers can distinguish "not set" from the zero value,
+// letting them override specific fields without copy-and-paste defaults.
+type RegisterOptions struct {
+	// Connect, when non-nil, controls whether the client is connected
+	// during registration. Defaults to true.
+	Connect *bool
+	// SetDefault, when non-nil and true, marks the newly registered
+	// connection as the default. Defaults to false, except that the first
+	// registered connection always becomes the default.
+	SetDefault *bool
+}
+
+// Register adds a new named connection. Returns ErrRegistry if name is
+// already in use.
+//
+// If opts.Connect is nil or *true, the client is connected synchronously
+// with ctx; the Connect error is returned verbatim on failure (the registry
+// is left unchanged).
+//
+// The first connection ever registered becomes the default; explicit
+// opts.SetDefault==true promotes a later connection ahead of it.
+func (r *Registry) Register(
+	ctx context.Context,
+	name string,
+	cfg ConnectionConfig,
+	opts *RegisterOptions,
+) (*DatabaseClient, error) {
+	if name == "" {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "connection name cannot be empty")
+	}
+
+	connect := true
+	setDefault := false
+	if opts != nil {
+		if opts.Connect != nil {
+			connect = *opts.Connect
+		}
+		if opts.SetDefault != nil {
+			setDefault = *opts.SetDefault
+		}
+	}
+
+	// Build the client outside the lock so its Connect (a blocking
+	// network call) doesn't serialise registry access. We only grab the
+	// lock once I/O has completed.
+	client, err := NewDatabaseClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if connect {
+		if err := client.Connect(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.connections[name]; exists {
+		if connect {
+			// Undo the connection we just made so we don't leak sockets.
+			_ = client.Disconnect()
+		}
+		return nil, surqlerrors.Newf(
+			surqlerrors.ErrRegistry,
+			"connection %q already registered", name,
+		)
+	}
+
+	r.connections[name] = client
+	r.configs[name] = cfg
+	if setDefault || r.defaultName == "" {
+		r.defaultName = name
+	}
+	return client, nil
+}
+
+// Unregister removes the named connection and, when disconnect is true,
+// closes it.
+//
+// Returns ErrRegistry if the connection does not exist. When the removed
+// connection was the default, the default falls back to the
+// lexicographically first remaining entry (or empty if none remain).
+func (r *Registry) Unregister(ctx context.Context, name string, disconnect bool) error {
+	r.mu.Lock()
+	client, exists := r.connections[name]
+	if !exists {
+		r.mu.Unlock()
+		return surqlerrors.Newf(surqlerrors.ErrRegistry, "connection %q not found", name)
+	}
+	delete(r.connections, name)
+	delete(r.configs, name)
+	if r.defaultName == name {
+		r.defaultName = firstName(r.connections)
+	}
+	r.mu.Unlock()
+
+	if disconnect && client != nil {
+		if err := client.Disconnect(); err != nil {
+			return err
+		}
+	}
+	_ = ctx // retained for symmetry with py; Disconnect currently ignores ctx
+	return nil
+}
+
+// Get returns the named connection or, when name is empty, the default
+// connection. Returns ErrRegistry when the connection does not exist.
+func (r *Registry) Get(name string) (*DatabaseClient, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if name == "" {
+		if r.defaultName == "" {
+			return nil, surqlerrors.New(surqlerrors.ErrRegistry, "no default connection set")
+		}
+		name = r.defaultName
+	}
+	client, ok := r.connections[name]
+	if !ok {
+		return nil, surqlerrors.Newf(surqlerrors.ErrRegistry, "connection %q not found", name)
+	}
+	return client, nil
+}
+
+// GetConfig returns the configuration for the named connection (or default
+// when name is empty). Returns ErrRegistry when the connection does not exist.
+func (r *Registry) GetConfig(name string) (ConnectionConfig, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if name == "" {
+		if r.defaultName == "" {
+			return ConnectionConfig{}, surqlerrors.New(
+				surqlerrors.ErrRegistry, "no default connection set",
+			)
+		}
+		name = r.defaultName
+	}
+	cfg, ok := r.configs[name]
+	if !ok {
+		return ConnectionConfig{}, surqlerrors.Newf(
+			surqlerrors.ErrRegistry, "connection %q not found", name,
+		)
+	}
+	return cfg, nil
+}
+
+// SetDefault promotes name to the default connection. Returns ErrRegistry
+// when the connection does not exist.
+func (r *Registry) SetDefault(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.connections[name]; !ok {
+		return surqlerrors.Newf(surqlerrors.ErrRegistry, "connection %q not found", name)
+	}
+	r.defaultName = name
+	return nil
+}
+
+// DefaultName returns the name of the default connection (empty string when
+// none is set).
+func (r *Registry) DefaultName() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.defaultName
+}
+
+// List returns the registered connection names sorted lexicographically so
+// the output is stable across calls.
+func (r *Registry) List() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.connections))
+	for name := range r.connections {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// DisconnectAll closes every registered connection. The registry entries
+// remain; call Clear to also remove them.
+//
+// The first non-nil Disconnect error is returned after attempting every
+// connection, so callers still drain the full set.
+func (r *Registry) DisconnectAll(ctx context.Context) error {
+	r.mu.RLock()
+	clients := make([]*DatabaseClient, 0, len(r.connections))
+	for _, c := range r.connections {
+		clients = append(clients, c)
+	}
+	r.mu.RUnlock()
+
+	var firstErr error
+	for _, c := range clients {
+		if c == nil || !c.IsConnected() {
+			continue
+		}
+		if err := c.Disconnect(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	_ = ctx
+	return firstErr
+}
+
+// Clear disconnects and removes every registered connection, leaving the
+// registry empty. Errors from DisconnectAll are returned verbatim.
+func (r *Registry) Clear(ctx context.Context) error {
+	if err := r.DisconnectAll(ctx); err != nil {
+		// Drain the map even when Disconnect fails so consumers are not
+		// stuck with phantom entries.
+		r.mu.Lock()
+		r.connections = map[string]*DatabaseClient{}
+		r.configs = map[string]ConnectionConfig{}
+		r.defaultName = ""
+		r.mu.Unlock()
+		return err
+	}
+	r.mu.Lock()
+	r.connections = map[string]*DatabaseClient{}
+	r.configs = map[string]ConnectionConfig{}
+	r.defaultName = ""
+	r.mu.Unlock()
+	return nil
+}
+
+// firstName returns the lexicographically first key in m, or the empty
+// string when m is empty. Used to pick a fallback default when the current
+// default is removed.
+func firstName(m map[string]*DatabaseClient) string {
+	if len(m) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names[0]
+}

--- a/pkg/surql/connection/registry_test.go
+++ b/pkg/surql/connection/registry_test.go
@@ -1,0 +1,242 @@
+package connection
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+// ptrBool returns &v; a small helper for RegisterOptions fields.
+func ptrBool(v bool) *bool { return &v }
+
+func TestRegistry_Register_BasicFlow(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	cfg := DefaultConfig()
+
+	client, err := r.Register(context.Background(), "primary", cfg, &RegisterOptions{Connect: ptrBool(false)})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if client == nil {
+		t.Fatal("Register returned nil client")
+	}
+	if r.DefaultName() != "primary" {
+		t.Fatalf("default name = %q, want primary (first registered auto-promotes)", r.DefaultName())
+	}
+
+	got, err := r.Get("primary")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != client {
+		t.Fatalf("Get returned %p, want %p", got, client)
+	}
+
+	// Default lookup (empty name) should hit the same entry.
+	defaultGot, err := r.Get("")
+	if err != nil {
+		t.Fatalf("Get default: %v", err)
+	}
+	if defaultGot != client {
+		t.Fatalf("Get default returned %p, want %p", defaultGot, client)
+	}
+}
+
+func TestRegistry_Register_DuplicateRejected(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	cfg := DefaultConfig()
+	if _, err := r.Register(context.Background(), "primary", cfg, &RegisterOptions{Connect: ptrBool(false)}); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+
+	_, err := r.Register(context.Background(), "primary", cfg, &RegisterOptions{Connect: ptrBool(false)})
+	if err == nil {
+		t.Fatal("second Register should fail")
+	}
+	if !errors.Is(err, surqlerrors.ErrRegistry) {
+		t.Fatalf("err = %v; want ErrRegistry", err)
+	}
+}
+
+func TestRegistry_EmptyName(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	_, err := r.Register(context.Background(), "", DefaultConfig(), &RegisterOptions{Connect: ptrBool(false)})
+	if err == nil {
+		t.Fatal("Register with empty name should fail")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("err = %v; want ErrValidation", err)
+	}
+}
+
+func TestRegistry_SetDefault_Promotion(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	cfg := DefaultConfig()
+
+	if _, err := r.Register(context.Background(), "primary", cfg, &RegisterOptions{Connect: ptrBool(false)}); err != nil {
+		t.Fatalf("Register primary: %v", err)
+	}
+	if _, err := r.Register(
+		context.Background(), "replica", cfg,
+		&RegisterOptions{Connect: ptrBool(false), SetDefault: ptrBool(true)},
+	); err != nil {
+		t.Fatalf("Register replica: %v", err)
+	}
+
+	if got := r.DefaultName(); got != "replica" {
+		t.Fatalf("default name = %q, want replica", got)
+	}
+	if err := r.SetDefault("primary"); err != nil {
+		t.Fatalf("SetDefault primary: %v", err)
+	}
+	if got := r.DefaultName(); got != "primary" {
+		t.Fatalf("default name after SetDefault = %q, want primary", got)
+	}
+
+	if err := r.SetDefault("missing"); err == nil {
+		t.Fatal("SetDefault on unknown name should fail")
+	}
+}
+
+func TestRegistry_Unregister(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	cfg := DefaultConfig()
+	for _, name := range []string{"a", "b", "c"} {
+		if _, err := r.Register(context.Background(), name, cfg, &RegisterOptions{Connect: ptrBool(false)}); err != nil {
+			t.Fatalf("Register %q: %v", name, err)
+		}
+	}
+
+	if err := r.Unregister(context.Background(), "a", false); err != nil {
+		t.Fatalf("Unregister a: %v", err)
+	}
+
+	// "a" was the default (registered first); the fallback goes to the
+	// next entry in sort order ("b").
+	if got := r.DefaultName(); got != "b" {
+		t.Fatalf("default name after unregistering 'a' = %q, want b", got)
+	}
+
+	if err := r.Unregister(context.Background(), "missing", false); err == nil {
+		t.Fatal("Unregister unknown should fail")
+	} else if !errors.Is(err, surqlerrors.ErrRegistry) {
+		t.Fatalf("err = %v; want ErrRegistry", err)
+	}
+}
+
+func TestRegistry_List_Sorted(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	for _, name := range []string{"zeta", "alpha", "mu"} {
+		if _, err := r.Register(context.Background(), name, DefaultConfig(), &RegisterOptions{Connect: ptrBool(false)}); err != nil {
+			t.Fatalf("Register %q: %v", name, err)
+		}
+	}
+	got := r.List()
+	want := []string{"alpha", "mu", "zeta"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("List() = %v; want %v", got, want)
+	}
+	// Defensive: a second call should return a distinct slice but the same content.
+	if &got[0] == &r.List()[0] {
+		t.Fatal("List returned the internal slice, not a copy")
+	}
+}
+
+func TestRegistry_GetConfig(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	cfg := DefaultConfig()
+	cfg.DBNS = "custom"
+	if _, err := r.Register(context.Background(), "primary", cfg, &RegisterOptions{Connect: ptrBool(false)}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	got, err := r.GetConfig("primary")
+	if err != nil {
+		t.Fatalf("GetConfig: %v", err)
+	}
+	if got.DBNS != "custom" {
+		t.Fatalf("cfg.DBNS = %q, want custom", got.DBNS)
+	}
+	if _, err := r.GetConfig("missing"); err == nil {
+		t.Fatal("GetConfig unknown should fail")
+	}
+}
+
+func TestRegistry_Clear(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	for _, name := range []string{"a", "b"} {
+		if _, err := r.Register(context.Background(), name, DefaultConfig(), &RegisterOptions{Connect: ptrBool(false)}); err != nil {
+			t.Fatalf("Register %q: %v", name, err)
+		}
+	}
+	if err := r.Clear(context.Background()); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	if got := r.List(); len(got) != 0 {
+		t.Fatalf("List() after Clear = %v; want empty", got)
+	}
+	if got := r.DefaultName(); got != "" {
+		t.Fatalf("DefaultName() after Clear = %q; want empty", got)
+	}
+}
+
+func TestRegistry_ConcurrentRegistration(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	cfg := DefaultConfig()
+	names := []string{"n1", "n2", "n3", "n4", "n5"}
+
+	var wg sync.WaitGroup
+	wg.Add(len(names))
+	errs := make(chan error, len(names))
+	for _, name := range names {
+		go func(n string) {
+			defer wg.Done()
+			if _, err := r.Register(context.Background(), n, cfg, &RegisterOptions{Connect: ptrBool(false)}); err != nil {
+				errs <- err
+			}
+		}(name)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent Register: %v", err)
+	}
+
+	got := r.List()
+	want := append([]string{}, names...)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("List() = %v; want %v", got, want)
+	}
+}
+
+func TestGetRegistry_Singleton(t *testing.T) {
+	t.Parallel()
+
+	if GetRegistry() != GetRegistry() {
+		t.Fatal("GetRegistry should return the same singleton on every call")
+	}
+}

--- a/pkg/surql/connection/streaming_manager.go
+++ b/pkg/surql/connection/streaming_manager.go
@@ -1,0 +1,109 @@
+package connection
+
+import (
+	"context"
+	"sync"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+// StreamingManager owns a set of LiveQuery subscriptions belonging to a
+// single DatabaseClient. It exposes a lifecycle surface (Spawn/Kill/Count/
+// DrainAll) so consumers can fan out many live queries and tear them down
+// uniformly. Mirrors surql-py's `connection.streaming.StreamingManager`,
+// adapted to idiomatic Go with a sync.Mutex rather than anyio.
+//
+// The zero value is not usable; construct via NewStreamingManager. All
+// methods are safe for concurrent use.
+type StreamingManager struct {
+	client *DatabaseClient
+
+	mu      sync.Mutex
+	queries map[string]*LiveQuery
+}
+
+// NewStreamingManager wraps client with a LiveQuery registry. The client
+// must be non-nil; spawning a LiveQuery further requires the client to use
+// a WebSocket transport (non-HTTP).
+func NewStreamingManager(client *DatabaseClient) (*StreamingManager, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	return &StreamingManager{
+		client:  client,
+		queries: map[string]*LiveQuery{},
+	}, nil
+}
+
+// Spawn opens a LIVE SELECT on table and registers the resulting LiveQuery
+// so it can be killed or drained later. Returns the LiveQuery as-is so
+// callers can range over its notification channel.
+func (m *StreamingManager) Spawn(ctx context.Context, table string, diff bool) (*LiveQuery, error) {
+	live, err := m.client.Live(ctx, table, diff)
+	if err != nil {
+		return nil, err
+	}
+	m.mu.Lock()
+	m.queries[live.ID()] = live
+	m.mu.Unlock()
+	return live, nil
+}
+
+// Kill closes the subscription identified by id and removes it from the
+// registry. Returns ErrValidation if id is unknown.
+func (m *StreamingManager) Kill(ctx context.Context, id string) error {
+	if id == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "live query id cannot be empty")
+	}
+	m.mu.Lock()
+	live, ok := m.queries[id]
+	if ok {
+		delete(m.queries, id)
+	}
+	m.mu.Unlock()
+
+	if !ok {
+		return surqlerrors.Newf(surqlerrors.ErrStreaming, "live query %q not found", id)
+	}
+	return live.Close(ctx)
+}
+
+// Count returns the number of live subscriptions currently tracked.
+func (m *StreamingManager) Count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.queries)
+}
+
+// Queries returns a snapshot slice of the tracked LiveQuery values. The
+// slice is a copy so callers are free to iterate without holding the lock.
+func (m *StreamingManager) Queries() []*LiveQuery {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*LiveQuery, 0, len(m.queries))
+	for _, q := range m.queries {
+		out = append(out, q)
+	}
+	return out
+}
+
+// DrainAll closes every tracked subscription. The first non-nil Close error
+// is returned after every queue entry has been attempted, so one bad
+// subscription cannot starve the rest of the drain.
+func (m *StreamingManager) DrainAll(ctx context.Context) error {
+	m.mu.Lock()
+	queries := make([]*LiveQuery, 0, len(m.queries))
+	for _, q := range m.queries {
+		queries = append(queries, q)
+	}
+	m.queries = map[string]*LiveQuery{}
+	m.mu.Unlock()
+
+	var firstErr error
+	for _, q := range queries {
+		if err := q.Close(ctx); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/pkg/surql/connection/streaming_manager_test.go
+++ b/pkg/surql/connection/streaming_manager_test.go
@@ -1,0 +1,99 @@
+package connection
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+func TestNewStreamingManager_RejectsNilClient(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewStreamingManager(nil)
+	if err == nil {
+		t.Fatal("NewStreamingManager(nil) should error")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("err = %v; want ErrValidation", err)
+	}
+}
+
+func TestStreamingManager_ZeroCount(t *testing.T) {
+	t.Parallel()
+
+	mgr, err := NewStreamingManager(&DatabaseClient{})
+	if err != nil {
+		t.Fatalf("NewStreamingManager: %v", err)
+	}
+	if got := mgr.Count(); got != 0 {
+		t.Fatalf("Count() = %d, want 0", got)
+	}
+	if got := mgr.Queries(); len(got) != 0 {
+		t.Fatalf("Queries() = %v; want empty", got)
+	}
+}
+
+func TestStreamingManager_SpawnOnDisconnectedClient(t *testing.T) {
+	t.Parallel()
+
+	mgr, err := NewStreamingManager(&DatabaseClient{})
+	if err != nil {
+		t.Fatalf("NewStreamingManager: %v", err)
+	}
+	// The DatabaseClient zero value has no cfg.DBURL, so Protocol() will
+	// reject before we even reach requireDB. Either way, spawn must fail
+	// with a validation error rather than panic.
+	_, err = mgr.Spawn(context.Background(), "person", false)
+	if err == nil {
+		t.Fatal("Spawn on disconnected client should fail")
+	}
+}
+
+func TestStreamingManager_KillRejectsEmptyID(t *testing.T) {
+	t.Parallel()
+
+	mgr, err := NewStreamingManager(&DatabaseClient{})
+	if err != nil {
+		t.Fatalf("NewStreamingManager: %v", err)
+	}
+	err = mgr.Kill(context.Background(), "")
+	if err == nil {
+		t.Fatal("Kill(\"\") should error")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("err = %v; want ErrValidation", err)
+	}
+}
+
+func TestStreamingManager_KillUnknownID(t *testing.T) {
+	t.Parallel()
+
+	mgr, err := NewStreamingManager(&DatabaseClient{})
+	if err != nil {
+		t.Fatalf("NewStreamingManager: %v", err)
+	}
+	err = mgr.Kill(context.Background(), "never-spawned")
+	if err == nil {
+		t.Fatal("Kill on unknown id should error")
+	}
+	if !errors.Is(err, surqlerrors.ErrStreaming) {
+		t.Fatalf("err = %v; want ErrStreaming", err)
+	}
+}
+
+func TestStreamingManager_DrainAllOnEmpty(t *testing.T) {
+	t.Parallel()
+
+	mgr, err := NewStreamingManager(&DatabaseClient{})
+	if err != nil {
+		t.Fatalf("NewStreamingManager: %v", err)
+	}
+	if err := mgr.DrainAll(context.Background()); err != nil {
+		t.Fatalf("DrainAll on empty manager: %v", err)
+	}
+	if got := mgr.Count(); got != 0 {
+		t.Fatalf("Count() = %d after drain; want 0", got)
+	}
+}

--- a/pkg/surql/migration/applied_versions_test.go
+++ b/pkg/surql/migration/applied_versions_test.go
@@ -1,0 +1,21 @@
+package migration
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+func TestGetAppliedVersions_NilClient(t *testing.T) {
+	t.Parallel()
+
+	_, err := GetAppliedVersions(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil client")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("err = %v; want ErrValidation", err)
+	}
+}

--- a/pkg/surql/migration/history.go
+++ b/pkg/surql/migration/history.go
@@ -164,6 +164,23 @@ func GetAppliedMigrations(ctx context.Context, client *connection.DatabaseClient
 	return migrations, nil
 }
 
+// GetAppliedVersions returns the set of version strings for every applied
+// migration, backed by GetAppliedMigrations. The returned map is suitable
+// for O(1) membership tests — Go's idiomatic "set" shape.
+//
+// Mirrors surql-py's `get_applied_versions`.
+func GetAppliedVersions(ctx context.Context, client *connection.DatabaseClient) (map[string]struct{}, error) {
+	migrations, err := GetAppliedMigrations(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]struct{}, len(migrations))
+	for _, m := range migrations {
+		out[m.Version] = struct{}{}
+	}
+	return out, nil
+}
+
 // IsMigrationApplied reports whether the given version has a history entry.
 func IsMigrationApplied(ctx context.Context, client *connection.DatabaseClient, version string) (bool, error) {
 	if client == nil {

--- a/pkg/surql/query/crud.go
+++ b/pkg/surql/query/crud.go
@@ -226,6 +226,27 @@ func QueryRecords(ctx context.Context, client *connection.DatabaseClient, table 
 	return ExtractResult(raw), nil
 }
 
+// QueryRecordsWrapped runs QueryRecords and returns the resulting rows
+// wrapped in a ListResult, retaining the Limit/Offset hints from opts so
+// downstream callers can inspect pagination metadata without re-threading
+// them manually. Mirrors surql-py's `query_records_wrapped`.
+func QueryRecordsWrapped(ctx context.Context, client *connection.DatabaseClient, table string, opts QueryOptions) (ListResult[map[string]any], error) {
+	rows, err := QueryRecords(ctx, client, table, opts)
+	if err != nil {
+		return ListResult[map[string]any]{}, err
+	}
+	var limit, offset *uint64
+	if opts.Limit != nil {
+		v := uint64(*opts.Limit)
+		limit = &v
+	}
+	if opts.Offset != nil {
+		v := uint64(*opts.Offset)
+		offset = &v
+	}
+	return Records(rows, nil, limit, offset), nil
+}
+
 // CountRecords returns `count()` for table, optionally scoped by a
 // condition (string or types.Operator).
 func CountRecords(ctx context.Context, client *connection.DatabaseClient, table string, condition any) (int64, error) {

--- a/pkg/surql/query/executor.go
+++ b/pkg/surql/query/executor.go
@@ -85,6 +85,23 @@ func FetchMany[T any](ctx context.Context, client *connection.DatabaseClient, q 
 	return Records[T](items, nil, limit, offset), nil
 }
 
+// FetchRecord executes q and wraps the first decoded row in a RecordResult.
+// Returns a RecordResult whose Exists flag is false when the query yielded
+// no rows, mirroring surql-py's `fetch_record`.
+func FetchRecord[T any](ctx context.Context, client *connection.DatabaseClient, q Query) (RecordResult[T], error) {
+	rec, err := FetchOne[T](ctx, client, q)
+	if err != nil {
+		return RecordResult[T]{}, err
+	}
+	return Record(rec, rec != nil), nil
+}
+
+// FetchRecords executes q and wraps the decoded rows in a ListResult that
+// retains the Limit/Offset hints from q. Mirrors surql-py's `fetch_records`.
+func FetchRecords[T any](ctx context.Context, client *connection.DatabaseClient, q Query) (ListResult[T], error) {
+	return FetchMany[T](ctx, client, q)
+}
+
 // ExecuteRawTyped runs a raw SurrealQL query and decodes every row into T.
 func ExecuteRawTyped[T any](ctx context.Context, client *connection.DatabaseClient, surql string, vars map[string]any) ([]T, error) {
 	raw, err := ExecuteRaw(ctx, client, surql, vars)

--- a/pkg/surql/query/fetch_wrapped_test.go
+++ b/pkg/surql/query/fetch_wrapped_test.go
@@ -1,0 +1,67 @@
+package query
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+func TestFetchRecord_NilClient(t *testing.T) {
+	t.Parallel()
+
+	q, err := Query{}.Select(nil).FromTable("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := FetchRecord[map[string]any](context.Background(), nil, q); err == nil {
+		t.Fatal("expected error for nil client")
+	} else if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("err = %v; want ErrValidation", err)
+	}
+}
+
+func TestFetchRecords_NilClient(t *testing.T) {
+	t.Parallel()
+
+	q, err := Query{}.Select(nil).FromTable("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := FetchRecords[map[string]any](context.Background(), nil, q); err == nil {
+		t.Fatal("expected error for nil client")
+	} else if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("err = %v; want ErrValidation", err)
+	}
+}
+
+func TestQueryRecordsWrapped_NilClient(t *testing.T) {
+	t.Parallel()
+
+	if _, err := QueryRecordsWrapped(context.Background(), nil, "user", QueryOptions{}); err == nil {
+		t.Fatal("expected error for nil client")
+	}
+}
+
+func TestQueryRecordsWrapped_HasMore_RetainsLimit(t *testing.T) {
+	t.Parallel()
+
+	// Exercise the non-DB-path: we drive a QueryRecordsWrapped-like flow
+	// manually to ensure Records() preserves Limit/Offset hints, mirroring
+	// surql-py's wrapper semantics. QueryRecordsWrapped itself needs a
+	// client, but the underlying wrapping is table-driven.
+	items := []map[string]any{{"id": "a"}, {"id": "b"}, {"id": "c"}}
+	limit := uint64(3)
+	offset := uint64(0)
+	got := Records(items, nil, &limit, &offset)
+	if !got.HasMore {
+		t.Fatal("Records should flag HasMore when len(items)==limit")
+	}
+	if got.Limit == nil || *got.Limit != 3 {
+		t.Fatalf("Limit = %v; want 3", got.Limit)
+	}
+	if got.Offset == nil || *got.Offset != 0 {
+		t.Fatalf("Offset = %v; want 0", got.Offset)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the connection-module parity gap vs `surql-py` / `surql-rs` and fills the remaining `DatabaseClient` surface.

### New modules
- `context.go` — context-keyed ambient `DatabaseClient` (`GetDB`, `SetDB`, `HasDB`, `ClearDB`, `ConnectionScope`, `ConnectionOverride`, `MustGetDB`). Go has no `contextvars` analog; callers thread the returned context explicitly.
- `registry.go` — thread-safe `ConnectionRegistry` with `sync.RWMutex`; package-level singleton via `GetRegistry()`. First registered auto-promotes to default. `RegisterOptions.Connect` is `*bool` to distinguish unset from false.
- `auth_manager.go` — async signin/signup/authenticate/invalidate/refresh orchestrator.
- `streaming_manager.go` — typed wrapper around `LiveQuery` lifecycle (`Spawn`/`Kill(id)`/`Count`/`DrainAll`). Uses `map[id]LiveQuery`, not object identity. Integration test reuses the existing `CloseLiveNotifications` race skip referencing #59.

### DatabaseClient methods added
- `Signup` (was rolled into `Authenticate`)
- `Invalidate` (was rolled into `Disconnect`)
- `Info` — explicitly uses raw `RETURN $auth` query rather than SDK's `db.Info` RPC. `surrealdb.go v1.4.0` unconditionally dereferences `*info.Result`, panicking on null results from root/ns/db sessions. Matches py behaviour; avoids band-aid recover.

### Query + migration additions
- `executor.go`: `FetchRecord`, `FetchRecords`
- `crud.go`: `QueryRecordsWrapped`
- `migration/history.go`: `GetAppliedVersions`

## Test plan

- [x] `gofmt -l .` empty
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./... -race -count=1` — 928 → 962 (+34)
- [x] `go test -tags=integration ./...` against `surrealdb/surrealdb:v3.0.5` — green in all 6 packages

Refs #58, closes #62.