### PR TITLE
feat(orchestration): add EnvironmentConfig/Coordinator/HealthCheck/Strategies

### DIFF
--- a/pkg/surql/orchestration/coordinator.go
+++ b/pkg/surql/orchestration/coordinator.go
@@ -1,0 +1,251 @@
+package orchestration
+
+import (
+	"context"
+	"strings"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/migration"
+)
+
+// DeployOptions tunes MigrationCoordinator.DeployToEnvironments. The
+// zero-value option set matches surql-py's defaults: sequential strategy,
+// health verification on, auto-rollback on, dry-run off.
+type DeployOptions struct {
+	// Strategy is the named strategy to use. Defaults to "sequential".
+	Strategy StrategyName
+	// BatchSize applies to rolling deployments.
+	BatchSize int
+	// CanaryPercentage applies to canary deployments.
+	CanaryPercentage float64
+	// MaxConcurrent applies to parallel deployments.
+	MaxConcurrent int
+	// VerifyHealth runs the health check against every environment before
+	// deploying. Defaults to true.
+	VerifyHealth *bool
+	// AutoRollback issues DOWN migrations on previously successful
+	// environments when any deploy fails. Defaults to true.
+	AutoRollback *bool
+	// DryRun bypasses migration execution and the health check while
+	// still producing realistic DeploymentResult shapes.
+	DryRun bool
+	// Factory overrides the DatabaseClient constructor. Nil uses the
+	// production factory (dials the real database).
+	Factory ClientFactory
+	// HealthCheck overrides the health prober. Nil uses the default. The
+	// factory is propagated from Factory if the supplied HealthCheck
+	// carries its own nil factory.
+	HealthCheck *HealthCheck
+}
+
+// resolveBools applies defaults for the tri-state pointer fields.
+func (o DeployOptions) resolveBools() (verify, rollback bool) {
+	verify, rollback = true, true
+	if o.VerifyHealth != nil {
+		verify = *o.VerifyHealth
+	}
+	if o.AutoRollback != nil {
+		rollback = *o.AutoRollback
+	}
+	return
+}
+
+// MigrationCoordinator orchestrates migration deploys across an
+// EnvironmentRegistry. Construct with NewMigrationCoordinator.
+type MigrationCoordinator struct {
+	registry    *EnvironmentRegistry
+	healthCheck *HealthCheck
+}
+
+// NewMigrationCoordinator builds a coordinator bound to registry. Pass
+// GetRegistry() to use the package-level singleton.
+func NewMigrationCoordinator(registry *EnvironmentRegistry) *MigrationCoordinator {
+	if registry == nil {
+		registry = GetRegistry()
+	}
+	return &MigrationCoordinator{
+		registry:    registry,
+		healthCheck: NewHealthCheck(),
+	}
+}
+
+// Registry returns the registry the coordinator was built with.
+func (c *MigrationCoordinator) Registry() *EnvironmentRegistry { return c.registry }
+
+// DeployToEnvironments resolves environments, optionally verifies their
+// health, dispatches to the requested strategy, and optionally rolls back
+// on failure. Returns per-environment results keyed by environment name.
+//
+// Errors fall into two buckets:
+//   - ErrOrchestration when a precondition fails (unknown environment,
+//     unhealthy environment, unknown strategy, ...).
+//   - A wrapped strategy error when the strategy implementation itself
+//     fails (rare — most failures surface via DeploymentResult.Status).
+func (c *MigrationCoordinator) DeployToEnvironments(
+	ctx context.Context,
+	environments []string,
+	migrations []migration.Migration,
+	opts *DeployOptions,
+) (map[string]DeploymentResult, error) {
+	if c.registry == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrOrchestration, "coordinator has no registry")
+	}
+	if len(environments) == 0 {
+		return nil, surqlerrors.New(surqlerrors.ErrOrchestration, "at least one environment is required")
+	}
+
+	effective := DeployOptions{}
+	if opts != nil {
+		effective = *opts
+	}
+	if effective.Strategy == "" {
+		effective.Strategy = StrategySequential
+	}
+	verifyHealth, autoRollback := effective.resolveBools()
+
+	// Resolve environment names -> configs.
+	envConfigs := make([]EnvironmentConfig, 0, len(environments))
+	for _, name := range environments {
+		cfg, err := c.registry.Get(name)
+		if err != nil {
+			return nil, surqlerrors.Wrapf(surqlerrors.ErrOrchestration, err,
+				"environment %q not registered", name)
+		}
+		envConfigs = append(envConfigs, cfg)
+	}
+
+	// Verify health unless dry-running or explicitly disabled.
+	if verifyHealth && !effective.DryRun {
+		hc := effective.HealthCheck
+		if hc == nil {
+			hc = c.healthCheck
+		}
+		// Inject factory override so health checks honour the same
+		// ClientFactory as the deploy itself.
+		if effective.Factory != nil && hc.Factory == nil {
+			hc = &HealthCheck{Factory: effective.Factory}
+		}
+		statuses := hc.VerifyAllEnvironments(ctx, envConfigs)
+		unhealthy := make([]string, 0)
+		for _, env := range envConfigs {
+			status, ok := statuses[env.Name]
+			if !ok || !status.IsHealthy {
+				unhealthy = append(unhealthy, env.Name)
+			}
+		}
+		if len(unhealthy) > 0 {
+			return nil, surqlerrors.Newf(surqlerrors.ErrOrchestration,
+				"unhealthy environments: %s", strings.Join(unhealthy, ", "))
+		}
+	}
+
+	plan := &DeploymentPlan{
+		Environments:     envConfigs,
+		Migrations:       migrations,
+		BatchSize:        effective.BatchSize,
+		CanaryPercentage: effective.CanaryPercentage,
+		MaxConcurrent:    effective.MaxConcurrent,
+		DryRun:           effective.DryRun,
+		Factory:          effective.Factory,
+	}
+
+	strategy, err := NewStrategy(effective.Strategy, plan)
+	if err != nil {
+		return nil, surqlerrors.Wrapf(surqlerrors.ErrOrchestration, err,
+			"failed to construct strategy %q", effective.Strategy)
+	}
+
+	results, err := strategy.DeployAll(ctx, plan)
+	if err != nil {
+		return nil, surqlerrors.Wrapf(surqlerrors.ErrOrchestration, err,
+			"deployment strategy %q failed", effective.Strategy)
+	}
+
+	resultMap := make(map[string]DeploymentResult, len(results))
+	for _, r := range results {
+		resultMap[r.Environment] = r
+	}
+
+	if autoRollback && !effective.DryRun {
+		failed := false
+		for _, r := range results {
+			if r.Status == DeploymentStatusFailed {
+				failed = true
+				break
+			}
+		}
+		if failed {
+			c.rollback(ctx, envConfigs, migrations, resultMap, effective.Factory)
+		}
+	}
+
+	return resultMap, nil
+}
+
+// GetDeploymentStatus returns a healthy/unhealthy verdict per environment.
+// Convenience wrapper around HealthCheck; unknown environments are
+// silently skipped (mirrors py).
+func (c *MigrationCoordinator) GetDeploymentStatus(
+	ctx context.Context,
+	environments []string,
+) map[string]bool {
+	out := make(map[string]bool, len(environments))
+	envConfigs := make([]EnvironmentConfig, 0, len(environments))
+	for _, name := range environments {
+		cfg, err := c.registry.Get(name)
+		if err != nil {
+			continue
+		}
+		envConfigs = append(envConfigs, cfg)
+	}
+	statuses := c.healthCheck.VerifyAllEnvironments(ctx, envConfigs)
+	for name, s := range statuses {
+		out[name] = s.IsHealthy
+	}
+	return out
+}
+
+// rollback issues DOWN migrations against every environment marked
+// DeploymentStatusSuccess, mirroring py's `_rollback_deployments`. The
+// result map is updated in place to mark rolled-back entries. Errors
+// during rollback are swallowed — the best-effort contract matches py.
+func (c *MigrationCoordinator) rollback(
+	ctx context.Context,
+	envs []EnvironmentConfig,
+	migrations []migration.Migration,
+	results map[string]DeploymentResult,
+	factory ClientFactory,
+) {
+	if factory == nil {
+		factory = defaultClientFactory
+	}
+	for _, env := range envs {
+		r, ok := results[env.Name]
+		if !ok || r.Status != DeploymentStatusSuccess {
+			continue
+		}
+		client, cleanup, err := factory(ctx, env.Connection)
+		if err != nil {
+			continue
+		}
+		// Execute DOWN migrations in reverse order.
+		for i := len(migrations) - 1; i >= 0; i-- {
+			_, _ = migration.ExecuteMigration(ctx, client, migrations[i], migration.MigrationDirectionDown)
+		}
+		cleanup()
+		r.Status = DeploymentStatusRolledBack
+		results[env.Name] = r
+	}
+}
+
+// DeployToEnvironments is the package-level convenience wrapper mirroring
+// py's `deploy_to_environments` helper.
+func DeployToEnvironments(
+	ctx context.Context,
+	registry *EnvironmentRegistry,
+	environments []string,
+	migrations []migration.Migration,
+	opts *DeployOptions,
+) (map[string]DeploymentResult, error) {
+	return NewMigrationCoordinator(registry).DeployToEnvironments(ctx, environments, migrations, opts)
+}

--- a/pkg/surql/orchestration/coordinator_test.go
+++ b/pkg/surql/orchestration/coordinator_test.go
@@ -1,0 +1,277 @@
+package orchestration
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Oneiriq/surql-go/pkg/surql/connection"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+func newTestRegistry(t *testing.T, names ...string) *EnvironmentRegistry {
+	t.Helper()
+	r := NewEnvironmentRegistry()
+	for i, name := range names {
+		if err := r.Register(name, testConfig(), &RegisterOptions{Priority: i + 1}); err != nil {
+			t.Fatalf("Register %s: %v", name, err)
+		}
+	}
+	return r
+}
+
+func TestCoordinator_DeployToEnvironments_DryRun(t *testing.T) {
+	t.Parallel()
+
+	registry := newTestRegistry(t, "prod", "staging")
+	c := NewMigrationCoordinator(registry)
+
+	results, err := c.DeployToEnvironments(
+		context.Background(),
+		[]string{"staging", "prod"},
+		buildMigrations(1),
+		&DeployOptions{DryRun: true},
+	)
+	if err != nil {
+		t.Fatalf("DeployToEnvironments: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	for _, r := range results {
+		if r.Status != DeploymentStatusSuccess {
+			t.Fatalf("env %s status = %s, want success", r.Environment, r.Status)
+		}
+	}
+}
+
+func TestCoordinator_UnknownEnvironment(t *testing.T) {
+	t.Parallel()
+
+	c := NewMigrationCoordinator(newTestRegistry(t, "prod"))
+	_, err := c.DeployToEnvironments(
+		context.Background(),
+		[]string{"ghost"},
+		buildMigrations(1),
+		&DeployOptions{DryRun: true},
+	)
+	if !errors.Is(err, surqlerrors.ErrOrchestration) {
+		t.Fatalf("err = %v; want ErrOrchestration", err)
+	}
+}
+
+func TestCoordinator_EmptyEnvironmentsRejected(t *testing.T) {
+	t.Parallel()
+
+	c := NewMigrationCoordinator(newTestRegistry(t, "prod"))
+	_, err := c.DeployToEnvironments(
+		context.Background(),
+		nil,
+		buildMigrations(1),
+		&DeployOptions{DryRun: true},
+	)
+	if !errors.Is(err, surqlerrors.ErrOrchestration) {
+		t.Fatalf("err = %v; want ErrOrchestration", err)
+	}
+}
+
+func TestCoordinator_UnknownStrategy(t *testing.T) {
+	t.Parallel()
+
+	c := NewMigrationCoordinator(newTestRegistry(t, "prod"))
+	_, err := c.DeployToEnvironments(
+		context.Background(),
+		[]string{"prod"},
+		buildMigrations(1),
+		&DeployOptions{DryRun: true, Strategy: StrategyName("bogus")},
+	)
+	if !errors.Is(err, surqlerrors.ErrOrchestration) {
+		t.Fatalf("err = %v; want ErrOrchestration", err)
+	}
+}
+
+func TestCoordinator_HealthVerificationPasses(t *testing.T) {
+	t.Parallel()
+
+	registry := newTestRegistry(t, "prod", "staging")
+	c := NewMigrationCoordinator(registry)
+
+	// Factory that "connects" — but we route through DryRun so no
+	// migrations are executed. Health check must honour the factory too.
+	factory := func(ctx context.Context, cfg connection.ConnectionConfig) (*connection.DatabaseClient, func(), error) {
+		return nil, func() {}, errors.New("should not be called in dry-run mode with VerifyHealth=false")
+	}
+	falseVal := false
+	_, err := c.DeployToEnvironments(
+		context.Background(),
+		[]string{"prod", "staging"},
+		buildMigrations(1),
+		&DeployOptions{
+			DryRun:       true,
+			VerifyHealth: &falseVal,
+			Factory:      factory,
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}
+
+func TestCoordinator_HealthVerificationFails(t *testing.T) {
+	t.Parallel()
+
+	registry := newTestRegistry(t, "prod")
+	c := NewMigrationCoordinator(registry)
+
+	// Failing factory -> every env is unhealthy.
+	var counter atomic.Int32
+	factory := failingFactory(&counter)
+
+	trueVal := true
+	_, err := c.DeployToEnvironments(
+		context.Background(),
+		[]string{"prod"},
+		buildMigrations(1),
+		&DeployOptions{
+			DryRun:       false,
+			VerifyHealth: &trueVal,
+			Factory:      factory,
+		},
+	)
+	if !errors.Is(err, surqlerrors.ErrOrchestration) {
+		t.Fatalf("err = %v; want ErrOrchestration", err)
+	}
+	if counter.Load() == 0 {
+		t.Fatal("factory should have been invoked for health check")
+	}
+}
+
+func TestCoordinator_AutoRollbackOnFailure(t *testing.T) {
+	t.Parallel()
+
+	registry := newTestRegistry(t, "prod")
+	c := NewMigrationCoordinator(registry)
+
+	// Factory always errors -> deploy fails -> nothing to rollback; but
+	// we can still verify that the rollback branch does not blow up.
+	var counter atomic.Int32
+	falseVal := false
+	trueVal := true
+	results, err := c.DeployToEnvironments(
+		context.Background(),
+		[]string{"prod"},
+		buildMigrations(1),
+		&DeployOptions{
+			Strategy:     StrategySequential,
+			DryRun:       false,
+			VerifyHealth: &falseVal,
+			AutoRollback: &trueVal,
+			Factory:      failingFactory(&counter),
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	r, ok := results["prod"]
+	if !ok {
+		t.Fatal("results missing prod entry")
+	}
+	if r.Status != DeploymentStatusFailed {
+		t.Fatalf("status = %s, want failed", r.Status)
+	}
+}
+
+func TestCoordinator_AutoRollbackFlipsSuccessToRolledBack(t *testing.T) {
+	t.Parallel()
+
+	registry := newTestRegistry(t, "prod", "staging")
+	c := NewMigrationCoordinator(registry)
+
+	// Env "prod" succeeds (via dry-run shortcut inside executeOnEnvironment
+	// would skip factory entirely; instead, we use a smart factory that
+	// succeeds for prod and fails for staging — but we cannot construct a
+	// real DatabaseClient without a live DB. Instead, use DryRun=false +
+	// a factory that always fails, and assert rollback handling preserves
+	// non-success entries).
+	//
+	// This test pins the more-important invariant that rollback only
+	// flips entries that were Success -> RolledBack; failures stay as-is.
+	var counter atomic.Int32
+	falseVal := false
+	trueVal := true
+	results, err := c.DeployToEnvironments(
+		context.Background(),
+		[]string{"prod", "staging"},
+		buildMigrations(1),
+		&DeployOptions{
+			Strategy:     StrategyParallel,
+			DryRun:       false,
+			VerifyHealth: &falseVal,
+			AutoRollback: &trueVal,
+			Factory:      failingFactory(&counter),
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	for name, r := range results {
+		if r.Status != DeploymentStatusFailed {
+			t.Fatalf("env %s status = %s, want failed (no successes -> none to roll back)", name, r.Status)
+		}
+	}
+}
+
+func TestCoordinator_GetDeploymentStatus_IgnoresUnknown(t *testing.T) {
+	t.Parallel()
+
+	registry := newTestRegistry(t, "prod")
+	c := NewMigrationCoordinator(registry)
+	// GetDeploymentStatus currently uses the default HealthCheck factory
+	// which would try to connect to the real DB. To keep the test hermetic
+	// we swap the internal HealthCheck.
+	c.healthCheck = &HealthCheck{
+		Factory: func(ctx context.Context, cfg connection.ConnectionConfig) (*connection.DatabaseClient, func(), error) {
+			return nil, func() {}, errors.New("no network in tests")
+		},
+	}
+
+	statuses := c.GetDeploymentStatus(context.Background(), []string{"prod", "ghost"})
+	if _, ok := statuses["ghost"]; ok {
+		t.Fatal("unknown env should be skipped from status map")
+	}
+	if statuses["prod"] {
+		t.Fatal("prod should be unhealthy under failing factory")
+	}
+}
+
+func TestPackageDeployToEnvironments_Wrapper(t *testing.T) {
+	t.Parallel()
+
+	registry := newTestRegistry(t, "prod")
+	results, err := DeployToEnvironments(
+		context.Background(),
+		registry,
+		[]string{"prod"},
+		buildMigrations(1),
+		&DeployOptions{DryRun: true},
+	)
+	if err != nil {
+		t.Fatalf("DeployToEnvironments: %v", err)
+	}
+	if _, ok := results["prod"]; !ok {
+		t.Fatal("results missing prod entry")
+	}
+}
+
+func TestNewMigrationCoordinator_NilRegistryUsesGlobal(t *testing.T) {
+	// Not parallel: mutates global registry.
+	original := GetRegistry()
+	t.Cleanup(func() { SetRegistry(original) })
+
+	SetRegistry(NewEnvironmentRegistry())
+	c := NewMigrationCoordinator(nil)
+	if c.Registry() != GetRegistry() {
+		t.Fatal("nil registry did not resolve to global")
+	}
+}

--- a/pkg/surql/orchestration/doc.go
+++ b/pkg/surql/orchestration/doc.go
@@ -1,0 +1,25 @@
+// Package orchestration coordinates SurrealDB migrations across multiple
+// environments (staging, production, per-region, ...) with pluggable
+// deployment strategies.
+//
+// The surface mirrors surql-py's `src/surql/orchestration/` so consumers
+// written against the Python port transfer one-to-one:
+//
+//   - EnvironmentConfig + EnvironmentRegistry describe the environments
+//     available to the coordinator. The registry is a sync.RWMutex-backed
+//     struct with a package-level singleton reachable via GetRegistry.
+//   - MigrationCoordinator orchestrates a DeploymentPlan against the
+//     registry, optionally verifying health first and auto-rolling-back on
+//     failure.
+//   - HealthCheck exposes connectivity + migration-table probes used by the
+//     coordinator and by CLI `status` commands.
+//   - DeploymentStrategy is an interface implemented by SequentialStrategy,
+//     ParallelStrategy, RollingStrategy, and CanaryStrategy. Each owns a
+//     distinct roll-out shape (one-at-a-time / all-at-once / batched /
+//     subset-then-rest).
+//   - DeploymentResult + DeploymentStatus capture the outcome per
+//     environment.
+//
+// Errors from this package wrap the sentinel errors.ErrOrchestration so
+// callers can match with errors.Is.
+package orchestration

--- a/pkg/surql/orchestration/environment.go
+++ b/pkg/surql/orchestration/environment.go
@@ -1,0 +1,382 @@
+package orchestration
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"sync"
+
+	"github.com/Oneiriq/surql-go/pkg/surql/connection"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+// EnvironmentConfig describes a single database environment the coordinator
+// can deploy migrations to.
+//
+// The struct mirrors surql-py's frozen `EnvironmentConfig` model. Instances
+// are expected to be treated as immutable after construction; the registry
+// returns copies so callers cannot mutate registered entries.
+type EnvironmentConfig struct {
+	// Name is the unique environment identifier (e.g. "production").
+	Name string `json:"name"`
+	// Connection carries the SurrealDB connection details. The connection
+	// is validated when the environment is registered.
+	Connection connection.ConnectionConfig `json:"connection"`
+	// Priority controls ordering in ListEnvironments: lower numbers sort
+	// first. Defaults to 100 when left at zero-value.
+	Priority int `json:"priority"`
+	// Tags are free-form labels used for categorisation (e.g. "prod",
+	// "critical"). Stored as a set to match py semantics.
+	Tags map[string]struct{} `json:"tags,omitempty"`
+	// RequireApproval indicates the CLI should prompt for confirmation
+	// before deploying. The coordinator does not enforce approval itself;
+	// it is surfaced for operator tooling.
+	RequireApproval bool `json:"require_approval,omitempty"`
+	// AllowDestructive controls whether destructive migrations (DROP,
+	// REMOVE, ...) are permitted against this environment. Defaults to
+	// true to mirror py.
+	AllowDestructive bool `json:"allow_destructive"`
+}
+
+// defaultPriority is applied when EnvironmentConfig.Priority is unset (zero).
+// Matches surql-py's default of 100.
+const defaultPriority = 100
+
+// HasTag reports whether the environment carries the named tag.
+func (e EnvironmentConfig) HasTag(tag string) bool {
+	if e.Tags == nil {
+		return false
+	}
+	_, ok := e.Tags[tag]
+	return ok
+}
+
+// TagList returns the environment's tags as a sorted slice for stable
+// iteration/logging.
+func (e EnvironmentConfig) TagList() []string {
+	tags := make([]string, 0, len(e.Tags))
+	for t := range e.Tags {
+		tags = append(tags, t)
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+// validate enforces the rules from surql-py's EnvironmentConfig validator.
+// name must be non-empty and alphanumeric (plus '_' / '-'); the underlying
+// connection config must validate.
+func (e EnvironmentConfig) validate() error {
+	if e.Name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "environment name cannot be empty")
+	}
+	for _, r := range e.Name {
+		ok := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || r == '_' || r == '-'
+		if !ok {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"environment name %q must be alphanumeric with optional underscores/hyphens", e.Name)
+		}
+	}
+	if err := e.Connection.Validate(); err != nil {
+		return err
+	}
+	if e.Priority < 0 {
+		return surqlerrors.Newf(surqlerrors.ErrValidation,
+			"environment priority must be >= 0, got %d", e.Priority)
+	}
+	return nil
+}
+
+// normalised returns a defensive copy with defaulted Priority and a non-nil
+// Tags map so downstream callers never have to nil-check.
+func (e EnvironmentConfig) normalised() EnvironmentConfig {
+	out := e
+	if out.Priority == 0 {
+		out.Priority = defaultPriority
+	}
+	if out.Tags == nil {
+		out.Tags = map[string]struct{}{}
+	} else {
+		tags := make(map[string]struct{}, len(out.Tags))
+		for k := range out.Tags {
+			tags[k] = struct{}{}
+		}
+		out.Tags = tags
+	}
+	return out
+}
+
+// EnvironmentRegistry is a thread-safe map of named EnvironmentConfig
+// entries. It mirrors surql-py's `EnvironmentRegistry` class while using
+// Go's sync.RWMutex — async primitives are unnecessary for an in-memory
+// lookup table.
+//
+// Construct with NewEnvironmentRegistry or reach the package-level
+// singleton via GetRegistry. The zero value is not usable.
+type EnvironmentRegistry struct {
+	mu           sync.RWMutex
+	environments map[string]EnvironmentConfig
+}
+
+// NewEnvironmentRegistry constructs an empty registry. Prefer GetRegistry
+// when you want the shared library-level registry; NewEnvironmentRegistry
+// is useful for tests that want isolation.
+func NewEnvironmentRegistry() *EnvironmentRegistry {
+	return &EnvironmentRegistry{environments: map[string]EnvironmentConfig{}}
+}
+
+// RegisterOptions tunes RegisterEnvironment behaviour. All fields are
+// optional; zero-values mirror surql-py's defaults.
+type RegisterOptions struct {
+	// Priority overrides the default of 100 when non-zero.
+	Priority int
+	// Tags is a set of free-form labels.
+	Tags []string
+	// RequireApproval toggles operator-confirmation gating.
+	RequireApproval bool
+	// AllowDestructive, when explicitly set to a non-nil pointer, replaces
+	// the default of true. A nil pointer leaves the default in place.
+	AllowDestructive *bool
+}
+
+// Register adds a new environment. Returns ErrRegistry when name is
+// already registered and ErrValidation on invalid input (empty name,
+// invalid ConnectionConfig, negative priority).
+//
+// The stored config is normalised (Priority defaults to 100,
+// AllowDestructive defaults to true) and frozen; callers can freely mutate
+// their local copy of cfg afterwards.
+func (r *EnvironmentRegistry) Register(
+	name string,
+	cfg connection.ConnectionConfig,
+	opts *RegisterOptions,
+) error {
+	allowDestructive := true
+	priority := defaultPriority
+	var tags []string
+	var requireApproval bool
+
+	if opts != nil {
+		if opts.Priority > 0 {
+			priority = opts.Priority
+		}
+		tags = opts.Tags
+		requireApproval = opts.RequireApproval
+		if opts.AllowDestructive != nil {
+			allowDestructive = *opts.AllowDestructive
+		}
+	}
+
+	tagSet := make(map[string]struct{}, len(tags))
+	for _, t := range tags {
+		tagSet[t] = struct{}{}
+	}
+
+	env := EnvironmentConfig{
+		Name:             name,
+		Connection:       cfg,
+		Priority:         priority,
+		Tags:             tagSet,
+		RequireApproval:  requireApproval,
+		AllowDestructive: allowDestructive,
+	}
+	if err := env.validate(); err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.environments[name]; exists {
+		return surqlerrors.Newf(surqlerrors.ErrRegistry,
+			"environment %q already registered", name)
+	}
+	r.environments[name] = env.normalised()
+	return nil
+}
+
+// Unregister removes the named environment. Returns ErrRegistry when the
+// environment does not exist.
+func (r *EnvironmentRegistry) Unregister(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.environments[name]; !ok {
+		return surqlerrors.Newf(surqlerrors.ErrRegistry,
+			"environment %q not found", name)
+	}
+	delete(r.environments, name)
+	return nil
+}
+
+// Get returns the named environment configuration. Returns
+// ErrRegistry when the environment is not registered.
+//
+// The returned value is a copy — mutations do not affect the registry.
+func (r *EnvironmentRegistry) Get(name string) (EnvironmentConfig, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	env, ok := r.environments[name]
+	if !ok {
+		return EnvironmentConfig{}, surqlerrors.Newf(surqlerrors.ErrRegistry,
+			"environment %q not found", name)
+	}
+	return env, nil
+}
+
+// List returns the registered environment names sorted by priority
+// ascending (ties broken alphabetically). Matches py's
+// `list_environments` semantics.
+func (r *EnvironmentRegistry) List() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	envs := make([]EnvironmentConfig, 0, len(r.environments))
+	for _, e := range r.environments {
+		envs = append(envs, e)
+	}
+	sort.Slice(envs, func(i, j int) bool {
+		if envs[i].Priority != envs[j].Priority {
+			return envs[i].Priority < envs[j].Priority
+		}
+		return envs[i].Name < envs[j].Name
+	})
+	names := make([]string, 0, len(envs))
+	for _, e := range envs {
+		names = append(names, e.Name)
+	}
+	return names
+}
+
+// FindByTag returns every environment tagged with tag, sorted by priority
+// ascending.
+func (r *EnvironmentRegistry) FindByTag(tag string) []EnvironmentConfig {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	matches := make([]EnvironmentConfig, 0)
+	for _, e := range r.environments {
+		if _, ok := e.Tags[tag]; ok {
+			matches = append(matches, e)
+		}
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].Priority != matches[j].Priority {
+			return matches[i].Priority < matches[j].Priority
+		}
+		return matches[i].Name < matches[j].Name
+	})
+	return matches
+}
+
+// Len returns the number of registered environments.
+func (r *EnvironmentRegistry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.environments)
+}
+
+// Clear removes every registered environment, leaving the registry empty.
+// Useful in tests.
+func (r *EnvironmentRegistry) Clear() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.environments = map[string]EnvironmentConfig{}
+}
+
+// environmentsFileSchema is the JSON shape parsed by LoadRegistryFromFile.
+// It mirrors surql-py's config file format.
+type environmentsFileSchema struct {
+	Environments []struct {
+		Name             string                      `json:"name"`
+		Connection       connection.ConnectionConfig `json:"connection"`
+		Priority         int                         `json:"priority,omitempty"`
+		Tags             []string                    `json:"tags,omitempty"`
+		RequireApproval  bool                        `json:"require_approval,omitempty"`
+		AllowDestructive *bool                       `json:"allow_destructive,omitempty"`
+	} `json:"environments"`
+}
+
+// LoadRegistryFromFile parses a JSON file of the form
+//
+//	{"environments": [{"name": "...", "connection": {...}, ...}, ...]}
+//
+// and returns a populated registry. A missing file produces an empty
+// registry (matching py's behaviour); malformed JSON or validation
+// failures surface as ErrSerialization / ErrValidation.
+func LoadRegistryFromFile(path string) (*EnvironmentRegistry, error) {
+	registry := NewEnvironmentRegistry()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return registry, nil
+		}
+		return nil, surqlerrors.Wrapf(surqlerrors.ErrOrchestration, err,
+			"failed to read environments config %q", path)
+	}
+
+	var schema environmentsFileSchema
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return nil, surqlerrors.Wrapf(surqlerrors.ErrSerialization, err,
+			"failed to parse environments config %q", path)
+	}
+
+	for _, entry := range schema.Environments {
+		opts := &RegisterOptions{
+			Priority:        entry.Priority,
+			Tags:            entry.Tags,
+			RequireApproval: entry.RequireApproval,
+		}
+		if entry.AllowDestructive != nil {
+			opts.AllowDestructive = entry.AllowDestructive
+		}
+		if err := registry.Register(entry.Name, entry.Connection, opts); err != nil {
+			return nil, err
+		}
+	}
+	return registry, nil
+}
+
+// globalRegistry holds the package-level singleton returned by GetRegistry.
+// A sync.Mutex guards replacement via SetRegistry; the registry's own
+// RWMutex handles concurrent reads/writes of the environment map.
+var (
+	globalRegistryMu sync.Mutex
+	globalRegistry   = NewEnvironmentRegistry()
+)
+
+// GetRegistry returns the shared package-level EnvironmentRegistry.
+// Mirrors surql-py's `get_registry()`.
+func GetRegistry() *EnvironmentRegistry {
+	globalRegistryMu.Lock()
+	defer globalRegistryMu.Unlock()
+	return globalRegistry
+}
+
+// SetRegistry replaces the package-level registry. Useful in tests that
+// want a hermetic registry without mutating shared state.
+func SetRegistry(r *EnvironmentRegistry) {
+	if r == nil {
+		r = NewEnvironmentRegistry()
+	}
+	globalRegistryMu.Lock()
+	defer globalRegistryMu.Unlock()
+	globalRegistry = r
+}
+
+// ConfigureEnvironments replaces the package-level registry with one
+// hydrated from path. Mirrors py's `configure_environments`.
+func ConfigureEnvironments(path string) error {
+	registry, err := LoadRegistryFromFile(path)
+	if err != nil {
+		return err
+	}
+	SetRegistry(registry)
+	return nil
+}
+
+// RegisterEnvironment registers cfg under name in the package-level
+// registry. Convenience wrapper around GetRegistry().Register.
+func RegisterEnvironment(
+	name string,
+	cfg connection.ConnectionConfig,
+	opts *RegisterOptions,
+) error {
+	return GetRegistry().Register(name, cfg, opts)
+}

--- a/pkg/surql/orchestration/environment_test.go
+++ b/pkg/surql/orchestration/environment_test.go
@@ -1,0 +1,440 @@
+package orchestration
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/Oneiriq/surql-go/pkg/surql/connection"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+// testConfig is a valid ConnectionConfig for registry tests. Using a
+// memory:// URL means no real connection is ever attempted.
+func testConfig() connection.ConnectionConfig {
+	cfg := connection.DefaultConfig()
+	cfg.DBURL = "memory://test"
+	return cfg
+}
+
+func TestEnvironmentConfig_Validate_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		input   EnvironmentConfig
+		wantErr error
+	}{
+		{
+			name: "valid",
+			input: EnvironmentConfig{
+				Name:       "prod",
+				Connection: testConfig(),
+				Priority:   1,
+			},
+			wantErr: nil,
+		},
+		{
+			name:    "empty name",
+			input:   EnvironmentConfig{Connection: testConfig()},
+			wantErr: surqlerrors.ErrValidation,
+		},
+		{
+			name: "invalid chars",
+			input: EnvironmentConfig{
+				Name:       "prod!",
+				Connection: testConfig(),
+			},
+			wantErr: surqlerrors.ErrValidation,
+		},
+		{
+			name: "negative priority",
+			input: EnvironmentConfig{
+				Name:       "staging",
+				Connection: testConfig(),
+				Priority:   -1,
+			},
+			wantErr: surqlerrors.ErrValidation,
+		},
+		{
+			name: "invalid connection",
+			input: EnvironmentConfig{
+				Name:       "staging",
+				Connection: connection.ConnectionConfig{DBURL: "ftp://bogus"},
+			},
+			wantErr: surqlerrors.ErrValidation,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.input.validate()
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("err = %v; want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestEnvironmentConfig_TagsHelpers(t *testing.T) {
+	t.Parallel()
+
+	env := EnvironmentConfig{
+		Name: "prod",
+		Tags: map[string]struct{}{"critical": {}, "us-east": {}},
+	}
+	if !env.HasTag("critical") {
+		t.Fatal("HasTag critical = false, want true")
+	}
+	if env.HasTag("missing") {
+		t.Fatal("HasTag missing = true, want false")
+	}
+	got := env.TagList()
+	want := []string{"critical", "us-east"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("TagList = %v, want %v", got, want)
+	}
+}
+
+func TestEnvironmentConfig_NormalisedFillsDefaults(t *testing.T) {
+	t.Parallel()
+
+	env := EnvironmentConfig{Name: "staging"}.normalised()
+	if env.Priority != defaultPriority {
+		t.Fatalf("Priority = %d, want %d", env.Priority, defaultPriority)
+	}
+	if env.Tags == nil {
+		t.Fatal("Tags should be non-nil after normalisation")
+	}
+}
+
+func TestRegistry_RegisterAndGet(t *testing.T) {
+	t.Parallel()
+
+	r := NewEnvironmentRegistry()
+	err := r.Register("prod", testConfig(), &RegisterOptions{Priority: 1, Tags: []string{"critical"}})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	got, err := r.Get("prod")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Name != "prod" || got.Priority != 1 {
+		t.Fatalf("got %+v, want Name=prod Priority=1", got)
+	}
+	if !got.HasTag("critical") {
+		t.Fatal("tag critical missing")
+	}
+	if !got.AllowDestructive {
+		t.Fatal("AllowDestructive should default to true")
+	}
+}
+
+func TestRegistry_Register_DuplicateRejected(t *testing.T) {
+	t.Parallel()
+
+	r := NewEnvironmentRegistry()
+	if err := r.Register("prod", testConfig(), nil); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	err := r.Register("prod", testConfig(), nil)
+	if err == nil {
+		t.Fatal("second Register should fail")
+	}
+	if !errors.Is(err, surqlerrors.ErrRegistry) {
+		t.Fatalf("err = %v; want ErrRegistry", err)
+	}
+}
+
+func TestRegistry_Get_Missing(t *testing.T) {
+	t.Parallel()
+
+	r := NewEnvironmentRegistry()
+	_, err := r.Get("missing")
+	if !errors.Is(err, surqlerrors.ErrRegistry) {
+		t.Fatalf("err = %v; want ErrRegistry", err)
+	}
+}
+
+func TestRegistry_Unregister(t *testing.T) {
+	t.Parallel()
+
+	r := NewEnvironmentRegistry()
+	if err := r.Register("prod", testConfig(), nil); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := r.Unregister("prod"); err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+	if _, err := r.Get("prod"); !errors.Is(err, surqlerrors.ErrRegistry) {
+		t.Fatalf("post-Unregister Get should ErrRegistry, got %v", err)
+	}
+	if err := r.Unregister("prod"); !errors.Is(err, surqlerrors.ErrRegistry) {
+		t.Fatalf("double Unregister should ErrRegistry, got %v", err)
+	}
+}
+
+func TestRegistry_List_OrderedByPriority(t *testing.T) {
+	t.Parallel()
+
+	r := NewEnvironmentRegistry()
+	for _, tc := range []struct {
+		name     string
+		priority int
+	}{
+		{"dev", 200},
+		{"prod", 1},
+		{"staging", 50},
+	} {
+		if err := r.Register(tc.name, testConfig(), &RegisterOptions{Priority: tc.priority}); err != nil {
+			t.Fatalf("Register %s: %v", tc.name, err)
+		}
+	}
+	got := r.List()
+	want := []string{"prod", "staging", "dev"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("List = %v, want %v", got, want)
+	}
+}
+
+func TestRegistry_FindByTag(t *testing.T) {
+	t.Parallel()
+
+	r := NewEnvironmentRegistry()
+	mustRegister(t, r, "prod", 1, []string{"critical"})
+	mustRegister(t, r, "staging", 50, []string{"critical"})
+	mustRegister(t, r, "dev", 200, []string{"ephemeral"})
+
+	got := r.FindByTag("critical")
+	if len(got) != 2 {
+		t.Fatalf("FindByTag critical len = %d, want 2", len(got))
+	}
+	// Should be priority-ordered.
+	if got[0].Name != "prod" || got[1].Name != "staging" {
+		names := make([]string, 0, len(got))
+		for _, e := range got {
+			names = append(names, e.Name)
+		}
+		t.Fatalf("FindByTag order = %v, want [prod staging]", names)
+	}
+
+	if got := r.FindByTag("nonexistent"); len(got) != 0 {
+		t.Fatalf("FindByTag nonexistent should be empty, got %v", got)
+	}
+}
+
+func TestRegistry_ConcurrentRegisterAndGet(t *testing.T) {
+	t.Parallel()
+
+	r := NewEnvironmentRegistry()
+	var wg sync.WaitGroup
+	const N = 50
+	for i := 0; i < N; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			name := "env" + itoa(i)
+			_ = r.Register(name, testConfig(), nil)
+			_, _ = r.Get(name)
+		}()
+	}
+	wg.Wait()
+	if r.Len() != N {
+		t.Fatalf("Len = %d, want %d", r.Len(), N)
+	}
+}
+
+func TestRegistry_Clear(t *testing.T) {
+	t.Parallel()
+
+	r := NewEnvironmentRegistry()
+	mustRegister(t, r, "prod", 1, nil)
+	mustRegister(t, r, "staging", 50, nil)
+	r.Clear()
+	if r.Len() != 0 {
+		t.Fatalf("after Clear Len = %d, want 0", r.Len())
+	}
+}
+
+func TestLoadRegistryFromFile_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "environments.json")
+
+	trueVal := true
+	fileContents := map[string]any{
+		"environments": []map[string]any{
+			{
+				"name": "prod",
+				"connection": map[string]any{
+					"db_url":                "memory://prod",
+					"db_ns":                 "prod",
+					"db":                    "main",
+					"db_timeout":            30.0,
+					"db_max_connections":    10,
+					"db_retry_max_attempts": 3,
+					"db_retry_min_wait":     1.0,
+					"db_retry_max_wait":     10.0,
+					"db_retry_multiplier":   2.0,
+					"enable_live_queries":   true,
+				},
+				"priority":          1,
+				"tags":              []string{"critical"},
+				"require_approval":  true,
+				"allow_destructive": &trueVal,
+			},
+		},
+	}
+	raw, err := json.Marshal(fileContents)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	registry, err := LoadRegistryFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadRegistryFromFile: %v", err)
+	}
+	env, err := registry.Get("prod")
+	if err != nil {
+		t.Fatalf("Get prod: %v", err)
+	}
+	if env.Priority != 1 {
+		t.Fatalf("Priority = %d, want 1", env.Priority)
+	}
+	if !env.RequireApproval {
+		t.Fatal("RequireApproval = false, want true")
+	}
+}
+
+func TestLoadRegistryFromFile_MissingReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	registry, err := LoadRegistryFromFile(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if err != nil {
+		t.Fatalf("expected nil err for missing file, got %v", err)
+	}
+	if registry.Len() != 0 {
+		t.Fatalf("empty registry expected, got %d entries", registry.Len())
+	}
+}
+
+func TestLoadRegistryFromFile_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := LoadRegistryFromFile(path)
+	if !errors.Is(err, surqlerrors.ErrSerialization) {
+		t.Fatalf("err = %v; want ErrSerialization", err)
+	}
+}
+
+func TestGlobalRegistry_SetAndGet(t *testing.T) {
+	// Not parallel: mutates package-level state.
+	original := GetRegistry()
+	t.Cleanup(func() { SetRegistry(original) })
+
+	fresh := NewEnvironmentRegistry()
+	SetRegistry(fresh)
+	if GetRegistry() != fresh {
+		t.Fatal("SetRegistry did not replace the singleton")
+	}
+
+	// SetRegistry(nil) should install a fresh empty registry rather than panicking.
+	SetRegistry(nil)
+	if GetRegistry() == nil {
+		t.Fatal("SetRegistry(nil) left a nil registry")
+	}
+	if GetRegistry().Len() != 0 {
+		t.Fatal("SetRegistry(nil) did not reset to empty")
+	}
+}
+
+func TestRegisterEnvironment_HitsGlobalRegistry(t *testing.T) {
+	// Not parallel: mutates package-level state.
+	original := GetRegistry()
+	t.Cleanup(func() { SetRegistry(original) })
+
+	SetRegistry(NewEnvironmentRegistry())
+	if err := RegisterEnvironment("prod", testConfig(), nil); err != nil {
+		t.Fatalf("RegisterEnvironment: %v", err)
+	}
+	if _, err := GetRegistry().Get("prod"); err != nil {
+		t.Fatalf("global registry missing prod: %v", err)
+	}
+}
+
+func TestConfigureEnvironments_ReplacesGlobal(t *testing.T) {
+	// Not parallel: mutates package-level state.
+	original := GetRegistry()
+	t.Cleanup(func() { SetRegistry(original) })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "env.json")
+	raw := []byte(`{"environments":[{"name":"prod","connection":{"db_url":"memory://prod","db_ns":"prod","db":"main","db_timeout":30,"db_max_connections":10,"db_retry_max_attempts":3,"db_retry_min_wait":1,"db_retry_max_wait":10,"db_retry_multiplier":2,"enable_live_queries":true}}]}`)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := ConfigureEnvironments(path); err != nil {
+		t.Fatalf("ConfigureEnvironments: %v", err)
+	}
+	names := GetRegistry().List()
+	sort.Strings(names)
+	if !reflect.DeepEqual(names, []string{"prod"}) {
+		t.Fatalf("List = %v, want [prod]", names)
+	}
+}
+
+// mustRegister registers env in r and fails the test on error.
+func mustRegister(t *testing.T, r *EnvironmentRegistry, name string, priority int, tags []string) {
+	t.Helper()
+	if err := r.Register(name, testConfig(), &RegisterOptions{Priority: priority, Tags: tags}); err != nil {
+		t.Fatalf("Register %s: %v", name, err)
+	}
+}
+
+// itoa is a tiny stdlib-free int->string helper used by concurrency tests.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/pkg/surql/orchestration/health.go
+++ b/pkg/surql/orchestration/health.go
@@ -1,0 +1,179 @@
+package orchestration
+
+import (
+	"context"
+	"sync"
+
+	"github.com/Oneiriq/surql-go/pkg/surql/connection"
+)
+
+// HealthStatus records the observed health of a single environment.
+// Mirrors surql-py's `HealthStatus` model.
+type HealthStatus struct {
+	// Environment is the environment name.
+	Environment string `json:"environment"`
+	// IsHealthy is the aggregate verdict. True iff CanConnect is true and
+	// no probe reported an error.
+	IsHealthy bool `json:"is_healthy"`
+	// CanConnect reports whether the client was able to reach the
+	// database and issue a trivial query.
+	CanConnect bool `json:"can_connect"`
+	// MigrationTableExists reports whether the migration history table
+	// was queryable.
+	MigrationTableExists bool `json:"migration_table_exists"`
+	// Error is a human-readable failure reason; empty when IsHealthy.
+	Error string `json:"error,omitempty"`
+}
+
+// ClientFactory builds a connected *DatabaseClient for an environment.
+// Injectable so tests can supply an in-memory fake without touching the
+// network. When non-nil it is preferred over the default factory.
+type ClientFactory func(ctx context.Context, cfg connection.ConnectionConfig) (*connection.DatabaseClient, func(), error)
+
+// defaultClientFactory constructs a DatabaseClient and connects it. The
+// returned cleanup disconnects the client; callers must invoke it.
+func defaultClientFactory(ctx context.Context, cfg connection.ConnectionConfig) (*connection.DatabaseClient, func(), error) {
+	client, err := connection.NewDatabaseClient(cfg)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	if err := client.Connect(ctx); err != nil {
+		return nil, func() {}, err
+	}
+	cleanup := func() { _ = client.Disconnect() }
+	return client, cleanup, nil
+}
+
+// HealthCheck performs connectivity + migration-table probes against
+// EnvironmentConfig entries. Construct with NewHealthCheck; the zero value
+// uses the default (real-network) factory.
+type HealthCheck struct {
+	// Factory overrides the client constructor. Leave nil for production.
+	Factory ClientFactory
+}
+
+// NewHealthCheck returns a HealthCheck using the default factory (which
+// dials the real database).
+func NewHealthCheck() *HealthCheck { return &HealthCheck{} }
+
+// clientFactory returns h.Factory or the default.
+func (h *HealthCheck) clientFactory() ClientFactory {
+	if h.Factory != nil {
+		return h.Factory
+	}
+	return defaultClientFactory
+}
+
+// CheckEnvironment performs a full health probe against env. Connectivity
+// is verified first; when it fails the returned HealthStatus short-circuits
+// with IsHealthy=false and the migration-table check is skipped.
+func (h *HealthCheck) CheckEnvironment(ctx context.Context, env EnvironmentConfig) HealthStatus {
+	client, cleanup, err := h.clientFactory()(ctx, env.Connection)
+	if err != nil {
+		return HealthStatus{
+			Environment: env.Name,
+			IsHealthy:   false,
+			CanConnect:  false,
+			Error:       "cannot connect to database: " + err.Error(),
+		}
+	}
+	defer cleanup()
+
+	// Trivial liveness query — mirrors py's `RETURN 1`.
+	if _, err := client.Query(ctx, "RETURN 1"); err != nil {
+		return HealthStatus{
+			Environment: env.Name,
+			IsHealthy:   false,
+			CanConnect:  false,
+			Error:       "connectivity probe failed: " + err.Error(),
+		}
+	}
+
+	tableExists := checkMigrationTable(ctx, client)
+
+	return HealthStatus{
+		Environment:          env.Name,
+		IsHealthy:            true,
+		CanConnect:           true,
+		MigrationTableExists: tableExists,
+	}
+}
+
+// CheckConnectivity is a stand-alone connectivity probe. Returns true iff
+// a connection could be opened and a trivial query succeeded.
+func (h *HealthCheck) CheckConnectivity(ctx context.Context, env EnvironmentConfig) bool {
+	client, cleanup, err := h.clientFactory()(ctx, env.Connection)
+	if err != nil {
+		return false
+	}
+	defer cleanup()
+	_, err = client.Query(ctx, "RETURN 1")
+	return err == nil
+}
+
+// VerifyAllEnvironments runs CheckEnvironment against each env in
+// parallel and returns a map keyed by environment name. The order of
+// probes is unspecified; callers that need deterministic ordering should
+// sort their result set themselves.
+func (h *HealthCheck) VerifyAllEnvironments(
+	ctx context.Context,
+	envs []EnvironmentConfig,
+) map[string]HealthStatus {
+	results := make(map[string]HealthStatus, len(envs))
+	if len(envs) == 0 {
+		return results
+	}
+
+	var (
+		mu sync.Mutex
+		wg sync.WaitGroup
+	)
+	wg.Add(len(envs))
+	for _, env := range envs {
+		env := env
+		go func() {
+			defer wg.Done()
+			status := h.CheckEnvironment(ctx, env)
+			mu.Lock()
+			results[env.Name] = status
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	return results
+}
+
+// checkMigrationTable probes the migration history table via a minimal
+// SELECT. Any error (including "table not found") is treated as a
+// negative signal — matching py's behaviour.
+//
+// Note: we query a literal table name here instead of importing the
+// migration package to avoid an import cycle between orchestration and
+// migration (coordinator already depends on migration for executor.go).
+// The migration package defines this table as `_migration_history`; the
+// constant is duplicated in migrationTableName below.
+func checkMigrationTable(ctx context.Context, client *connection.DatabaseClient) bool {
+	if client == nil {
+		return false
+	}
+	_, err := client.Query(ctx, "SELECT * FROM "+migrationTableName+" LIMIT 1")
+	return err == nil
+}
+
+// migrationTableName mirrors migration.MigrationTableName. Duplicated to
+// keep the orchestration/migration dependency one-way (migration does not
+// import orchestration, and this package only consumes migration in
+// coordinator.go).
+const migrationTableName = "_migration_history"
+
+// CheckEnvironmentHealth is a convenience wrapper around
+// HealthCheck.CheckEnvironment using a fresh HealthCheck.
+func CheckEnvironmentHealth(ctx context.Context, env EnvironmentConfig) HealthStatus {
+	return NewHealthCheck().CheckEnvironment(ctx, env)
+}
+
+// VerifyConnectivity is a convenience wrapper around
+// HealthCheck.CheckConnectivity using a fresh HealthCheck.
+func VerifyConnectivity(ctx context.Context, env EnvironmentConfig) bool {
+	return NewHealthCheck().CheckConnectivity(ctx, env)
+}

--- a/pkg/surql/orchestration/health_test.go
+++ b/pkg/surql/orchestration/health_test.go
@@ -1,0 +1,116 @@
+package orchestration
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Oneiriq/surql-go/pkg/surql/connection"
+)
+
+func TestHealthCheck_CannotConnect(t *testing.T) {
+	t.Parallel()
+
+	hc := &HealthCheck{
+		Factory: func(ctx context.Context, cfg connection.ConnectionConfig) (*connection.DatabaseClient, func(), error) {
+			return nil, func() {}, errors.New("boom")
+		},
+	}
+	status := hc.CheckEnvironment(context.Background(), EnvironmentConfig{
+		Name:       "prod",
+		Connection: testConfig(),
+	})
+	if status.IsHealthy {
+		t.Fatal("IsHealthy = true, want false on connection failure")
+	}
+	if status.CanConnect {
+		t.Fatal("CanConnect = true, want false")
+	}
+	if status.Error == "" {
+		t.Fatal("Error should be populated on failure")
+	}
+}
+
+func TestHealthCheck_CheckConnectivity_Fail(t *testing.T) {
+	t.Parallel()
+
+	hc := &HealthCheck{
+		Factory: func(ctx context.Context, cfg connection.ConnectionConfig) (*connection.DatabaseClient, func(), error) {
+			return nil, func() {}, errors.New("boom")
+		},
+	}
+	if hc.CheckConnectivity(context.Background(), EnvironmentConfig{
+		Name:       "prod",
+		Connection: testConfig(),
+	}) {
+		t.Fatal("CheckConnectivity = true, want false")
+	}
+}
+
+func TestHealthCheck_VerifyAllEnvironments_ParallelFailures(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	hc := &HealthCheck{
+		Factory: func(ctx context.Context, cfg connection.ConnectionConfig) (*connection.DatabaseClient, func(), error) {
+			calls.Add(1)
+			return nil, func() {}, errors.New("boom")
+		},
+	}
+	envs := buildEnvs(5)
+	statuses := hc.VerifyAllEnvironments(context.Background(), envs)
+	if len(statuses) != 5 {
+		t.Fatalf("len(statuses) = %d, want 5", len(statuses))
+	}
+	if calls.Load() != 5 {
+		t.Fatalf("factory calls = %d, want 5", calls.Load())
+	}
+	for name, s := range statuses {
+		if s.IsHealthy {
+			t.Fatalf("env %s should be unhealthy", name)
+		}
+	}
+}
+
+func TestHealthCheck_VerifyAllEnvironments_Empty(t *testing.T) {
+	t.Parallel()
+
+	hc := NewHealthCheck()
+	statuses := hc.VerifyAllEnvironments(context.Background(), nil)
+	if len(statuses) != 0 {
+		t.Fatalf("len(statuses) = %d, want 0", len(statuses))
+	}
+}
+
+func TestCheckEnvironmentHealth_PopulatesEnvironment(t *testing.T) {
+	t.Parallel()
+
+	// Using an already-cancelled context the default factory fails fast,
+	// so we exercise the wrapper shape without waiting on network retries.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	status := CheckEnvironmentHealth(ctx, EnvironmentConfig{
+		Name:       "prod",
+		Connection: testConfig(),
+	})
+	if status.Environment != "prod" {
+		t.Fatalf("Environment = %q, want prod", status.Environment)
+	}
+	if status.IsHealthy {
+		t.Fatal("expected unhealthy status under cancelled context")
+	}
+}
+
+func TestVerifyConnectivity_CancelledContextReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if VerifyConnectivity(ctx, EnvironmentConfig{
+		Name:       "prod",
+		Connection: testConfig(),
+	}) {
+		t.Fatal("VerifyConnectivity = true under cancelled ctx, want false")
+	}
+}

--- a/pkg/surql/orchestration/integration_test.go
+++ b/pkg/surql/orchestration/integration_test.go
@@ -1,0 +1,189 @@
+//go:build integration
+// +build integration
+
+package orchestration
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Oneiriq/surql-go/pkg/surql/connection"
+	"github.com/Oneiriq/surql-go/pkg/surql/migration"
+)
+
+// getIntegrationURL reads the SurrealDB URL used by CI's integration job.
+// Falls back to ws://localhost:8000/rpc when SURREAL_URL is unset; tests
+// skip when connectivity fails.
+func getIntegrationURL(t *testing.T) string {
+	t.Helper()
+	if url := os.Getenv("SURREAL_URL"); url != "" {
+		return url
+	}
+	return "ws://localhost:8000/rpc"
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// integrationConfig returns a ConnectionConfig tuned for the v3.0.5
+// docker-run container documented in the repo README. The namespace is
+// isolated so the orchestration integration suite can run alongside the
+// migration suite without collisions.
+func integrationConfig(t *testing.T, env string) connection.ConnectionConfig {
+	t.Helper()
+	cfg := connection.DefaultConfig()
+	cfg.DBURL = getIntegrationURL(t)
+	cfg.DBNS = "surqlgo_test"
+	cfg.DB = "orch_" + env
+	cfg.DBRetryMaxAttempts = 2
+	cfg.DBRetryMinWait = 0.2
+	cfg.DBRetryMaxWait = 1.0
+	cfg.DBRetryMultiplier = 2.0
+	return cfg
+}
+
+// integrationFactory is a ClientFactory that authenticates after
+// connecting so downstream queries hit a ready client. Required because
+// the default factory (defaultClientFactory) leaves the client
+// unauthenticated.
+func integrationFactory(t *testing.T) ClientFactory {
+	t.Helper()
+	user := envOr("SURREAL_USER", "root")
+	pass := envOr("SURREAL_PASS", "root")
+	return func(ctx context.Context, cfg connection.ConnectionConfig) (*connection.DatabaseClient, func(), error) {
+		client, err := connection.NewDatabaseClient(cfg)
+		if err != nil {
+			return nil, func() {}, err
+		}
+		if err := client.Connect(ctx); err != nil {
+			return nil, func() {}, err
+		}
+		if _, err := client.Signin(ctx, connection.NewRootCredentials(user, pass)); err != nil {
+			_ = client.Disconnect()
+			return nil, func() {}, err
+		}
+		return client, func() { _ = client.Disconnect() }, nil
+	}
+}
+
+// TestIntegration_DeployToEnvironments_Sequential verifies an end-to-end
+// sequential deploy against a live SurrealDB: two environments, one
+// migration each, health checks enabled.
+func TestIntegration_DeployToEnvironments_Sequential(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	factory := integrationFactory(t)
+
+	// Smoke-test the factory once to surface SKIP early when the
+	// container is unreachable.
+	if _, cleanup, err := factory(ctx, integrationConfig(t, "probe")); err != nil {
+		t.Skipf("SurrealDB unreachable: %v", err)
+	} else {
+		cleanup()
+	}
+
+	registry := NewEnvironmentRegistry()
+	if err := registry.Register("env_a", integrationConfig(t, "a"), &RegisterOptions{Priority: 1}); err != nil {
+		t.Fatalf("Register env_a: %v", err)
+	}
+	if err := registry.Register("env_b", integrationConfig(t, "b"), &RegisterOptions{Priority: 2}); err != nil {
+		t.Fatalf("Register env_b: %v", err)
+	}
+
+	// Clean history tables before the test so repeated runs stay idempotent.
+	cleanupEnvs(ctx, t, factory, registry, "env_a", "env_b")
+	t.Cleanup(func() { cleanupEnvs(ctx, t, factory, registry, "env_a", "env_b") })
+
+	coord := NewMigrationCoordinator(registry)
+	migrations := []migration.Migration{
+		{
+			Version:        "20240101_000000",
+			Description:    "create orch_demo",
+			UpStatements:   []string{"DEFINE TABLE orch_demo SCHEMAFULL;"},
+			DownStatements: []string{"REMOVE TABLE IF EXISTS orch_demo;"},
+		},
+	}
+
+	falseVal := false
+	results, err := coord.DeployToEnvironments(
+		ctx,
+		[]string{"env_a", "env_b"},
+		migrations,
+		&DeployOptions{
+			Strategy:     StrategySequential,
+			Factory:      factory,
+			VerifyHealth: &falseVal, // history table probe would add latency; rely on deploy to surface failures.
+		},
+	)
+	if err != nil {
+		t.Fatalf("DeployToEnvironments: %v", err)
+	}
+	for _, env := range []string{"env_a", "env_b"} {
+		r, ok := results[env]
+		if !ok {
+			t.Fatalf("results missing %s", env)
+		}
+		if r.Status != DeploymentStatusSuccess {
+			t.Fatalf("%s status = %s (err=%q), want success", env, r.Status, r.Error)
+		}
+		if r.MigrationsApplied != 1 {
+			t.Fatalf("%s MigrationsApplied = %d, want 1", env, r.MigrationsApplied)
+		}
+	}
+}
+
+// TestIntegration_HealthCheck verifies the connectivity probe against a
+// live SurrealDB.
+func TestIntegration_HealthCheck(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	factory := integrationFactory(t)
+	if _, cleanup, err := factory(ctx, integrationConfig(t, "probe")); err != nil {
+		t.Skipf("SurrealDB unreachable: %v", err)
+	} else {
+		cleanup()
+	}
+
+	hc := &HealthCheck{Factory: factory}
+	status := hc.CheckEnvironment(ctx, EnvironmentConfig{
+		Name:       "env_health",
+		Connection: integrationConfig(t, "health"),
+	})
+	if !status.IsHealthy {
+		t.Fatalf("status = %+v, want healthy", status)
+	}
+	if !status.CanConnect {
+		t.Fatal("CanConnect = false")
+	}
+}
+
+// cleanupEnvs drops the migration history + orch_demo table in each named
+// environment. Swallows errors: the purpose is best-effort isolation.
+func cleanupEnvs(ctx context.Context, t *testing.T, factory ClientFactory, registry *EnvironmentRegistry, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		env, err := registry.Get(name)
+		if err != nil {
+			continue
+		}
+		client, cleanup, err := factory(ctx, env.Connection)
+		if err != nil {
+			continue
+		}
+		for _, stmt := range []string{
+			"REMOVE TABLE IF EXISTS orch_demo;",
+			"REMOVE TABLE IF EXISTS _migration_history;",
+		} {
+			_, _ = client.Query(ctx, stmt)
+		}
+		cleanup()
+	}
+}

--- a/pkg/surql/orchestration/result.go
+++ b/pkg/surql/orchestration/result.go
@@ -1,0 +1,72 @@
+package orchestration
+
+import "time"
+
+// DeploymentStatus captures the lifecycle state of a single environment's
+// deployment. Mirrors surql-py's `DeploymentStatus` enum.
+type DeploymentStatus string
+
+// DeploymentStatus values.
+const (
+	// DeploymentStatusPending indicates the deployment has not started.
+	DeploymentStatusPending DeploymentStatus = "pending"
+	// DeploymentStatusInProgress indicates the deployment is running.
+	DeploymentStatusInProgress DeploymentStatus = "in_progress"
+	// DeploymentStatusSuccess indicates every migration applied cleanly.
+	DeploymentStatusSuccess DeploymentStatus = "success"
+	// DeploymentStatusFailed indicates at least one migration failed.
+	DeploymentStatusFailed DeploymentStatus = "failed"
+	// DeploymentStatusRolledBack indicates a previously successful
+	// deployment has been reverted via auto-rollback.
+	DeploymentStatusRolledBack DeploymentStatus = "rolled_back"
+)
+
+// IsValid reports whether s is one of the defined DeploymentStatus values.
+func (s DeploymentStatus) IsValid() bool {
+	switch s {
+	case DeploymentStatusPending, DeploymentStatusInProgress,
+		DeploymentStatusSuccess, DeploymentStatusFailed,
+		DeploymentStatusRolledBack:
+		return true
+	}
+	return false
+}
+
+// String returns the serialized form of the status.
+func (s DeploymentStatus) String() string { return string(s) }
+
+// DeploymentResult is the outcome of running a strategy against a single
+// environment. All timing fields are in UTC.
+//
+// Zero-value DeploymentResult is meaningful only as a placeholder while a
+// deployment is in flight (CompletedAt will be the zero Time). Callers
+// should inspect Status for a definitive verdict.
+type DeploymentResult struct {
+	// Environment is the name of the target environment.
+	Environment string `json:"environment"`
+	// Status is the final lifecycle state.
+	Status DeploymentStatus `json:"status"`
+	// StartedAt is when the strategy began deploying to this environment.
+	StartedAt time.Time `json:"started_at"`
+	// CompletedAt is when the strategy finished (success or failure). Zero
+	// value when still in progress.
+	CompletedAt time.Time `json:"completed_at,omitempty"`
+	// Error is the human-readable failure reason; empty when Status ==
+	// DeploymentStatusSuccess.
+	Error string `json:"error,omitempty"`
+	// ExecutionTimeMs is the wall-clock duration of the deploy in
+	// milliseconds. Zero when still in progress or when the deploy failed
+	// before timing could be captured.
+	ExecutionTimeMs int64 `json:"execution_time_ms,omitempty"`
+	// MigrationsApplied is how many migrations were executed successfully.
+	MigrationsApplied int `json:"migrations_applied"`
+}
+
+// DurationSeconds returns the wall-clock duration of the deploy in seconds,
+// or 0 when CompletedAt is the zero Time.
+func (r DeploymentResult) DurationSeconds() float64 {
+	if r.CompletedAt.IsZero() {
+		return 0
+	}
+	return r.CompletedAt.Sub(r.StartedAt).Seconds()
+}

--- a/pkg/surql/orchestration/result_test.go
+++ b/pkg/surql/orchestration/result_test.go
@@ -1,0 +1,74 @@
+package orchestration
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDeploymentStatus_IsValid(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   DeploymentStatus
+		want bool
+	}{
+		{DeploymentStatusPending, true},
+		{DeploymentStatusInProgress, true},
+		{DeploymentStatusSuccess, true},
+		{DeploymentStatusFailed, true},
+		{DeploymentStatusRolledBack, true},
+		{DeploymentStatus(""), false},
+		{DeploymentStatus("bogus"), false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(string(tc.in), func(t *testing.T) {
+			t.Parallel()
+			if got := tc.in.IsValid(); got != tc.want {
+				t.Fatalf("IsValid(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeploymentStatus_String(t *testing.T) {
+	t.Parallel()
+
+	if DeploymentStatusSuccess.String() != "success" {
+		t.Fatalf("String = %q, want success", DeploymentStatusSuccess.String())
+	}
+}
+
+func TestDeploymentResult_DurationSeconds(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name  string
+		input DeploymentResult
+		want  float64
+	}{
+		{
+			name: "completed 2s",
+			input: DeploymentResult{
+				StartedAt:   start,
+				CompletedAt: start.Add(2 * time.Second),
+			},
+			want: 2.0,
+		},
+		{
+			name:  "in progress returns 0",
+			input: DeploymentResult{StartedAt: start},
+			want:  0,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.input.DurationSeconds(); got != tc.want {
+				t.Fatalf("DurationSeconds = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/surql/orchestration/strategies.go
+++ b/pkg/surql/orchestration/strategies.go
@@ -1,0 +1,519 @@
+package orchestration
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/migration"
+)
+
+// DeploymentPlan is the input to DeploymentStrategy.Deploy. It carries the
+// target environments, the migrations to apply, and strategy-specific
+// knobs (BatchSize, CanaryPercentage, ...).
+//
+// Strategies read only the fields relevant to their shape; irrelevant
+// fields are ignored. Plans are safe to share across strategies because
+// they are treated as read-only.
+type DeploymentPlan struct {
+	// Environments is the ordered list of environments to deploy to. The
+	// coordinator resolves names against the registry before building the
+	// plan, so this slice must contain ready EnvironmentConfig values.
+	Environments []EnvironmentConfig
+	// Migrations are the migrations to apply in order (UP direction).
+	Migrations []migration.Migration
+	// BatchSize applies to RollingStrategy — environments are deployed in
+	// batches of this size. Defaults to 1 when zero.
+	BatchSize int
+	// CanaryPercentage applies to CanaryStrategy — the percentage (1-50)
+	// of environments to deploy to first before rolling out the remainder.
+	// Defaults to 10.0 when zero.
+	CanaryPercentage float64
+	// MaxConcurrent applies to ParallelStrategy — caps the number of
+	// in-flight deployments. Defaults to 5 when zero.
+	MaxConcurrent int
+	// DryRun skips migration execution but still reports realistic
+	// DeploymentResult shapes.
+	DryRun bool
+	// Factory overrides the DatabaseClient constructor. When nil the
+	// production factory is used (which dials the real database). Tests
+	// inject a fake factory to keep runs hermetic.
+	Factory ClientFactory
+}
+
+// DeploymentStrategy is the interface implemented by Sequential,
+// Parallel, Rolling, and Canary strategies. Implementations must be safe
+// to call concurrently across different plans but need not protect their
+// own state; the coordinator never reuses a strategy instance across
+// concurrent deploys.
+type DeploymentStrategy interface {
+	Deploy(ctx context.Context, plan *DeploymentPlan) (*DeploymentResult, error)
+	// DeployAll returns the per-environment results, ordered to match
+	// plan.Environments. DeployAll is the primary surface used by
+	// MigrationCoordinator; Deploy returns the first failing or last
+	// successful result for callers that want a simple single-result view.
+	DeployAll(ctx context.Context, plan *DeploymentPlan) ([]DeploymentResult, error)
+}
+
+// ---------------------------------------------------------------------------
+// Shared deploy helpers
+// ---------------------------------------------------------------------------
+
+// executeOnEnvironment runs every migration in plan.Migrations (UP
+// direction) against env. Returns a DeploymentResult describing the
+// outcome. Errors never escape this function — they are reported via the
+// returned result's Status / Error fields.
+func executeOnEnvironment(
+	ctx context.Context,
+	env EnvironmentConfig,
+	plan *DeploymentPlan,
+) DeploymentResult {
+	started := time.Now().UTC()
+
+	if plan.DryRun {
+		// Mirror py's simulated 100ms sleep so dry-runs look realistic
+		// without doing any I/O.
+		select {
+		case <-time.After(100 * time.Millisecond):
+		case <-ctx.Done():
+			completed := time.Now().UTC()
+			return DeploymentResult{
+				Environment:     env.Name,
+				Status:          DeploymentStatusFailed,
+				StartedAt:       started,
+				CompletedAt:     completed,
+				Error:           ctx.Err().Error(),
+				ExecutionTimeMs: completed.Sub(started).Milliseconds(),
+			}
+		}
+		completed := time.Now().UTC()
+		return DeploymentResult{
+			Environment:       env.Name,
+			Status:            DeploymentStatusSuccess,
+			StartedAt:         started,
+			CompletedAt:       completed,
+			ExecutionTimeMs:   completed.Sub(started).Milliseconds(),
+			MigrationsApplied: len(plan.Migrations),
+		}
+	}
+
+	factory := plan.Factory
+	if factory == nil {
+		factory = defaultClientFactory
+	}
+
+	client, cleanup, err := factory(ctx, env.Connection)
+	if err != nil {
+		completed := time.Now().UTC()
+		return DeploymentResult{
+			Environment: env.Name,
+			Status:      DeploymentStatusFailed,
+			StartedAt:   started,
+			CompletedAt: completed,
+			Error:       fmt.Sprintf("connect to %s failed: %v", env.Name, err),
+		}
+	}
+	defer cleanup()
+
+	applied := 0
+	for _, m := range plan.Migrations {
+		if _, err := migration.ExecuteMigration(ctx, client, m, migration.MigrationDirectionUp); err != nil {
+			completed := time.Now().UTC()
+			return DeploymentResult{
+				Environment:       env.Name,
+				Status:            DeploymentStatusFailed,
+				StartedAt:         started,
+				CompletedAt:       completed,
+				Error:             fmt.Sprintf("migration %s failed: %v", m.Version, err),
+				MigrationsApplied: applied,
+			}
+		}
+		applied++
+	}
+
+	completed := time.Now().UTC()
+	return DeploymentResult{
+		Environment:       env.Name,
+		Status:            DeploymentStatusSuccess,
+		StartedAt:         started,
+		CompletedAt:       completed,
+		ExecutionTimeMs:   completed.Sub(started).Milliseconds(),
+		MigrationsApplied: applied,
+	}
+}
+
+// lastOrEmpty returns the last result in results (or a zero-value
+// DeploymentResult when the slice is empty). Used to supply a sensible
+// Deploy return when the caller wants a single-result view.
+func lastOrEmpty(results []DeploymentResult) *DeploymentResult {
+	if len(results) == 0 {
+		return &DeploymentResult{}
+	}
+	last := results[len(results)-1]
+	return &last
+}
+
+// firstFailure scans results and returns the first DeploymentStatusFailed
+// entry, or nil when every entry succeeded.
+func firstFailure(results []DeploymentResult) *DeploymentResult {
+	for i := range results {
+		if results[i].Status == DeploymentStatusFailed {
+			r := results[i]
+			return &r
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// SequentialStrategy
+// ---------------------------------------------------------------------------
+
+// SequentialStrategy deploys to environments one at a time in order,
+// stopping at the first failure. Mirrors surql-py's `SequentialStrategy`.
+type SequentialStrategy struct{}
+
+// NewSequentialStrategy constructs a SequentialStrategy.
+func NewSequentialStrategy() *SequentialStrategy { return &SequentialStrategy{} }
+
+// Deploy runs the plan and returns the last processed result (failed or
+// final).
+func (s *SequentialStrategy) Deploy(ctx context.Context, plan *DeploymentPlan) (*DeploymentResult, error) {
+	results, err := s.DeployAll(ctx, plan)
+	if err != nil {
+		return nil, err
+	}
+	if fail := firstFailure(results); fail != nil {
+		return fail, nil
+	}
+	return lastOrEmpty(results), nil
+}
+
+// DeployAll deploys sequentially, stopping on the first failure.
+func (s *SequentialStrategy) DeployAll(ctx context.Context, plan *DeploymentPlan) ([]DeploymentResult, error) {
+	if plan == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrOrchestration, "deployment plan cannot be nil")
+	}
+	results := make([]DeploymentResult, 0, len(plan.Environments))
+	for _, env := range plan.Environments {
+		r := executeOnEnvironment(ctx, env, plan)
+		results = append(results, r)
+		if r.Status == DeploymentStatusFailed {
+			break
+		}
+	}
+	return results, nil
+}
+
+// ---------------------------------------------------------------------------
+// ParallelStrategy
+// ---------------------------------------------------------------------------
+
+// ParallelStrategy deploys to every environment concurrently, bounded by
+// MaxConcurrent. Mirrors surql-py's `ParallelStrategy`.
+type ParallelStrategy struct {
+	// MaxConcurrent caps in-flight deployments. Zero defers to
+	// plan.MaxConcurrent, which defaults to 5.
+	MaxConcurrent int
+}
+
+// NewParallelStrategy constructs a ParallelStrategy. Pass maxConcurrent <= 0
+// to inherit from the plan.
+func NewParallelStrategy(maxConcurrent int) *ParallelStrategy {
+	return &ParallelStrategy{MaxConcurrent: maxConcurrent}
+}
+
+// Deploy runs the plan and returns the first failing result (when any) or
+// the last successful result.
+func (p *ParallelStrategy) Deploy(ctx context.Context, plan *DeploymentPlan) (*DeploymentResult, error) {
+	results, err := p.DeployAll(ctx, plan)
+	if err != nil {
+		return nil, err
+	}
+	if fail := firstFailure(results); fail != nil {
+		return fail, nil
+	}
+	return lastOrEmpty(results), nil
+}
+
+// DeployAll fans out to environments with a semaphore-bounded worker pool.
+// Results are returned in plan.Environments order regardless of
+// completion order.
+func (p *ParallelStrategy) DeployAll(ctx context.Context, plan *DeploymentPlan) ([]DeploymentResult, error) {
+	if plan == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrOrchestration, "deployment plan cannot be nil")
+	}
+	limit := p.MaxConcurrent
+	if limit <= 0 {
+		limit = plan.MaxConcurrent
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+
+	results := make([]DeploymentResult, len(plan.Environments))
+	sem := make(chan struct{}, limit)
+	var wg sync.WaitGroup
+
+	for i, env := range plan.Environments {
+		i, env := i, env
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			results[i] = executeOnEnvironment(ctx, env, plan)
+		}()
+	}
+	wg.Wait()
+	return results, nil
+}
+
+// ---------------------------------------------------------------------------
+// RollingStrategy
+// ---------------------------------------------------------------------------
+
+// RollingStrategy deploys environments in batches. Within each batch the
+// deployments run in parallel; batches run sequentially with a short
+// stability delay in between. Stops on the first batch that contains a
+// failure. Mirrors surql-py's `RollingStrategy`.
+type RollingStrategy struct {
+	// BatchSize defaults to plan.BatchSize when <= 0; plan default is 1.
+	BatchSize int
+	// BatchDelay is the pause between successive batches. Defaults to
+	// 1s — matching py's `anyio.sleep(1.0)`.
+	BatchDelay time.Duration
+}
+
+// NewRollingStrategy constructs a RollingStrategy. batchSize <= 0 defers
+// to the plan; batchDelay <= 0 defers to the 1s default.
+func NewRollingStrategy(batchSize int, batchDelay time.Duration) *RollingStrategy {
+	return &RollingStrategy{BatchSize: batchSize, BatchDelay: batchDelay}
+}
+
+// Deploy runs the plan and returns the first failing result (when any) or
+// the last successful result.
+func (r *RollingStrategy) Deploy(ctx context.Context, plan *DeploymentPlan) (*DeploymentResult, error) {
+	results, err := r.DeployAll(ctx, plan)
+	if err != nil {
+		return nil, err
+	}
+	if fail := firstFailure(results); fail != nil {
+		return fail, nil
+	}
+	return lastOrEmpty(results), nil
+}
+
+// DeployAll deploys in batches.
+func (r *RollingStrategy) DeployAll(ctx context.Context, plan *DeploymentPlan) ([]DeploymentResult, error) {
+	if plan == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrOrchestration, "deployment plan cannot be nil")
+	}
+	batchSize := r.BatchSize
+	if batchSize <= 0 {
+		batchSize = plan.BatchSize
+	}
+	if batchSize <= 0 {
+		batchSize = 1
+	}
+	delay := r.BatchDelay
+	if delay <= 0 {
+		delay = time.Second
+	}
+
+	results := make([]DeploymentResult, 0, len(plan.Environments))
+	total := len(plan.Environments)
+
+	for i := 0; i < total; i += batchSize {
+		end := i + batchSize
+		if end > total {
+			end = total
+		}
+		batch := plan.Environments[i:end]
+		batchResults := make([]DeploymentResult, len(batch))
+		var wg sync.WaitGroup
+		for j, env := range batch {
+			j, env := j, env
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				batchResults[j] = executeOnEnvironment(ctx, env, plan)
+			}()
+		}
+		wg.Wait()
+		results = append(results, batchResults...)
+
+		// Stop on first batch failure.
+		if firstFailure(batchResults) != nil {
+			break
+		}
+
+		// Stability delay between batches, unless we just finished.
+		if end < total {
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return results, nil
+			}
+		}
+	}
+	return results, nil
+}
+
+// ---------------------------------------------------------------------------
+// CanaryStrategy
+// ---------------------------------------------------------------------------
+
+// CanaryStrategy deploys to a small subset (the "canary") first, then
+// rolls out to the remaining environments only when the canary succeeds.
+// Mirrors surql-py's `CanaryStrategy`, including percentage validation.
+type CanaryStrategy struct {
+	// Percentage is the canary percentage (1-50). Zero defers to the
+	// plan; plan default is 10.
+	Percentage float64
+}
+
+// NewCanaryStrategy constructs a CanaryStrategy. percentage <= 0 defers
+// to the plan. When non-zero the percentage must sit in [1, 50]; an
+// invalid value surfaces as ErrValidation on Deploy.
+func NewCanaryStrategy(percentage float64) *CanaryStrategy {
+	return &CanaryStrategy{Percentage: percentage}
+}
+
+// Deploy runs the canary + remainder and returns the first failing
+// result (when any) or the last successful result.
+func (c *CanaryStrategy) Deploy(ctx context.Context, plan *DeploymentPlan) (*DeploymentResult, error) {
+	results, err := c.DeployAll(ctx, plan)
+	if err != nil {
+		return nil, err
+	}
+	if fail := firstFailure(results); fail != nil {
+		return fail, nil
+	}
+	return lastOrEmpty(results), nil
+}
+
+// DeployAll runs the canary batch first; when any canary environment
+// fails the remainder is skipped. When the canary succeeds every
+// remaining environment is deployed in parallel.
+func (c *CanaryStrategy) DeployAll(ctx context.Context, plan *DeploymentPlan) ([]DeploymentResult, error) {
+	if plan == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrOrchestration, "deployment plan cannot be nil")
+	}
+	pct := c.Percentage
+	// Only the zero-value percentage defers to the plan; a non-zero but
+	// out-of-range percentage surfaces as ErrValidation below so
+	// operators see their mistake instead of silently falling back to
+	// defaults. Mirrors py's constructor-time check.
+	if pct == 0 {
+		pct = plan.CanaryPercentage
+	}
+	if pct == 0 {
+		pct = 10.0
+	}
+	if pct < 1.0 || pct > 50.0 {
+		return nil, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"canary percentage must be between 1.0 and 50.0, got %.2f", pct)
+	}
+
+	envs := plan.Environments
+	if len(envs) == 0 {
+		return nil, nil
+	}
+	canaryCount := int(float64(len(envs)) * pct / 100.0)
+	if canaryCount < 1 {
+		canaryCount = 1
+	}
+	if canaryCount > len(envs) {
+		canaryCount = len(envs)
+	}
+
+	canary := envs[:canaryCount]
+	remainder := envs[canaryCount:]
+
+	canaryResults := runParallel(ctx, canary, plan)
+	if firstFailure(canaryResults) != nil {
+		return canaryResults, nil
+	}
+	if len(remainder) == 0 {
+		return canaryResults, nil
+	}
+	remainderResults := runParallel(ctx, remainder, plan)
+	return append(canaryResults, remainderResults...), nil
+}
+
+// runParallel is the unbounded-parallel helper used by canary batches.
+// It preserves input order in the returned slice.
+func runParallel(ctx context.Context, envs []EnvironmentConfig, plan *DeploymentPlan) []DeploymentResult {
+	results := make([]DeploymentResult, len(envs))
+	var wg sync.WaitGroup
+	for i, env := range envs {
+		i, env := i, env
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results[i] = executeOnEnvironment(ctx, env, plan)
+		}()
+	}
+	wg.Wait()
+	return results
+}
+
+// ---------------------------------------------------------------------------
+// Strategy naming helpers
+// ---------------------------------------------------------------------------
+
+// StrategyName is a string alias used by DeploymentPlan-style entry
+// points that accept a named strategy (mirrors py's `strategy='rolling'`).
+type StrategyName string
+
+// Recognised strategy names.
+const (
+	StrategySequential StrategyName = "sequential"
+	StrategyParallel   StrategyName = "parallel"
+	StrategyRolling    StrategyName = "rolling"
+	StrategyCanary     StrategyName = "canary"
+)
+
+// IsValid reports whether s is a recognised strategy name.
+func (s StrategyName) IsValid() bool {
+	switch s {
+	case StrategySequential, StrategyParallel, StrategyRolling, StrategyCanary:
+		return true
+	}
+	return false
+}
+
+// NewStrategy constructs a DeploymentStrategy from a named strategy and a
+// reference plan. Unknown names return ErrValidation. Parameters come
+// from the plan (BatchSize, CanaryPercentage, MaxConcurrent) so strategies
+// produced by this helper stay in sync with the plan's knobs.
+func NewStrategy(name StrategyName, plan *DeploymentPlan) (DeploymentStrategy, error) {
+	switch name {
+	case StrategySequential:
+		return NewSequentialStrategy(), nil
+	case StrategyParallel:
+		max := 0
+		if plan != nil {
+			max = plan.MaxConcurrent
+		}
+		return NewParallelStrategy(max), nil
+	case StrategyRolling:
+		batch := 0
+		if plan != nil {
+			batch = plan.BatchSize
+		}
+		return NewRollingStrategy(batch, 0), nil
+	case StrategyCanary:
+		pct := 0.0
+		if plan != nil {
+			pct = plan.CanaryPercentage
+		}
+		return NewCanaryStrategy(pct), nil
+	default:
+		return nil, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"unknown deployment strategy %q (want sequential, parallel, rolling, or canary)", name)
+	}
+}

--- a/pkg/surql/orchestration/strategies_test.go
+++ b/pkg/surql/orchestration/strategies_test.go
@@ -1,0 +1,438 @@
+package orchestration
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Oneiriq/surql-go/pkg/surql/connection"
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/migration"
+)
+
+// buildEnvs produces n environments named env0..envN-1 with priority i+1
+// using a dummy memory:// connection config that passes validation.
+func buildEnvs(n int) []EnvironmentConfig {
+	out := make([]EnvironmentConfig, n)
+	for i := 0; i < n; i++ {
+		out[i] = EnvironmentConfig{
+			Name:       "env" + itoa(i),
+			Connection: testConfig(),
+			Priority:   i + 1,
+		}
+	}
+	return out
+}
+
+// buildMigrations produces n dummy migrations.
+func buildMigrations(n int) []migration.Migration {
+	out := make([]migration.Migration, n)
+	for i := 0; i < n; i++ {
+		out[i] = migration.Migration{
+			Version:      "2024010" + itoa(i) + "_000000",
+			Description:  "test",
+			UpStatements: []string{"DEFINE TABLE dummy;"},
+		}
+	}
+	return out
+}
+
+// failingFactory returns a ClientFactory whose every call returns an
+// error. Useful for verifying that strategies report failures without
+// requiring a live database.
+func failingFactory(counter *atomic.Int32) ClientFactory {
+	return func(ctx context.Context, cfg connection.ConnectionConfig) (*connection.DatabaseClient, func(), error) {
+		counter.Add(1)
+		return nil, func() {}, errors.New("factory disabled for test")
+	}
+}
+
+// selectiveFactory returns a factory that fails for environments listed in
+// failFor; every other environment is returned via the default factory
+// (which would attempt to connect — so tests using selectiveFactory must
+// arrange to never hit the success path, e.g. by listing every env).
+func selectiveFactory(failFor map[string]struct{}) ClientFactory {
+	return func(ctx context.Context, cfg connection.ConnectionConfig) (*connection.DatabaseClient, func(), error) {
+		if _, ok := failFor[cfg.DBNS]; ok {
+			return nil, func() {}, errors.New("selective failure")
+		}
+		// Should not be invoked in tests; produce an error to keep
+		// runs hermetic.
+		return nil, func() {}, errors.New("unconfigured environment in test factory")
+	}
+}
+
+func TestSequentialStrategy_DryRunAllSucceed(t *testing.T) {
+	t.Parallel()
+
+	plan := &DeploymentPlan{
+		Environments: buildEnvs(3),
+		Migrations:   buildMigrations(2),
+		DryRun:       true,
+	}
+	results, err := NewSequentialStrategy().DeployAll(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("DeployAll: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("len(results) = %d, want 3", len(results))
+	}
+	for _, r := range results {
+		if r.Status != DeploymentStatusSuccess {
+			t.Fatalf("env %s status = %s, want success", r.Environment, r.Status)
+		}
+		if r.MigrationsApplied != 2 {
+			t.Fatalf("env %s MigrationsApplied = %d, want 2", r.Environment, r.MigrationsApplied)
+		}
+	}
+}
+
+func TestSequentialStrategy_StopsOnFirstFailure(t *testing.T) {
+	t.Parallel()
+
+	var counter atomic.Int32
+	plan := &DeploymentPlan{
+		Environments: buildEnvs(3),
+		Migrations:   buildMigrations(1),
+		Factory:      failingFactory(&counter),
+	}
+	results, err := NewSequentialStrategy().DeployAll(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("DeployAll: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1 (sequential must stop on failure)", len(results))
+	}
+	if results[0].Status != DeploymentStatusFailed {
+		t.Fatalf("status = %s, want failed", results[0].Status)
+	}
+	if counter.Load() != 1 {
+		t.Fatalf("factory called %d times, want 1", counter.Load())
+	}
+}
+
+func TestSequentialStrategy_Deploy_ReturnsFirstFailure(t *testing.T) {
+	t.Parallel()
+
+	var counter atomic.Int32
+	plan := &DeploymentPlan{
+		Environments: buildEnvs(3),
+		Migrations:   buildMigrations(1),
+		Factory:      failingFactory(&counter),
+	}
+	r, err := NewSequentialStrategy().Deploy(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if r.Status != DeploymentStatusFailed {
+		t.Fatalf("Deploy status = %s, want failed", r.Status)
+	}
+}
+
+func TestParallelStrategy_DryRunAllSucceed(t *testing.T) {
+	t.Parallel()
+
+	plan := &DeploymentPlan{
+		Environments:  buildEnvs(5),
+		Migrations:    buildMigrations(1),
+		DryRun:        true,
+		MaxConcurrent: 2,
+	}
+	start := time.Now()
+	results, err := NewParallelStrategy(0).DeployAll(context.Background(), plan)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("DeployAll: %v", err)
+	}
+	if len(results) != 5 {
+		t.Fatalf("len(results) = %d, want 5", len(results))
+	}
+	for _, r := range results {
+		if r.Status != DeploymentStatusSuccess {
+			t.Fatalf("env %s status = %s, want success", r.Environment, r.Status)
+		}
+	}
+	// With MaxConcurrent=2 and a 100ms simulated deploy, 5 envs take
+	// at least 3 * 100ms. Use a loose upper bound to avoid flakiness.
+	if elapsed < 250*time.Millisecond {
+		t.Fatalf("elapsed %v too short for MaxConcurrent=2 (want >= 250ms)", elapsed)
+	}
+}
+
+func TestParallelStrategy_PreservesOrder(t *testing.T) {
+	t.Parallel()
+
+	plan := &DeploymentPlan{
+		Environments: buildEnvs(4),
+		Migrations:   buildMigrations(1),
+		DryRun:       true,
+	}
+	results, err := NewParallelStrategy(10).DeployAll(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("DeployAll: %v", err)
+	}
+	for i, r := range results {
+		if r.Environment != "env"+itoa(i) {
+			t.Fatalf("results[%d].Environment = %s, want env%d", i, r.Environment, i)
+		}
+	}
+}
+
+func TestParallelStrategy_FactoryFailureReportsAll(t *testing.T) {
+	t.Parallel()
+
+	var counter atomic.Int32
+	plan := &DeploymentPlan{
+		Environments: buildEnvs(3),
+		Migrations:   buildMigrations(1),
+		Factory:      failingFactory(&counter),
+	}
+	results, err := NewParallelStrategy(0).DeployAll(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("DeployAll: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("len(results) = %d, want 3 (parallel deploys all, including failures)", len(results))
+	}
+	for _, r := range results {
+		if r.Status != DeploymentStatusFailed {
+			t.Fatalf("env %s status = %s, want failed", r.Environment, r.Status)
+		}
+	}
+	if counter.Load() != 3 {
+		t.Fatalf("factory calls = %d, want 3", counter.Load())
+	}
+}
+
+func TestRollingStrategy_DryRunBatches(t *testing.T) {
+	t.Parallel()
+
+	plan := &DeploymentPlan{
+		Environments: buildEnvs(4),
+		Migrations:   buildMigrations(1),
+		DryRun:       true,
+		BatchSize:    2,
+	}
+	results, err := NewRollingStrategy(0, 10*time.Millisecond).DeployAll(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("DeployAll: %v", err)
+	}
+	if len(results) != 4 {
+		t.Fatalf("len(results) = %d, want 4", len(results))
+	}
+	for _, r := range results {
+		if r.Status != DeploymentStatusSuccess {
+			t.Fatalf("env %s status = %s, want success", r.Environment, r.Status)
+		}
+	}
+}
+
+func TestRollingStrategy_StopsOnBatchFailure(t *testing.T) {
+	t.Parallel()
+
+	var factoryCalls atomic.Int32
+	// Every factory call fails, so the first batch fails wholesale and
+	// the rolling strategy must stop before attempting the second batch.
+	factory := func(ctx context.Context, cfg connection.ConnectionConfig) (*connection.DatabaseClient, func(), error) {
+		factoryCalls.Add(1)
+		return nil, func() {}, errors.New("injected failure")
+	}
+
+	plan := &DeploymentPlan{
+		Environments: buildEnvs(4),
+		Migrations:   buildMigrations(1),
+		BatchSize:    2,
+		Factory:      factory,
+	}
+	results, err := NewRollingStrategy(0, 10*time.Millisecond).DeployAll(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("DeployAll: %v", err)
+	}
+	// First batch's 2 failures are recorded; second batch never runs.
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2 (rolling stops on batch failure)", len(results))
+	}
+	if factoryCalls.Load() != 2 {
+		t.Fatalf("factory calls = %d, want 2 (first batch only)", factoryCalls.Load())
+	}
+}
+
+func TestRollingStrategy_BatchSizeDefaultsToOne(t *testing.T) {
+	t.Parallel()
+
+	plan := &DeploymentPlan{
+		Environments: buildEnvs(3),
+		Migrations:   buildMigrations(1),
+		DryRun:       true,
+	}
+	r := NewRollingStrategy(0, 1*time.Millisecond)
+	results, err := r.DeployAll(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("DeployAll: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("len(results) = %d, want 3", len(results))
+	}
+}
+
+func TestCanaryStrategy_SucceedsThenDeploysRemainder(t *testing.T) {
+	t.Parallel()
+
+	plan := &DeploymentPlan{
+		Environments:     buildEnvs(10),
+		Migrations:       buildMigrations(1),
+		DryRun:           true,
+		CanaryPercentage: 20.0, // 2 envs canary, 8 remainder
+	}
+	results, err := NewCanaryStrategy(0).DeployAll(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("DeployAll: %v", err)
+	}
+	if len(results) != 10 {
+		t.Fatalf("len(results) = %d, want 10", len(results))
+	}
+	for _, r := range results {
+		if r.Status != DeploymentStatusSuccess {
+			t.Fatalf("env %s status = %s, want success", r.Environment, r.Status)
+		}
+	}
+}
+
+func TestCanaryStrategy_FailsSkipsRemainder(t *testing.T) {
+	t.Parallel()
+
+	var canaryCalls atomic.Int32
+	// All factory calls fail — this also asserts that once the canary
+	// fails the remainder is never attempted (remainder would add more
+	// factory calls beyond the canary count).
+	factory := func(ctx context.Context, cfg connection.ConnectionConfig) (*connection.DatabaseClient, func(), error) {
+		canaryCalls.Add(1)
+		return nil, func() {}, errors.New("canary failure")
+	}
+
+	plan := &DeploymentPlan{
+		Environments:     buildEnvs(10),
+		Migrations:       buildMigrations(1),
+		CanaryPercentage: 20.0, // 2 canary envs
+		Factory:          factory,
+	}
+	results, err := NewCanaryStrategy(0).DeployAll(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("DeployAll: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2 (canary only)", len(results))
+	}
+	if canaryCalls.Load() != 2 {
+		t.Fatalf("factory calls = %d, want 2", canaryCalls.Load())
+	}
+}
+
+func TestCanaryStrategy_InvalidPercentageErrors(t *testing.T) {
+	t.Parallel()
+
+	cases := []float64{0.5, 51.0, -1.0}
+	for _, pct := range cases {
+		pct := pct
+		t.Run("pct="+ftoa(pct), func(t *testing.T) {
+			t.Parallel()
+			plan := &DeploymentPlan{
+				Environments: buildEnvs(5),
+				Migrations:   buildMigrations(1),
+				DryRun:       true,
+			}
+			_, err := NewCanaryStrategy(pct).DeployAll(context.Background(), plan)
+			if !errors.Is(err, surqlerrors.ErrValidation) {
+				t.Fatalf("err = %v; want ErrValidation", err)
+			}
+		})
+	}
+}
+
+func TestCanaryStrategy_DefaultPercentage(t *testing.T) {
+	t.Parallel()
+
+	plan := &DeploymentPlan{
+		Environments: buildEnvs(10),
+		Migrations:   buildMigrations(1),
+		DryRun:       true,
+	}
+	results, err := NewCanaryStrategy(0).DeployAll(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("DeployAll: %v", err)
+	}
+	if len(results) != 10 {
+		t.Fatalf("len(results) = %d, want 10", len(results))
+	}
+}
+
+func TestNewStrategy_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		input   StrategyName
+		wantErr error
+	}{
+		{"sequential", StrategySequential, nil},
+		{"parallel", StrategyParallel, nil},
+		{"rolling", StrategyRolling, nil},
+		{"canary", StrategyCanary, nil},
+		{"unknown", StrategyName("bogus"), surqlerrors.ErrValidation},
+	}
+	plan := &DeploymentPlan{}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s, err := NewStrategy(tc.input, plan)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+				if s == nil {
+					t.Fatal("nil strategy")
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("err = %v; want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestStrategy_NilPlan(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cases := []DeploymentStrategy{
+		NewSequentialStrategy(),
+		NewParallelStrategy(0),
+		NewRollingStrategy(0, 0),
+		NewCanaryStrategy(0),
+	}
+	for _, s := range cases {
+		if _, err := s.DeployAll(ctx, nil); !errors.Is(err, surqlerrors.ErrOrchestration) {
+			t.Fatalf("DeployAll(nil) err = %v; want ErrOrchestration", err)
+		}
+	}
+}
+
+// ftoa formats a float64 without importing strconv/fmt into the test.
+func ftoa(f float64) string {
+	// Simple non-scientific formatter for tiny test labels.
+	neg := f < 0
+	if neg {
+		f = -f
+	}
+	intPart := int(f)
+	fracPart := int((f - float64(intPart)) * 100)
+	s := itoa(intPart) + "." + itoa(fracPart)
+	if neg {
+		s = "-" + s
+	}
+	return s
+}


### PR DESCRIPTION
## Summary

Closes the multi-DB orchestration parity gap vs `surql-py`.

### New package `pkg/surql/orchestration/`
- `environment.go` — `EnvironmentConfig`, `EnvironmentRegistry`, helpers
- `coordinator.go` — `MigrationCoordinator`, `DeploymentPlan`, `DeployToEnvironments`
- `health.go` — `HealthCheck`, `HealthStatus`, connectivity + migration-table probe
- `strategies.go` — `DeploymentStrategy` interface + `Sequential/Parallel/Rolling/Canary`
- `result.go` — `DeploymentResult`, `DeploymentStatus`

## Deviations from py (documented inline)

- `DeploymentStrategy.Deploy` returns `(*DeploymentResult, error)`; added `DeployAll(ctx, plan) ([]DeploymentResult, error)` as the coordinator-level surface to make single-result / multi-result views explicit.
- `DeployOptions` uses tri-state `*bool` fields (`VerifyHealth`, `AutoRollback`) instead of py kwargs — distinguishes unset from explicitly-false.
- `ClientFactory` injection point for tests (py monkey-patches `get_client`).
- `CanaryStrategy` treats `pct == 0` as "not set" (falls back to plan or default 10); range 1-50 enforced at `DeployAll` time.
- `FindByTag` returns priority-ordered slice (py returns unordered).
- `_migration_history` table name duplicated as a private const in `health.go` to keep the dependency one-way.

## Test plan

- [x] `gofmt -l .` empty
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./... -race -count=1` — 1062 → 1215 test lines (+153)
- [x] `go test -tags=integration ./...` against `surrealdb/surrealdb:v3.0.5` — new `TestIntegration_DeployToEnvironments_Sequential` and `TestIntegration_HealthCheck` green

Refs #58, closes #66.