### PR TITLE
feat(migration): add squash + watcher + auto-snapshot hooks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Oneiriq/surql-go
 go 1.26.1
 
 require (
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/joho/godotenv v1.5.1
 	github.com/pelletier/go-toml/v2 v2.3.0
 	github.com/redis/go-redis/v9 v9.18.0
@@ -19,4 +20,5 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dolthub/maphash v0.1.0 h1:bsQ7JsF4FkkWyrP3oCnFJgrCUAFbFf3kOl4L/QxPDyQ=
 github.com/dolthub/maphash v0.1.0/go.mod h1:gkg4Ch4CdCDu5h6PMriVLawB7koZ+5ijb9puGMV50a4=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
@@ -49,6 +51,8 @@ github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/pkg/surql/migration/hooks.go
+++ b/pkg/surql/migration/hooks.go
@@ -7,8 +7,10 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync/atomic"
 
 	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/schema"
 )
 
 // DriftSeverity categorises a single DriftIssue. The zero value
@@ -297,4 +299,138 @@ func GeneratePreCommitConfig(schemaPath string, failOnDrift bool) string {
 			"        pass_filenames: false\n",
 		schemaPath, failFlag,
 	)
+}
+
+// ---------------------------------------------------------------------------
+// Auto-snapshot hooks
+// ---------------------------------------------------------------------------
+
+// autoSnapshotEnabled is the global kill switch toggled by
+// EnableAutoSnapshots / DisableAutoSnapshots. We use an atomic int32
+// (0 == off, 1 == on) so readers on the hot migration path can check it
+// with a single atomic load; writers are rare and come from test setups
+// or application bootstrap.
+var autoSnapshotEnabled atomic.Int32
+
+// EnableAutoSnapshots turns on automatic snapshot creation after a
+// migration is applied. Subsequent CreateSnapshotOnMigration calls will
+// persist a SchemaSnapshot to the caller-supplied directory.
+//
+// The state is process-global, matching surql-py's AUTO_SNAPSHOT_ENABLED
+// flag. It is safe to call concurrently from multiple goroutines.
+func EnableAutoSnapshots() {
+	autoSnapshotEnabled.Store(1)
+}
+
+// DisableAutoSnapshots turns off automatic snapshot creation. Queued
+// writes that have already started are unaffected.
+func DisableAutoSnapshots() {
+	autoSnapshotEnabled.Store(0)
+}
+
+// IsAutoSnapshotEnabled reports whether auto-snapshot creation is
+// currently enabled. Callers can gate their own snapshot emission on
+// this flag to mirror CreateSnapshotOnMigration's behaviour.
+func IsAutoSnapshotEnabled() bool {
+	return autoSnapshotEnabled.Load() == 1
+}
+
+// SnapshotHook captures optional callbacks that fire around an
+// automatic snapshot creation. Before runs immediately before the
+// snapshot is built; returning a non-nil error aborts the operation.
+// After runs after a successful Store, receiving the freshly written
+// file path and the snapshot itself.
+//
+// The Registry field supplies the schema registry to snapshot from;
+// it must be non-nil on invocation of CreateSnapshotOnMigration even
+// when both callbacks are nil.
+//
+// The zero value is a no-op wrapper suitable for callers that only
+// need the default pre/post hook semantics.
+type SnapshotHook struct {
+	// Registry is the schema registry to snapshot. Required.
+	Registry *schema.SchemaRegistry
+	// Before, when non-nil, runs before the snapshot is created. A
+	// non-nil return aborts the operation.
+	Before func(ctx context.Context, m Migration) error
+	// After, when non-nil, runs after the snapshot is successfully
+	// stored. path is the absolute filename on disk.
+	After func(ctx context.Context, m Migration, snapshot SchemaSnapshot, path string) error
+}
+
+// CreateSnapshotOnMigration builds and persists a SchemaSnapshot for
+// the just-applied migration, provided auto-snapshots are enabled.
+//
+// When IsAutoSnapshotEnabled returns false the call is a silent no-op
+// that returns an empty path and nil error — mirroring surql-py's
+// behaviour. When enabled, it runs any configured pre hook, calls
+// CreateSnapshot + StoreSnapshot with dir as the destination, and then
+// runs the post hook.
+//
+// dir must name an existing (or creatable) directory; the snapshot file
+// is written under "<dir>/<version>.snapshot.json". Failures at any
+// stage return a wrapped ErrMigrationHistory so the caller has a single
+// sentinel to match against.
+func CreateSnapshotOnMigration(
+	ctx context.Context,
+	dir string,
+	migration Migration,
+	hook SnapshotHook,
+) (string, error) {
+	if !IsAutoSnapshotEnabled() {
+		return "", nil
+	}
+
+	if err := ctx.Err(); err != nil {
+		return "", surqlerrors.Wrap(surqlerrors.ErrMigrationHistory,
+			"context cancelled before auto-snapshot", err)
+	}
+	if strings.TrimSpace(dir) == "" {
+		return "", surqlerrors.New(surqlerrors.ErrValidation,
+			"snapshot directory must not be empty")
+	}
+	if hook.Registry == nil {
+		return "", surqlerrors.New(surqlerrors.ErrValidation,
+			"SnapshotHook.Registry must not be nil")
+	}
+
+	if hook.Before != nil {
+		if err := hook.Before(ctx, migration); err != nil {
+			return "", surqlerrors.Wrap(surqlerrors.ErrMigrationHistory,
+				"pre-snapshot hook failed", err)
+		}
+	}
+
+	description := migration.Description
+	if description == "" {
+		description = fmt.Sprintf("auto-snapshot after %s", migration.Version)
+	}
+
+	snapshot, err := CreateSnapshot(hook.Registry, description)
+	if err != nil {
+		return "", surqlerrors.Wrap(surqlerrors.ErrMigrationHistory,
+			"failed to create snapshot", err)
+	}
+
+	if err := StoreSnapshot(snapshot, dir); err != nil {
+		return "", surqlerrors.Wrap(surqlerrors.ErrMigrationHistory,
+			"failed to store snapshot", err)
+	}
+
+	// Recompute the on-disk path so callers can log or reference it.
+	path, resolveErr := resolveSnapshotPath(dir, snapshot.Version)
+	if resolveErr != nil {
+		// StoreSnapshot succeeded, so the file exists; if the resolver
+		// fails at this point the caller still gets a valid result,
+		// just without the path.
+		path = ""
+	}
+
+	if hook.After != nil {
+		if err := hook.After(ctx, migration, snapshot, path); err != nil {
+			return path, surqlerrors.Wrap(surqlerrors.ErrMigrationHistory,
+				"post-snapshot hook failed", err)
+		}
+	}
+	return path, nil
 }

--- a/pkg/surql/migration/hooks_snapshot_test.go
+++ b/pkg/surql/migration/hooks_snapshot_test.go
@@ -1,0 +1,375 @@
+package migration
+
+import (
+	"context"
+	stdErrors "errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/schema"
+)
+
+// resetAutoSnapshot makes the global flag test-local so tests don't bleed
+// into one another.
+func resetAutoSnapshot(t *testing.T) {
+	t.Helper()
+	previous := IsAutoSnapshotEnabled()
+	t.Cleanup(func() {
+		if previous {
+			EnableAutoSnapshots()
+		} else {
+			DisableAutoSnapshots()
+		}
+	})
+}
+
+func TestAutoSnapshotToggle(t *testing.T) {
+	resetAutoSnapshot(t)
+
+	DisableAutoSnapshots()
+	if IsAutoSnapshotEnabled() {
+		t.Error("disabled should read false")
+	}
+
+	EnableAutoSnapshots()
+	if !IsAutoSnapshotEnabled() {
+		t.Error("enabled should read true")
+	}
+
+	DisableAutoSnapshots()
+	if IsAutoSnapshotEnabled() {
+		t.Error("re-disabled should read false")
+	}
+}
+
+func TestCreateSnapshotOnMigration_NoopWhenDisabled(t *testing.T) {
+	resetAutoSnapshot(t)
+	DisableAutoSnapshots()
+
+	dir := t.TempDir()
+	reg := schema.NewSchemaRegistry()
+	path, err := CreateSnapshotOnMigration(
+		context.Background(), dir,
+		Migration{Version: "20260101_000000", Description: "noop"},
+		SnapshotHook{Registry: reg},
+	)
+	if err != nil {
+		t.Fatalf("disabled CreateSnapshotOnMigration: %v", err)
+	}
+	if path != "" {
+		t.Errorf("disabled path = %q, want empty", path)
+	}
+	// No files should have been written.
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Errorf("unexpected files in snapshot dir: %+v", entries)
+	}
+}
+
+func TestCreateSnapshotOnMigration_WritesSnapshot(t *testing.T) {
+	resetAutoSnapshot(t)
+	EnableAutoSnapshots()
+
+	// Fixed clock so the snapshot version is predictable.
+	fixed := time.Date(2026, 4, 18, 12, 30, 45, 0, time.UTC)
+	orig := snapshotClock
+	snapshotClock = func() time.Time { return fixed }
+	t.Cleanup(func() { snapshotClock = orig })
+
+	dir := t.TempDir()
+	reg := schema.NewSchemaRegistry()
+	if err := reg.RegisterTable(schema.NewTable("user",
+		schema.WithFields(schema.StringField("email")),
+	)); err != nil {
+		t.Fatalf("RegisterTable: %v", err)
+	}
+
+	path, err := CreateSnapshotOnMigration(
+		context.Background(), dir,
+		Migration{Version: "20260101_000000", Description: "initial schema"},
+		SnapshotHook{Registry: reg},
+	)
+	if err != nil {
+		t.Fatalf("CreateSnapshotOnMigration: %v", err)
+	}
+	if path == "" {
+		t.Fatal("path must not be empty on success")
+	}
+	if !strings.HasSuffix(path, "20260418_123045.snapshot.json") {
+		t.Errorf("unexpected snapshot filename: %q", path)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("snapshot file missing: %v", err)
+	}
+
+	// The snapshot should round-trip cleanly.
+	snap, err := LoadSnapshot(path)
+	if err != nil {
+		t.Fatalf("LoadSnapshot: %v", err)
+	}
+	if snap.Version != "20260418_123045" {
+		t.Errorf("snapshot version = %q", snap.Version)
+	}
+	if snap.Description != "initial schema" {
+		t.Errorf("snapshot description = %q", snap.Description)
+	}
+	if len(snap.Tables) != 1 {
+		t.Errorf("tables = %v, want 1", snap.Tables)
+	}
+}
+
+func TestCreateSnapshotOnMigration_RunsBeforeAndAfterHooks(t *testing.T) {
+	resetAutoSnapshot(t)
+	EnableAutoSnapshots()
+
+	dir := t.TempDir()
+	reg := schema.NewSchemaRegistry()
+	if err := reg.RegisterTable(schema.NewTable("user",
+		schema.WithFields(schema.StringField("email")),
+	)); err != nil {
+		t.Fatalf("RegisterTable: %v", err)
+	}
+
+	var (
+		beforeCalls, afterCalls int
+		observedPath            string
+		observedVersion         string
+		mu                      sync.Mutex
+	)
+	hook := SnapshotHook{
+		Registry: reg,
+		Before: func(ctx context.Context, m Migration) error {
+			mu.Lock()
+			defer mu.Unlock()
+			beforeCalls++
+			observedVersion = m.Version
+			return nil
+		},
+		After: func(ctx context.Context, m Migration, snap SchemaSnapshot, p string) error {
+			mu.Lock()
+			defer mu.Unlock()
+			afterCalls++
+			observedPath = p
+			return nil
+		},
+	}
+
+	path, err := CreateSnapshotOnMigration(
+		context.Background(), dir,
+		Migration{Version: "20260101_000000", Description: "x"},
+		hook,
+	)
+	if err != nil {
+		t.Fatalf("CreateSnapshotOnMigration: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if beforeCalls != 1 {
+		t.Errorf("beforeCalls = %d, want 1", beforeCalls)
+	}
+	if afterCalls != 1 {
+		t.Errorf("afterCalls = %d, want 1", afterCalls)
+	}
+	if observedVersion != "20260101_000000" {
+		t.Errorf("observedVersion = %q", observedVersion)
+	}
+	if observedPath != path {
+		t.Errorf("observedPath = %q, want %q", observedPath, path)
+	}
+}
+
+func TestCreateSnapshotOnMigration_AbortOnBeforeError(t *testing.T) {
+	resetAutoSnapshot(t)
+	EnableAutoSnapshots()
+
+	dir := t.TempDir()
+	reg := schema.NewSchemaRegistry()
+	sentinel := stdErrors.New("veto")
+
+	_, err := CreateSnapshotOnMigration(
+		context.Background(), dir,
+		Migration{Version: "v1"},
+		SnapshotHook{
+			Registry: reg,
+			Before: func(ctx context.Context, m Migration) error {
+				return sentinel
+			},
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error from before hook")
+	}
+	if !stdErrors.Is(err, sentinel) {
+		t.Errorf("err does not wrap sentinel: %v", err)
+	}
+	// No files should have been written.
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Errorf("snapshot dir should be empty, got %+v", entries)
+	}
+}
+
+func TestCreateSnapshotOnMigration_AfterErrorStillReturnsPath(t *testing.T) {
+	resetAutoSnapshot(t)
+	EnableAutoSnapshots()
+
+	dir := t.TempDir()
+	reg := schema.NewSchemaRegistry()
+	if err := reg.RegisterTable(schema.NewTable("user",
+		schema.WithFields(schema.StringField("email")),
+	)); err != nil {
+		t.Fatalf("RegisterTable: %v", err)
+	}
+
+	sentinel := stdErrors.New("after-boom")
+	path, err := CreateSnapshotOnMigration(
+		context.Background(), dir,
+		Migration{Version: "v1", Description: "d"},
+		SnapshotHook{
+			Registry: reg,
+			After: func(ctx context.Context, m Migration, s SchemaSnapshot, p string) error {
+				return sentinel
+			},
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error from after hook")
+	}
+	if !stdErrors.Is(err, sentinel) {
+		t.Errorf("err does not wrap sentinel: %v", err)
+	}
+	if path == "" {
+		t.Error("path should be returned even when after hook fails")
+	}
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Errorf("snapshot file missing after after-hook error: %v", statErr)
+	}
+}
+
+func TestCreateSnapshotOnMigration_ValidatesInputs(t *testing.T) {
+	resetAutoSnapshot(t)
+	EnableAutoSnapshots()
+
+	reg := schema.NewSchemaRegistry()
+
+	cases := []struct {
+		name string
+		dir  string
+		hook SnapshotHook
+	}{
+		{"empty dir", "", SnapshotHook{Registry: reg}},
+		{"nil registry", t.TempDir(), SnapshotHook{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := CreateSnapshotOnMigration(
+				context.Background(), tc.dir,
+				Migration{Version: "v1"}, tc.hook,
+			)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+				t.Errorf("err not ErrValidation: %v", err)
+			}
+		})
+	}
+}
+
+func TestCreateSnapshotOnMigration_CancelledContext(t *testing.T) {
+	resetAutoSnapshot(t)
+	EnableAutoSnapshots()
+
+	reg := schema.NewSchemaRegistry()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := CreateSnapshotOnMigration(
+		ctx, t.TempDir(),
+		Migration{Version: "v1"},
+		SnapshotHook{Registry: reg},
+	)
+	if err == nil {
+		t.Fatal("expected cancellation error")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationHistory) {
+		t.Errorf("err not ErrMigrationHistory: %v", err)
+	}
+}
+
+func TestCreateSnapshotOnMigration_UsesDefaultDescription(t *testing.T) {
+	resetAutoSnapshot(t)
+	EnableAutoSnapshots()
+
+	dir := t.TempDir()
+	reg := schema.NewSchemaRegistry()
+	if err := reg.RegisterTable(schema.NewTable("user",
+		schema.WithFields(schema.StringField("email")),
+	)); err != nil {
+		t.Fatalf("RegisterTable: %v", err)
+	}
+
+	path, err := CreateSnapshotOnMigration(
+		context.Background(), dir,
+		Migration{Version: "20260101_000000"}, // no Description
+		SnapshotHook{Registry: reg},
+	)
+	if err != nil {
+		t.Fatalf("CreateSnapshotOnMigration: %v", err)
+	}
+
+	snap, err := LoadSnapshot(path)
+	if err != nil {
+		t.Fatalf("LoadSnapshot: %v", err)
+	}
+	if !strings.Contains(snap.Description, "auto-snapshot after 20260101_000000") {
+		t.Errorf("default description missing: %q", snap.Description)
+	}
+}
+
+func TestCreateSnapshotOnMigration_ZeroValueHook(t *testing.T) {
+	resetAutoSnapshot(t)
+	EnableAutoSnapshots()
+
+	// Zero value hook (Registry nil) must be rejected with ErrValidation.
+	_, err := CreateSnapshotOnMigration(
+		context.Background(), t.TempDir(),
+		Migration{Version: "v1"}, SnapshotHook{},
+	)
+	if err == nil {
+		t.Fatal("expected error for zero-value hook")
+	}
+}
+
+func TestCreateSnapshotOnMigration_CreatesParentDirectory(t *testing.T) {
+	resetAutoSnapshot(t)
+	EnableAutoSnapshots()
+
+	base := t.TempDir()
+	nested := filepath.Join(base, "nested", "snaps")
+
+	reg := schema.NewSchemaRegistry()
+	if err := reg.RegisterTable(schema.NewTable("user",
+		schema.WithFields(schema.StringField("email")),
+	)); err != nil {
+		t.Fatalf("RegisterTable: %v", err)
+	}
+
+	path, err := CreateSnapshotOnMigration(
+		context.Background(), nested,
+		Migration{Version: "v1", Description: "d"},
+		SnapshotHook{Registry: reg},
+	)
+	if err != nil {
+		t.Fatalf("CreateSnapshotOnMigration: %v", err)
+	}
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Errorf("snapshot missing: %v", statErr)
+	}
+}

--- a/pkg/surql/migration/squash.go
+++ b/pkg/surql/migration/squash.go
@@ -1,0 +1,634 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+// SquashError is the sentinel error returned when a squash operation cannot
+// be completed safely. It wraps surqlerrors.ErrMigrationSquash so callers
+// that already filter on the package-level sentinel continue to work; new
+// callers can match on SquashError directly via errors.Is.
+var SquashError = surqlerrors.ErrMigrationSquash
+
+// squashedFromMarker is emitted in the squashed migration's description
+// header so that discovery tooling can recognise the provenance of the
+// squashed file without re-parsing the full body.
+const squashedFromMarker = "-- @squashed-from:"
+
+// SquashWarning captures a potential issue with a squash operation. The
+// severity field mirrors surql-py's validate_squash_safety so callers can
+// decide whether to abort or proceed with a warning log.
+type SquashWarning struct {
+	// Migration is the source migration version that produced the warning.
+	Migration string `json:"migration"`
+	// Message is a human-readable description of the concern.
+	Message string `json:"message"`
+	// Severity is one of "low", "medium", "high".
+	Severity string `json:"severity"`
+}
+
+// SquashResult is returned from a successful SquashMigrations call.
+type SquashResult struct {
+	// SquashedPath is the absolute path to the newly written migration file.
+	SquashedPath string `json:"squashed_path"`
+	// Version is the YYYYMMDD_HHMMSS version of the new migration.
+	Version string `json:"version"`
+	// Checksum is the SHA-256 digest of the generated file's contents.
+	Checksum string `json:"checksum"`
+	// OriginalCount is the number of migrations combined.
+	OriginalCount int `json:"original_count"`
+	// StatementCount is the number of up statements in the squashed output
+	// after any optimisation pass.
+	StatementCount int `json:"statement_count"`
+	// OptimizationsApplied is the number of redundant statements removed.
+	OptimizationsApplied int `json:"optimizations_applied"`
+	// OriginalMigrations lists the versions of the source migrations, in
+	// discovery (ascending) order.
+	OriginalMigrations []string `json:"original_migrations"`
+	// Warnings lists non-fatal issues detected during safety validation.
+	Warnings []SquashWarning `json:"warnings,omitempty"`
+}
+
+// SquashOptions configures the SquashMigrations operation. The zero value
+// is valid and applies the default behaviour (optimise on, write to disk).
+type SquashOptions struct {
+	// Description is the human-readable summary to emit for the squashed
+	// migration. When empty a synthetic "squashed_<from>_to_<to>" slug is used.
+	Description string
+	// OutputPath is an explicit destination file path. When empty the
+	// squashed migration is written to the source directory under the
+	// canonical <version>_<slug>.surql name.
+	OutputPath string
+	// Optimize controls whether redundant DEFINE / REMOVE pairs and
+	// duplicate DEFINEs are removed from the merged statement list.
+	// Defaults to true; pass &false to disable.
+	Optimize *bool
+	// DryRun skips the on-disk write and returns a result with an empty
+	// Checksum and the would-be SquashedPath.
+	DryRun bool
+}
+
+// SquashMigrations combines every migration in directory whose version is
+// within [fromVersion, toVersion] (inclusive, empty strings treated as
+// open-ended) into a single migration file.
+//
+// The new file carries a merged up section (each source migration's
+// UpStatements concatenated in ascending version order, optionally
+// optimised) and a merged down section (each migration's DownStatements
+// concatenated in reverse order). Its description is annotated with the
+// "-- @squashed-from: vA..vZ" marker so downstream tooling can recognise
+// the provenance. A fresh SHA-256 checksum is computed from the generated
+// body and returned in the SquashResult.
+//
+// The operation is atomic on the filesystem (via GenerateMigration's
+// temp-file + rename) and never mutates the source migrations. Duplicate
+// INSERT / UPDATE / DELETE statements that surql-py flags as high-severity
+// abort the call with a wrapped SquashError so the caller can review and
+// retry with an explicit safety override.
+func SquashMigrations(
+	ctx context.Context,
+	directory, fromVersion, toVersion string,
+) (*SquashResult, error) {
+	return SquashMigrationsWithOptions(ctx, directory, fromVersion, toVersion, SquashOptions{})
+}
+
+// SquashMigrationsWithOptions is the configurable variant of
+// SquashMigrations. See SquashOptions for field semantics.
+func SquashMigrationsWithOptions(
+	ctx context.Context,
+	directory, fromVersion, toVersion string,
+	opts SquashOptions,
+) (*SquashResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, surqlerrors.Wrap(SquashError, "context cancelled before squash", err)
+	}
+
+	all, err := DiscoverMigrations(directory)
+	if err != nil {
+		return nil, surqlerrors.Wrap(SquashError, "failed to discover migrations", err)
+	}
+	if len(all) == 0 {
+		return nil, surqlerrors.New(SquashError, "no migrations found in directory")
+	}
+
+	selected := filterMigrationsByVersion(all, fromVersion, toVersion)
+	if len(selected) == 0 {
+		return nil, surqlerrors.New(SquashError, "no migrations match the specified version range")
+	}
+	if len(selected) < 2 {
+		return nil, surqlerrors.New(SquashError, "at least 2 migrations are required for squashing")
+	}
+
+	warnings := validateSquashSafety(selected)
+	var highSeverity []SquashWarning
+	for _, w := range warnings {
+		if w.Severity == "high" {
+			highSeverity = append(highSeverity, w)
+		}
+	}
+	if len(highSeverity) > 0 {
+		msgs := make([]string, 0, len(highSeverity))
+		for _, w := range highSeverity {
+			msgs = append(msgs, w.Message)
+		}
+		return nil, surqlerrors.Newf(SquashError,
+			"high severity warnings prevent squashing: %s",
+			strings.Join(msgs, "; "),
+		)
+	}
+
+	up := make([]string, 0)
+	versions := make([]string, 0, len(selected))
+	for _, m := range selected {
+		up = append(up, m.UpStatements...)
+		versions = append(versions, m.Version)
+	}
+
+	// Down is the reverse-order concatenation of each source's down. We
+	// reverse both the list of migrations and (within each) the statement
+	// order so that the resulting script undoes them in the inverse
+	// sequence of their up section.
+	down := make([]string, 0)
+	for i := len(selected) - 1; i >= 0; i-- {
+		stmts := selected[i].DownStatements
+		for j := len(stmts) - 1; j >= 0; j-- {
+			down = append(down, stmts[j])
+		}
+	}
+
+	optimize := true
+	if opts.Optimize != nil {
+		optimize = *opts.Optimize
+	}
+	optimizationsApplied := 0
+	if optimize {
+		up, optimizationsApplied = optimizeStatements(up)
+	}
+
+	firstVersion := selected[0].Version
+	lastVersion := selected[len(selected)-1].Version
+	description := opts.Description
+	if strings.TrimSpace(description) == "" {
+		description = fmt.Sprintf("squashed_%s_to_%s", firstVersion, lastVersion)
+	}
+
+	version := now().Format(timestampLayout)
+	outputDir := directory
+	if opts.OutputPath != "" {
+		// When the caller supplied an explicit file we still delegate to
+		// writeMigrationFile (which derives its own name), but we respect
+		// the requested parent directory.
+		outputDir = filepath.Dir(opts.OutputPath)
+	}
+
+	extraHeader := []string{
+		fmt.Sprintf("%s %s..%s", squashedFromMarker, firstVersion, lastVersion),
+	}
+
+	if opts.DryRun {
+		result := &SquashResult{
+			SquashedPath:         buildSquashedPath(outputDir, version, description),
+			Version:              version,
+			Checksum:             "",
+			OriginalCount:        len(selected),
+			StatementCount:       len(up),
+			OptimizationsApplied: optimizationsApplied,
+			OriginalMigrations:   versions,
+			Warnings:             warnings,
+		}
+		return result, nil
+	}
+
+	written, err := writeSquashedMigrationFile(
+		version,
+		description,
+		description,
+		extraHeader,
+		up,
+		down,
+		outputDir,
+	)
+	if err != nil {
+		return nil, surqlerrors.Wrap(SquashError, "failed to write squashed migration", err)
+	}
+
+	return &SquashResult{
+		SquashedPath:         written.Path,
+		Version:              written.Version,
+		Checksum:             written.Checksum,
+		OriginalCount:        len(selected),
+		StatementCount:       len(up),
+		OptimizationsApplied: optimizationsApplied,
+		OriginalMigrations:   versions,
+		Warnings:             warnings,
+	}, nil
+}
+
+// filterMigrationsByVersion returns the subset of migrations whose version
+// is within [from, to] inclusive. Empty from / to strings are treated as
+// open-ended bounds, matching surql-py's _filter_migrations_by_version.
+func filterMigrationsByVersion(migrations []Migration, from, to string) []Migration {
+	out := make([]Migration, 0, len(migrations))
+	for _, m := range migrations {
+		if from != "" && m.Version < from {
+			continue
+		}
+		if to != "" && m.Version > to {
+			continue
+		}
+		out = append(out, m)
+	}
+	// DiscoverMigrations already returns ascending order, but callers of
+	// this helper may pass pre-filtered slices; re-sort to be safe.
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Version < out[j].Version
+	})
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Statement optimisation
+// ---------------------------------------------------------------------------
+
+// parsedStatement captures the minimal metadata needed to match DEFINE /
+// REMOVE pairs across a squashed migration. The receiver semantics mirror
+// surql-py's _ParsedStatement.
+type parsedStatement struct {
+	statement  string
+	operation  string
+	objectType string
+	tableName  string
+	fieldName  string
+	indexName  string
+}
+
+var (
+	reDefineTable = regexp.MustCompile(`(?i)^(DEFINE|REMOVE)\s+TABLE(?:\s+IF\s+(?:NOT\s+)?EXISTS)?\s+(\w+)`)
+	reDefineField = regexp.MustCompile(`(?i)^(DEFINE|REMOVE)\s+FIELD(?:\s+IF\s+(?:NOT\s+)?EXISTS)?\s+(\w+)\s+ON\s+(?:TABLE\s+)?(\w+)`)
+	reDefineIndex = regexp.MustCompile(`(?i)^(DEFINE|REMOVE)\s+INDEX(?:\s+IF\s+(?:NOT\s+)?EXISTS)?\s+(\w+)\s+ON\s+(?:TABLE\s+)?(\w+)`)
+	reDefineEvent = regexp.MustCompile(`(?i)^(DEFINE|REMOVE)\s+EVENT(?:\s+IF\s+(?:NOT\s+)?EXISTS)?\s+(\w+)\s+ON\s+(?:TABLE\s+)?(\w+)`)
+	reUpdateSet   = regexp.MustCompile(`(?i)\bSET\s+(\w+)\s*=`)
+	reUpdateTable = regexp.MustCompile(`(?i)\bUPDATE\s+(\w+)\b`)
+)
+
+// parseStatement extracts the operation and object metadata from a single
+// SurrealQL statement. Only DEFINE, REMOVE, INSERT, UPDATE, DELETE, CREATE
+// are recognised — everything else is returned with operation=="UNKNOWN".
+func parseStatement(statement string) parsedStatement {
+	trimmed := strings.TrimSpace(statement)
+	upper := strings.ToUpper(trimmed)
+
+	operation := ""
+	switch {
+	case strings.HasPrefix(upper, "DEFINE"):
+		operation = "DEFINE"
+	case strings.HasPrefix(upper, "REMOVE"):
+		operation = "REMOVE"
+	case strings.HasPrefix(upper, "INSERT"):
+		operation = "INSERT"
+	case strings.HasPrefix(upper, "UPDATE"):
+		operation = "UPDATE"
+	case strings.HasPrefix(upper, "DELETE"):
+		operation = "DELETE"
+	case strings.HasPrefix(upper, "CREATE"):
+		operation = "CREATE"
+	default:
+		return parsedStatement{statement: trimmed, operation: "UNKNOWN"}
+	}
+
+	out := parsedStatement{statement: trimmed, operation: operation}
+
+	// Order matters: FIELD / INDEX / EVENT patterns are more specific than
+	// TABLE because they contain an additional "ON TABLE" clause.
+	if m := reDefineField.FindStringSubmatch(trimmed); m != nil {
+		out.objectType = "FIELD"
+		out.fieldName = strings.ToLower(m[2])
+		out.tableName = strings.ToLower(m[3])
+		return out
+	}
+	if m := reDefineIndex.FindStringSubmatch(trimmed); m != nil {
+		out.objectType = "INDEX"
+		out.indexName = strings.ToLower(m[2])
+		out.tableName = strings.ToLower(m[3])
+		return out
+	}
+	if m := reDefineEvent.FindStringSubmatch(trimmed); m != nil {
+		out.objectType = "EVENT"
+		// Reuse indexName for event identifier (matches surql-py).
+		out.indexName = strings.ToLower(m[2])
+		out.tableName = strings.ToLower(m[3])
+		return out
+	}
+	if m := reDefineTable.FindStringSubmatch(trimmed); m != nil {
+		out.objectType = "TABLE"
+		out.tableName = strings.ToLower(m[2])
+		return out
+	}
+	return out
+}
+
+// optimizeStatements removes redundant SurrealQL statements from a squashed
+// list. Three passes run in sequence:
+//
+//  1. DEFINE + REMOVE pairs for the same object are dropped (the net effect
+//     on the schema is a no-op).
+//  2. Duplicate DEFINE statements for the same object keep only the last
+//     occurrence; earlier ones are removed.
+//  3. UPDATE statements that target a field that was removed in pass (1)
+//     are also dropped, since the field no longer exists.
+//
+// The returned int is the number of statements removed.
+func optimizeStatements(statements []string) ([]string, int) {
+	optimizations := 0
+	parsed := make([]parsedStatement, len(statements))
+	for i, s := range statements {
+		parsed[i] = parseStatement(s)
+	}
+
+	toRemove := make(map[int]struct{})
+
+	// Pass 1: DEFINE + REMOVE pairs.
+	for i, stmtI := range parsed {
+		if _, skip := toRemove[i]; skip {
+			continue
+		}
+		if stmtI.operation != "DEFINE" {
+			continue
+		}
+		for j := i + 1; j < len(parsed); j++ {
+			if _, skip := toRemove[j]; skip {
+				continue
+			}
+			stmtJ := parsed[j]
+			if stmtJ.operation != "REMOVE" {
+				continue
+			}
+			if stmtI.objectType != stmtJ.objectType || stmtI.tableName != stmtJ.tableName {
+				continue
+			}
+			match := false
+			switch stmtI.objectType {
+			case "TABLE":
+				match = true
+			case "FIELD":
+				match = stmtI.fieldName == stmtJ.fieldName
+			case "INDEX", "EVENT":
+				match = stmtI.indexName == stmtJ.indexName
+			}
+			if !match {
+				continue
+			}
+			toRemove[i] = struct{}{}
+			toRemove[j] = struct{}{}
+			optimizations += 2
+			break
+		}
+	}
+
+	// Pass 2: duplicate DEFINE statements (keep the last occurrence).
+	type defineKey struct {
+		objectType string
+		tableName  string
+		fieldName  string
+		indexName  string
+	}
+	defines := make(map[defineKey]int)
+	for i, stmt := range parsed {
+		if _, skip := toRemove[i]; skip {
+			continue
+		}
+		if stmt.operation != "DEFINE" {
+			continue
+		}
+		key := defineKey{
+			objectType: stmt.objectType,
+			tableName:  stmt.tableName,
+			fieldName:  stmt.fieldName,
+			indexName:  stmt.indexName,
+		}
+		if earlier, ok := defines[key]; ok {
+			if _, already := toRemove[earlier]; !already {
+				toRemove[earlier] = struct{}{}
+				optimizations++
+			}
+		}
+		defines[key] = i
+	}
+
+	// Pass 3: UPDATE statements against fields removed in pass (1).
+	type fieldKey struct {
+		tableName string
+		fieldName string
+	}
+	removedFields := make(map[fieldKey]struct{})
+	for idx := range toRemove {
+		stmt := parsed[idx]
+		if stmt.objectType == "FIELD" && stmt.tableName != "" && stmt.fieldName != "" {
+			removedFields[fieldKey{stmt.tableName, stmt.fieldName}] = struct{}{}
+		}
+	}
+	if len(removedFields) > 0 {
+		for i, stmt := range parsed {
+			if _, skip := toRemove[i]; skip {
+				continue
+			}
+			if stmt.operation != "UPDATE" {
+				continue
+			}
+			for key := range removedFields {
+				setMatch := reUpdateSet.FindStringSubmatch(stmt.statement)
+				tableMatch := reUpdateTable.FindStringSubmatch(stmt.statement)
+				if setMatch == nil || tableMatch == nil {
+					continue
+				}
+				if strings.EqualFold(setMatch[1], key.fieldName) &&
+					strings.EqualFold(tableMatch[1], key.tableName) {
+					toRemove[i] = struct{}{}
+					optimizations++
+					break
+				}
+			}
+		}
+	}
+
+	out := make([]string, 0, len(statements)-len(toRemove))
+	for i, s := range statements {
+		if _, skip := toRemove[i]; skip {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out, optimizations
+}
+
+// validateSquashSafety walks the merged statement list and returns
+// warnings for patterns that surql-py treats as risky to squash: INSERT,
+// non-backfill UPDATE, DELETE, CREATE (non-table), and record-reference
+// DEFINE FIELDs. Severity follows the reference implementation.
+func validateSquashSafety(migrations []Migration) []SquashWarning {
+	var warnings []SquashWarning
+	for _, m := range migrations {
+		for _, stmt := range m.UpStatements {
+			trimmed := strings.TrimSpace(stmt)
+			upper := strings.ToUpper(trimmed)
+
+			switch {
+			case strings.HasPrefix(upper, "INSERT"):
+				warnings = append(warnings, SquashWarning{
+					Migration: m.Version,
+					Message:   "Contains INSERT statement: " + truncateForWarning(trimmed),
+					Severity:  "medium",
+				})
+			case strings.HasPrefix(upper, "UPDATE") && strings.Contains(upper, "SET"):
+				// Only warn when the UPDATE is not a backfill
+				// (WHERE ... IS NONE pattern).
+				if !strings.Contains(upper, "IS NONE") {
+					warnings = append(warnings, SquashWarning{
+						Migration: m.Version,
+						Message:   "Contains UPDATE statement: " + truncateForWarning(trimmed),
+						Severity:  "medium",
+					})
+				}
+			case strings.HasPrefix(upper, "DELETE"):
+				warnings = append(warnings, SquashWarning{
+					Migration: m.Version,
+					Message:   "Contains DELETE statement: " + truncateForWarning(trimmed),
+					Severity:  "high",
+				})
+			case strings.HasPrefix(upper, "CREATE") && !strings.Contains(upper, "CREATE TABLE"):
+				warnings = append(warnings, SquashWarning{
+					Migration: m.Version,
+					Message:   "Contains CREATE statement: " + truncateForWarning(trimmed),
+					Severity:  "low",
+				})
+			}
+
+			if strings.Contains(upper, "RECORD") && strings.Contains(upper, "TYPE") {
+				warnings = append(warnings, SquashWarning{
+					Migration: m.Version,
+					Message:   "Contains record reference - verify table order",
+					Severity:  "low",
+				})
+			}
+		}
+	}
+	return warnings
+}
+
+// truncateForWarning keeps warning messages bounded so logs stay scannable
+// while still showing a reasonable prefix of the offending statement.
+func truncateForWarning(stmt string) string {
+	const limit = 50
+	if len(stmt) <= limit {
+		return stmt
+	}
+	return stmt[:limit] + "..."
+}
+
+// buildSquashedPath mirrors writeMigrationFile's naming so DryRun callers
+// get an accurate preview without writing anything to disk.
+func buildSquashedPath(dir, version, description string) string {
+	filename := BuildFilename(version, description)
+	if dir == "" {
+		return filename
+	}
+	return filepath.Join(dir, filename)
+}
+
+// writeSquashedMigrationFile renders a migration file body that includes a
+// `-- @squashed-from:` marker line in the header (in addition to the usual
+// description / up / down sections) and writes it atomically.
+//
+// The marker is preserved verbatim when the file is re-parsed because
+// parseMigrationContent ignores unknown header comment lines, keeping the
+// round-trip contract intact.
+func writeSquashedMigrationFile(
+	version string,
+	slugSource string,
+	description string,
+	extraHeader []string,
+	up []string,
+	down []string,
+	dir string,
+) (Migration, error) {
+	if strings.TrimSpace(dir) == "" {
+		return Migration{}, surqlerrors.New(
+			surqlerrors.ErrMigrationGeneration,
+			"migration directory must not be empty",
+		)
+	}
+
+	filename := BuildFilename(version, slugSource)
+	if !ValidateMigrationName(filename) {
+		return Migration{}, surqlerrors.Newf(
+			surqlerrors.ErrMigrationGeneration,
+			"generated filename %q is not a valid migration name", filename,
+		)
+	}
+
+	// Render the canonical body and splice the squashed-from header in
+	// directly before the `-- @up` marker so the resulting file still
+	// matches the layout produced by GenerateMigration.
+	body := renderMigrationContent(description, nil, up, down)
+	if len(extraHeader) > 0 {
+		marker := "-- @up\n"
+		idx := strings.Index(body, marker)
+		if idx == -1 {
+			return Migration{}, surqlerrors.New(
+				surqlerrors.ErrMigrationGeneration,
+				"rendered migration body is missing the -- @up marker",
+			)
+		}
+		var b strings.Builder
+		b.WriteString(body[:idx])
+		for _, line := range extraHeader {
+			b.WriteString(line)
+			if !strings.HasSuffix(line, "\n") {
+				b.WriteByte('\n')
+			}
+		}
+		b.WriteString(body[idx:])
+		body = b.String()
+	}
+
+	finalPath := filepath.Join(dir, filename)
+	// Ensure the directory exists before attempting the atomic rename.
+	if err := ensureDir(dir); err != nil {
+		return Migration{}, err
+	}
+	if err := atomicWriteFile(finalPath, []byte(body)); err != nil {
+		return Migration{}, surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationGeneration, err,
+			"failed to write migration %q", finalPath,
+		)
+	}
+
+	m, err := LoadMigration(finalPath)
+	if err != nil {
+		return Migration{}, surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationGeneration, err,
+			"generator produced invalid migration file %q", finalPath,
+		)
+	}
+	return m, nil
+}
+
+// ensureDir creates dir (and intermediate directories) with 0755 perms if
+// it does not yet exist. Existing directories are a no-op.
+func ensureDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return surqlerrors.Wrapf(
+			surqlerrors.ErrMigrationGeneration, err,
+			"cannot create migration directory %q", dir,
+		)
+	}
+	return nil
+}

--- a/pkg/surql/migration/squash_test.go
+++ b/pkg/surql/migration/squash_test.go
@@ -1,0 +1,474 @@
+package migration
+
+import (
+	"context"
+	stdErrors "errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+// writeMigrationFixture creates a minimal, discoverable migration file
+// directly in dir so squash tests can operate on a deterministic set of
+// versions without depending on the generator's clock.
+func writeMigrationFixture(t *testing.T, dir, version, slug, body string) string {
+	t.Helper()
+	filename := version + "_" + slug + ".surql"
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write fixture %q: %v", filename, err)
+	}
+	return path
+}
+
+func TestOptimizeStatements_RemovesDefineRemovePair(t *testing.T) {
+	input := []string{
+		"DEFINE TABLE user SCHEMAFULL;",
+		"DEFINE FIELD temp ON TABLE user TYPE string;",
+		"REMOVE FIELD temp ON TABLE user;",
+	}
+	out, count := optimizeStatements(input)
+	if count != 2 {
+		t.Errorf("optimizations = %d, want 2", count)
+	}
+	if len(out) != 1 || out[0] != "DEFINE TABLE user SCHEMAFULL;" {
+		t.Errorf("out = %v, want [DEFINE TABLE user SCHEMAFULL;]", out)
+	}
+}
+
+func TestOptimizeStatements_DefineRemoveTablePair(t *testing.T) {
+	input := []string{
+		"DEFINE TABLE tmp SCHEMAFULL;",
+		"DEFINE TABLE keep SCHEMAFULL;",
+		"REMOVE TABLE tmp;",
+	}
+	out, count := optimizeStatements(input)
+	if count != 2 {
+		t.Errorf("optimizations = %d, want 2", count)
+	}
+	if len(out) != 1 || out[0] != "DEFINE TABLE keep SCHEMAFULL;" {
+		t.Errorf("out = %v, want [DEFINE TABLE keep SCHEMAFULL;]", out)
+	}
+}
+
+func TestOptimizeStatements_DuplicateDefineKeepsLast(t *testing.T) {
+	input := []string{
+		"DEFINE FIELD name ON TABLE user TYPE string;",
+		"DEFINE FIELD name ON TABLE user TYPE string ASSERT $value != NONE;",
+	}
+	out, count := optimizeStatements(input)
+	if count != 1 {
+		t.Errorf("optimizations = %d, want 1", count)
+	}
+	if len(out) != 1 ||
+		out[0] != "DEFINE FIELD name ON TABLE user TYPE string ASSERT $value != NONE;" {
+		t.Errorf("out = %v, want last-wins", out)
+	}
+}
+
+func TestOptimizeStatements_RemovesOrphanedUpdate(t *testing.T) {
+	input := []string{
+		"DEFINE FIELD temp ON TABLE user TYPE string;",
+		"UPDATE user SET temp = 'value' WHERE id = 1;",
+		"REMOVE FIELD temp ON TABLE user;",
+	}
+	out, count := optimizeStatements(input)
+	if count < 3 {
+		t.Errorf("optimizations = %d, want >=3 (pair + orphan)", count)
+	}
+	for _, s := range out {
+		if strings.Contains(strings.ToUpper(s), "UPDATE USER SET TEMP") {
+			t.Errorf("orphaned UPDATE survived optimisation: %q", s)
+		}
+	}
+}
+
+func TestOptimizeStatements_IndexAndEvent(t *testing.T) {
+	input := []string{
+		"DEFINE INDEX idx_user_email ON TABLE user COLUMNS email UNIQUE;",
+		"REMOVE INDEX idx_user_email ON TABLE user;",
+		"DEFINE EVENT audit_user ON TABLE user WHEN $event = 'CREATE' THEN ($value);",
+		"REMOVE EVENT audit_user ON TABLE user;",
+	}
+	out, count := optimizeStatements(input)
+	if count != 4 {
+		t.Errorf("optimizations = %d, want 4", count)
+	}
+	if len(out) != 0 {
+		t.Errorf("out = %v, want []", out)
+	}
+}
+
+func TestParseStatement_TableFieldIndexEvent(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         string
+		op         string
+		objectType string
+		table      string
+		field      string
+		index      string
+	}{
+		{
+			name:       "define table",
+			in:         "DEFINE TABLE user SCHEMAFULL;",
+			op:         "DEFINE",
+			objectType: "TABLE",
+			table:      "user",
+		},
+		{
+			name:       "remove field",
+			in:         "REMOVE FIELD email ON TABLE user;",
+			op:         "REMOVE",
+			objectType: "FIELD",
+			field:      "email",
+			table:      "user",
+		},
+		{
+			name:       "define index if not exists",
+			in:         "DEFINE INDEX IF NOT EXISTS idx_email ON TABLE user COLUMNS email;",
+			op:         "DEFINE",
+			objectType: "INDEX",
+			index:      "idx_email",
+			table:      "user",
+		},
+		{
+			name:       "remove event",
+			in:         "REMOVE EVENT audit ON TABLE user;",
+			op:         "REMOVE",
+			objectType: "EVENT",
+			index:      "audit",
+			table:      "user",
+		},
+		{
+			name:       "unknown op",
+			in:         "RELATE user:1->follows->user:2;",
+			op:         "UNKNOWN",
+			objectType: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := parseStatement(tc.in)
+			if p.operation != tc.op {
+				t.Errorf("operation = %q, want %q", p.operation, tc.op)
+			}
+			if p.objectType != tc.objectType {
+				t.Errorf("objectType = %q, want %q", p.objectType, tc.objectType)
+			}
+			if p.tableName != tc.table {
+				t.Errorf("tableName = %q, want %q", p.tableName, tc.table)
+			}
+			if p.fieldName != tc.field {
+				t.Errorf("fieldName = %q, want %q", p.fieldName, tc.field)
+			}
+			if p.indexName != tc.index {
+				t.Errorf("indexName = %q, want %q", p.indexName, tc.index)
+			}
+		})
+	}
+}
+
+func TestValidateSquashSafety_FlagsDataStatements(t *testing.T) {
+	migrations := []Migration{
+		{
+			Version: "20260101_000000",
+			UpStatements: []string{
+				"INSERT INTO user { name: 'alice' };",
+				"UPDATE user SET active = true;",
+				"UPDATE user SET backfill = 1 WHERE active IS NONE;",
+				"DELETE user WHERE archived = true;",
+			},
+		},
+	}
+
+	warnings := validateSquashSafety(migrations)
+
+	var hasInsert, hasUpdate, hasDelete bool
+	hasBackfill := true // must remain false
+	for _, w := range warnings {
+		switch {
+		case strings.Contains(w.Message, "INSERT"):
+			hasInsert = true
+			if w.Severity != "medium" {
+				t.Errorf("INSERT severity = %q, want medium", w.Severity)
+			}
+		case strings.Contains(w.Message, "UPDATE"):
+			hasUpdate = true
+			// the backfill variant should NOT produce a warning.
+			if strings.Contains(w.Message, "IS NONE") {
+				hasBackfill = false
+			}
+		case strings.Contains(w.Message, "DELETE"):
+			hasDelete = true
+			if w.Severity != "high" {
+				t.Errorf("DELETE severity = %q, want high", w.Severity)
+			}
+		}
+	}
+	if !hasInsert {
+		t.Error("expected an INSERT warning")
+	}
+	if !hasUpdate {
+		t.Error("expected an UPDATE warning")
+	}
+	if !hasDelete {
+		t.Error("expected a DELETE warning")
+	}
+	if !hasBackfill {
+		t.Error("unexpectedly warned about IS NONE backfill UPDATE")
+	}
+}
+
+func TestFilterMigrationsByVersion(t *testing.T) {
+	migrations := []Migration{
+		{Version: "20260101_000000"},
+		{Version: "20260102_000000"},
+		{Version: "20260103_000000"},
+		{Version: "20260104_000000"},
+	}
+
+	tests := []struct {
+		name       string
+		from, to   string
+		wantCount  int
+		wantFirst  string
+		wantLast   string
+		shouldSort bool
+	}{
+		{"no bounds", "", "", 4, "20260101_000000", "20260104_000000", true},
+		{"from only", "20260102_000000", "", 3, "20260102_000000", "20260104_000000", true},
+		{"to only", "", "20260102_000000", 2, "20260101_000000", "20260102_000000", true},
+		{"both", "20260102_000000", "20260103_000000", 2, "20260102_000000", "20260103_000000", true},
+		{"none match", "20260105_000000", "", 0, "", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterMigrationsByVersion(migrations, tc.from, tc.to)
+			if len(got) != tc.wantCount {
+				t.Fatalf("count = %d, want %d (got=%v)", len(got), tc.wantCount, got)
+			}
+			if tc.wantCount == 0 {
+				return
+			}
+			if got[0].Version != tc.wantFirst {
+				t.Errorf("first = %q, want %q", got[0].Version, tc.wantFirst)
+			}
+			if got[len(got)-1].Version != tc.wantLast {
+				t.Errorf("last = %q, want %q", got[len(got)-1].Version, tc.wantLast)
+			}
+		})
+	}
+}
+
+func TestSquashMigrations_WritesConsolidatedFile(t *testing.T) {
+	dir := t.TempDir()
+	writeMigrationFixture(t, dir, "20260101_000000", "initial",
+		"-- @description: initial\n-- @up\nDEFINE TABLE user SCHEMAFULL;\n-- @down\nREMOVE TABLE user;\n")
+	writeMigrationFixture(t, dir, "20260102_000000", "add_email",
+		"-- @description: add email\n-- @up\nDEFINE FIELD email ON TABLE user TYPE string;\n-- @down\nREMOVE FIELD email ON TABLE user;\n")
+	writeMigrationFixture(t, dir, "20260103_000000", "add_index",
+		"-- @description: add index\n-- @up\nDEFINE INDEX idx_user_email ON TABLE user COLUMNS email UNIQUE;\n-- @down\nREMOVE INDEX idx_user_email ON TABLE user;\n")
+
+	// Use a fixed clock so the test can assert on the resulting filename.
+	orig := now
+	now = func() time.Time { return time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC) }
+	t.Cleanup(func() { now = orig })
+
+	result, err := SquashMigrations(context.Background(), dir, "", "")
+	if err != nil {
+		t.Fatalf("SquashMigrations: %v", err)
+	}
+	if result == nil {
+		t.Fatal("result is nil")
+	}
+	if result.OriginalCount != 3 {
+		t.Errorf("OriginalCount = %d, want 3", result.OriginalCount)
+	}
+	if result.Version != "20260601_120000" {
+		t.Errorf("Version = %q, want 20260601_120000", result.Version)
+	}
+	if result.Checksum == "" {
+		t.Error("Checksum empty")
+	}
+	if len(result.OriginalMigrations) != 3 {
+		t.Errorf("OriginalMigrations = %v", result.OriginalMigrations)
+	}
+	if _, err := os.Stat(result.SquashedPath); err != nil {
+		t.Errorf("squashed file missing: %v", err)
+	}
+
+	// Verify the written file contains the squashed-from marker and merged
+	// up/down sections in the correct order.
+	body, err := os.ReadFile(result.SquashedPath)
+	if err != nil {
+		t.Fatalf("read squashed: %v", err)
+	}
+	text := string(body)
+	if !strings.Contains(text, "-- @squashed-from: 20260101_000000..20260103_000000") {
+		t.Errorf("squashed-from marker missing in:\n%s", text)
+	}
+	if !strings.Contains(text, "DEFINE TABLE user SCHEMAFULL;") {
+		t.Errorf("missing up statement in:\n%s", text)
+	}
+	// Down statements should appear in reverse migration order.
+	downIdx := strings.Index(text, "-- @down")
+	if downIdx == -1 {
+		t.Fatalf("no -- @down section:\n%s", text)
+	}
+	downBody := text[downIdx:]
+	removeIndex := strings.Index(downBody, "REMOVE INDEX")
+	removeField := strings.Index(downBody, "REMOVE FIELD")
+	removeTable := strings.Index(downBody, "REMOVE TABLE")
+	if removeIndex == -1 || removeField == -1 || removeTable == -1 {
+		t.Fatalf("down section missing statements:\n%s", downBody)
+	}
+	if !(removeIndex < removeField && removeField < removeTable) {
+		t.Errorf("down order wrong: idx=%d field=%d table=%d\n%s",
+			removeIndex, removeField, removeTable, downBody)
+	}
+}
+
+func TestSquashMigrations_DryRunDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	writeMigrationFixture(t, dir, "20260101_000000", "a",
+		"-- @up\nDEFINE TABLE a SCHEMAFULL;\n-- @down\nREMOVE TABLE a;\n")
+	writeMigrationFixture(t, dir, "20260102_000000", "b",
+		"-- @up\nDEFINE TABLE b SCHEMAFULL;\n-- @down\nREMOVE TABLE b;\n")
+
+	result, err := SquashMigrationsWithOptions(
+		context.Background(), dir, "", "",
+		SquashOptions{DryRun: true},
+	)
+	if err != nil {
+		t.Fatalf("SquashMigrationsWithOptions: %v", err)
+	}
+	if result.Checksum != "" {
+		t.Errorf("Checksum should be empty on dry run, got %q", result.Checksum)
+	}
+	if _, err := os.Stat(result.SquashedPath); !os.IsNotExist(err) {
+		t.Errorf("dry-run wrote a file at %q (err=%v)", result.SquashedPath, err)
+	}
+}
+
+func TestSquashMigrations_RangeFilters(t *testing.T) {
+	dir := t.TempDir()
+	writeMigrationFixture(t, dir, "20260101_000000", "a",
+		"-- @up\nDEFINE TABLE a SCHEMAFULL;\n-- @down\nREMOVE TABLE a;\n")
+	writeMigrationFixture(t, dir, "20260102_000000", "b",
+		"-- @up\nDEFINE TABLE b SCHEMAFULL;\n-- @down\nREMOVE TABLE b;\n")
+	writeMigrationFixture(t, dir, "20260103_000000", "c",
+		"-- @up\nDEFINE TABLE c SCHEMAFULL;\n-- @down\nREMOVE TABLE c;\n")
+
+	result, err := SquashMigrations(context.Background(), dir,
+		"20260101_000000", "20260102_000000")
+	if err != nil {
+		t.Fatalf("SquashMigrations: %v", err)
+	}
+	if result.OriginalCount != 2 {
+		t.Errorf("OriginalCount = %d, want 2", result.OriginalCount)
+	}
+}
+
+func TestSquashMigrations_ErrorOnEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	_, err := SquashMigrations(context.Background(), dir, "", "")
+	if err == nil {
+		t.Fatal("expected error on empty dir")
+	}
+	if !stdErrors.Is(err, SquashError) {
+		t.Errorf("err not SquashError: %v", err)
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrMigrationSquash) {
+		t.Errorf("err should wrap ErrMigrationSquash: %v", err)
+	}
+}
+
+func TestSquashMigrations_ErrorOnSingleMigration(t *testing.T) {
+	dir := t.TempDir()
+	writeMigrationFixture(t, dir, "20260101_000000", "a",
+		"-- @up\nDEFINE TABLE a SCHEMAFULL;\n-- @down\nREMOVE TABLE a;\n")
+	_, err := SquashMigrations(context.Background(), dir, "", "")
+	if err == nil {
+		t.Fatal("expected error when fewer than 2 migrations")
+	}
+	if !strings.Contains(err.Error(), "at least 2") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSquashMigrations_AbortsOnHighSeverity(t *testing.T) {
+	dir := t.TempDir()
+	writeMigrationFixture(t, dir, "20260101_000000", "a",
+		"-- @up\nDEFINE TABLE a SCHEMAFULL;\n-- @down\nREMOVE TABLE a;\n")
+	// DELETE is flagged as high severity.
+	writeMigrationFixture(t, dir, "20260102_000000", "b",
+		"-- @up\nDELETE a WHERE id = 1;\n-- @down\n")
+
+	_, err := SquashMigrations(context.Background(), dir, "", "")
+	if err == nil {
+		t.Fatal("expected high-severity error")
+	}
+	if !strings.Contains(err.Error(), "high severity") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSquashMigrations_ContextCancelled(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := SquashMigrations(ctx, dir, "", "")
+	if err == nil {
+		t.Fatal("expected cancellation error")
+	}
+}
+
+func TestSquashMigrations_DisableOptimisation(t *testing.T) {
+	dir := t.TempDir()
+	writeMigrationFixture(t, dir, "20260101_000000", "a",
+		"-- @up\nDEFINE FIELD temp ON TABLE user TYPE string;\n-- @down\nREMOVE FIELD temp ON TABLE user;\n")
+	writeMigrationFixture(t, dir, "20260102_000000", "b",
+		"-- @up\nREMOVE FIELD temp ON TABLE user;\n-- @down\nDEFINE FIELD temp ON TABLE user TYPE string;\n")
+
+	disable := false
+	result, err := SquashMigrationsWithOptions(context.Background(), dir, "", "",
+		SquashOptions{Optimize: &disable})
+	if err != nil {
+		t.Fatalf("SquashMigrationsWithOptions: %v", err)
+	}
+	if result.OptimizationsApplied != 0 {
+		t.Errorf("OptimizationsApplied = %d, want 0 when disabled", result.OptimizationsApplied)
+	}
+}
+
+func TestTruncateForWarning(t *testing.T) {
+	short := "SHORT"
+	if got := truncateForWarning(short); got != short {
+		t.Errorf("truncate short: got %q", got)
+	}
+	long := strings.Repeat("x", 80)
+	got := truncateForWarning(long)
+	if !strings.HasSuffix(got, "...") || len(got) != 53 {
+		t.Errorf("truncate long: %q (len=%d)", got, len(got))
+	}
+}
+
+func TestSquashError_IsMigrationSquash(t *testing.T) {
+	if !stdErrors.Is(SquashError, surqlerrors.ErrMigrationSquash) {
+		t.Error("SquashError should equal ErrMigrationSquash")
+	}
+}
+
+func TestBuildSquashedPath(t *testing.T) {
+	got := buildSquashedPath("/tmp/migrations", "20260101_000000", "squashed_a_to_b")
+	want := filepath.Join("/tmp/migrations", "20260101_000000_squashed_a_to_b.surql")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/pkg/surql/migration/watcher.go
+++ b/pkg/surql/migration/watcher.go
@@ -1,0 +1,487 @@
+package migration
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+// DefaultWatcherDebounce is the debounce window applied to a burst of
+// filesystem events before the watcher invokes its DriftChecker.
+const DefaultWatcherDebounce = 500 * time.Millisecond
+
+// SchemaChangeType categorises an observed filesystem event.
+type SchemaChangeType string
+
+// SchemaChangeType values.
+const (
+	SchemaChangeCreated  SchemaChangeType = "created"
+	SchemaChangeModified SchemaChangeType = "modified"
+	SchemaChangeDeleted  SchemaChangeType = "deleted"
+	SchemaChangeRenamed  SchemaChangeType = "renamed"
+)
+
+// SchemaChangeEvent is a single filesystem change captured by the watcher.
+// Multiple events can collapse into a single DriftReport invocation after
+// debouncing.
+type SchemaChangeEvent struct {
+	Path       string           `json:"path"`
+	ChangeType SchemaChangeType `json:"change_type"`
+	Timestamp  time.Time        `json:"timestamp"`
+}
+
+// DriftChecker produces a DriftReport for the given batch of change
+// events. It is called from the watcher's goroutine after the debounce
+// window elapses; implementations should be fast or push the slow work
+// into their own worker pool.
+//
+// A nil return with a nil error indicates the checker decided no report
+// is warranted; the watcher will not emit anything to its output channel
+// in that case.
+type DriftChecker func(ctx context.Context, events []SchemaChangeEvent) (*DriftReport, error)
+
+// SchemaFileFilter reports whether path should be considered a schema
+// file for watch purposes. By default the watcher uses
+// DefaultSchemaFileFilter which accepts any `.surql` file or any `.go`
+// file that is not a test file; callers can supply a custom filter to
+// narrow or broaden the set.
+type SchemaFileFilter func(path string) bool
+
+// WatcherOptions configures a SchemaWatcher. The zero value is valid:
+// Debounce defaults to DefaultWatcherDebounce, Filter defaults to
+// DefaultSchemaFileFilter, and Recursive defaults to true.
+type WatcherOptions struct {
+	// Debounce controls how long the watcher waits for a burst of events
+	// to settle before invoking the DriftChecker. Zero or negative values
+	// are replaced with DefaultWatcherDebounce.
+	Debounce time.Duration
+	// Recursive, when true, watches subdirectories of Dir. Defaults to true.
+	// Callers that want to opt out must explicitly set Recursive=false.
+	Recursive bool
+	// RecursiveSet tracks whether the caller provided an explicit Recursive
+	// value; when false the zero default (Recursive=true) is used.
+	RecursiveSet bool
+	// Filter narrows the set of paths the watcher reacts to. Nil uses
+	// DefaultSchemaFileFilter.
+	Filter SchemaFileFilter
+	// ReportBufferSize is the size of the output DriftReport channel. A
+	// value of 0 applies a sensible default of 8. Callers that consume
+	// reports synchronously should leave this at the default.
+	ReportBufferSize int
+	// OnError, when non-nil, is invoked for each non-fatal watcher error
+	// (checker failure, observer failure, filesystem glitch). The
+	// callback must not block; the watcher otherwise pauses event
+	// dispatch.
+	OnError func(error)
+}
+
+// SchemaWatcher monitors a schema directory for filesystem changes and
+// runs a DriftChecker against the collapsed batch of events after each
+// debounce window. It is the Go equivalent of surql-py's SchemaWatcher
+// and mirrors its lifecycle (Start / Stop) while surfacing drift
+// results over a channel rather than an async callback.
+//
+// Instances are not safe for concurrent Start/Stop calls; the expected
+// use is to create a watcher, Start it once, drain Reports(), then Stop.
+type SchemaWatcher struct {
+	dir      string
+	checker  DriftChecker
+	opts     WatcherOptions
+	fsw      *fsnotify.Watcher
+	reports  chan DriftReport
+	done     chan struct{}
+	events   chan SchemaChangeEvent
+	mu       sync.Mutex
+	running  bool
+	stopOnce sync.Once
+}
+
+// NewSchemaWatcher constructs a SchemaWatcher watching dir using checker
+// to compute a DriftReport for each debounced batch. The returned
+// watcher is dormant until Start is called.
+//
+// dir must exist and be a directory. checker must be non-nil.
+func NewSchemaWatcher(dir string, checker DriftChecker, opts WatcherOptions) (*SchemaWatcher, error) {
+	if checker == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation,
+			"DriftChecker must not be nil")
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, surqlerrors.Wrapf(surqlerrors.ErrValidation, err,
+			"failed to stat schema directory %q", dir)
+	}
+	if !info.IsDir() {
+		return nil, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"schema path %q is not a directory", dir)
+	}
+
+	// Normalise options with defaults.
+	if opts.Debounce <= 0 {
+		opts.Debounce = DefaultWatcherDebounce
+	}
+	if !opts.RecursiveSet {
+		opts.Recursive = true
+	}
+	if opts.Filter == nil {
+		opts.Filter = DefaultSchemaFileFilter
+	}
+	if opts.ReportBufferSize <= 0 {
+		opts.ReportBufferSize = 8
+	}
+
+	return &SchemaWatcher{
+		dir:     dir,
+		checker: checker,
+		opts:    opts,
+		reports: make(chan DriftReport, opts.ReportBufferSize),
+		done:    make(chan struct{}),
+		events:  make(chan SchemaChangeEvent, 64),
+	}, nil
+}
+
+// Reports returns the read end of the DriftReport channel. The channel
+// is closed when the watcher's goroutines have fully shut down after a
+// Stop call.
+func (w *SchemaWatcher) Reports() <-chan DriftReport {
+	return w.reports
+}
+
+// Start begins the watch loop. The provided ctx cancels the watcher and
+// its internal goroutines; a Stop call achieves the same.
+//
+// Start is idempotent — calling it twice returns ErrValidation rather
+// than panicking. The watcher must be fully Stopped before it can be
+// restarted; create a new instance for that use case.
+func (w *SchemaWatcher) Start(ctx context.Context) error {
+	w.mu.Lock()
+	if w.running {
+		w.mu.Unlock()
+		return surqlerrors.New(surqlerrors.ErrValidation,
+			"SchemaWatcher is already running")
+	}
+
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		w.mu.Unlock()
+		return surqlerrors.Wrap(surqlerrors.ErrValidation,
+			"failed to create fsnotify watcher", err)
+	}
+	w.fsw = fsw
+	w.running = true
+	w.mu.Unlock()
+
+	// Register directories. When Recursive is true we walk the tree once
+	// at startup so newly-created subdirectories below dir are covered.
+	if err := w.addRoot(); err != nil {
+		_ = fsw.Close()
+		w.mu.Lock()
+		w.fsw = nil
+		w.running = false
+		w.mu.Unlock()
+		return err
+	}
+
+	go w.eventLoop(ctx)
+	go w.dispatchLoop(ctx)
+
+	return nil
+}
+
+// Stop signals the watcher to shut down and waits until its goroutines
+// have exited and the Reports channel is closed. It is safe to call
+// Stop from any goroutine and from multiple callers concurrently; only
+// the first invocation performs the shutdown.
+func (w *SchemaWatcher) Stop() error {
+	w.stopOnce.Do(func() {
+		close(w.done)
+	})
+
+	w.mu.Lock()
+	fsw := w.fsw
+	w.mu.Unlock()
+	if fsw != nil {
+		_ = fsw.Close()
+	}
+	return nil
+}
+
+// addRoot registers w.dir with fsnotify, honouring the Recursive option.
+func (w *SchemaWatcher) addRoot() error {
+	if !w.opts.Recursive {
+		if err := w.fsw.Add(w.dir); err != nil {
+			return surqlerrors.Wrapf(surqlerrors.ErrValidation, err,
+				"failed to watch %q", w.dir)
+		}
+		return nil
+	}
+
+	return filepath.Walk(w.dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			// Surface walk errors via OnError, but keep traversing.
+			w.reportError(surqlerrors.Wrapf(
+				surqlerrors.ErrValidation, err,
+				"walking %q", path))
+			return nil
+		}
+		if !info.IsDir() {
+			return nil
+		}
+		if err := w.fsw.Add(path); err != nil {
+			w.reportError(surqlerrors.Wrapf(
+				surqlerrors.ErrValidation, err,
+				"failed to watch directory %q", path))
+		}
+		return nil
+	})
+}
+
+// eventLoop translates fsnotify events into SchemaChangeEvents and
+// forwards them to the dispatcher. Directory creates trigger an
+// incremental Add so new subtrees are covered without re-walking.
+func (w *SchemaWatcher) eventLoop(ctx context.Context) {
+	defer close(w.events)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.done:
+			return
+		case err, ok := <-w.fsw.Errors:
+			if !ok {
+				return
+			}
+			w.reportError(surqlerrors.Wrap(
+				surqlerrors.ErrValidation,
+				"filesystem watcher error", err))
+		case ev, ok := <-w.fsw.Events:
+			if !ok {
+				return
+			}
+			w.handleEvent(ev)
+		}
+	}
+}
+
+// handleEvent filters and translates a single fsnotify.Event.
+func (w *SchemaWatcher) handleEvent(ev fsnotify.Event) {
+	// Attempt to register newly-created directories so we keep covering
+	// the subtree. This is best-effort; errors are reported via OnError.
+	if w.opts.Recursive && ev.Has(fsnotify.Create) {
+		if info, err := os.Stat(ev.Name); err == nil && info.IsDir() {
+			if addErr := w.fsw.Add(ev.Name); addErr != nil {
+				w.reportError(surqlerrors.Wrapf(
+					surqlerrors.ErrValidation, addErr,
+					"failed to watch new directory %q", ev.Name))
+			}
+			return
+		}
+	}
+
+	if w.opts.Filter != nil && !w.opts.Filter(ev.Name) {
+		return
+	}
+
+	change := classifyEvent(ev)
+	select {
+	case w.events <- SchemaChangeEvent{
+		Path:       ev.Name,
+		ChangeType: change,
+		Timestamp:  time.Now().UTC(),
+	}:
+	default:
+		// Buffer full: drop oldest via a best-effort non-blocking receive
+		// and retry once. This keeps the watcher responsive under bursty
+		// loads without falling back to unbounded memory growth.
+		select {
+		case <-w.events:
+		default:
+		}
+		select {
+		case w.events <- SchemaChangeEvent{
+			Path:       ev.Name,
+			ChangeType: change,
+			Timestamp:  time.Now().UTC(),
+		}:
+		default:
+		}
+	}
+}
+
+// classifyEvent maps an fsnotify.Op bitmap to a SchemaChangeType. Rename
+// is reported as "renamed"; multiple bits favour the more destructive
+// interpretation (Remove > Rename > Create > Write).
+func classifyEvent(ev fsnotify.Event) SchemaChangeType {
+	switch {
+	case ev.Has(fsnotify.Remove):
+		return SchemaChangeDeleted
+	case ev.Has(fsnotify.Rename):
+		return SchemaChangeRenamed
+	case ev.Has(fsnotify.Create):
+		return SchemaChangeCreated
+	default:
+		return SchemaChangeModified
+	}
+}
+
+// dispatchLoop collects events into batches separated by the debounce
+// window and invokes the DriftChecker once per batch. The resulting
+// DriftReport (when non-nil) is written to the Reports channel.
+func (w *SchemaWatcher) dispatchLoop(ctx context.Context) {
+	defer close(w.reports)
+
+	var (
+		batch []SchemaChangeEvent
+		// timer is created lazily and always stopped / drained together
+		// with batch resets so stale ticks cannot fire on a subsequent
+		// batch.
+		timer *time.Timer
+	)
+	dedupe := make(map[string]SchemaChangeEvent)
+
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		ordered := make([]SchemaChangeEvent, 0, len(batch))
+		seen := make(map[string]struct{}, len(batch))
+		// Preserve the insertion order while removing same-path duplicates.
+		for i := len(batch) - 1; i >= 0; i-- {
+			ev := batch[i]
+			if _, ok := seen[ev.Path]; ok {
+				continue
+			}
+			seen[ev.Path] = struct{}{}
+			ordered = append([]SchemaChangeEvent{ev}, ordered...)
+		}
+		report, err := w.checker(ctx, ordered)
+		if err != nil {
+			w.reportError(surqlerrors.Wrap(
+				surqlerrors.ErrValidation,
+				"drift checker failed", err))
+		} else if report != nil {
+			select {
+			case w.reports <- *report:
+			case <-ctx.Done():
+			case <-w.done:
+			}
+		}
+		batch = batch[:0]
+		for k := range dedupe {
+			delete(dedupe, k)
+		}
+	}
+
+	for {
+		var timerC <-chan time.Time
+		if timer != nil {
+			timerC = timer.C
+		}
+
+		select {
+		case <-ctx.Done():
+			if timer != nil {
+				timer.Stop()
+			}
+			flush()
+			return
+		case <-w.done:
+			if timer != nil {
+				timer.Stop()
+			}
+			flush()
+			return
+		case ev, ok := <-w.events:
+			if !ok {
+				if timer != nil {
+					timer.Stop()
+				}
+				flush()
+				return
+			}
+			// Track the latest event per path for deduplication; the
+			// slice retains order for downstream consumers.
+			if _, exists := dedupe[ev.Path]; !exists {
+				batch = append(batch, ev)
+			} else {
+				// Overwrite the prior occurrence in place so ChangeType
+				// reflects the most recent state (e.g. a create+delete
+				// pair still surfaces the delete).
+				for i, existing := range batch {
+					if existing.Path == ev.Path {
+						batch[i] = ev
+						break
+					}
+				}
+			}
+			dedupe[ev.Path] = ev
+
+			// Reset (or start) the debounce timer.
+			if timer == nil {
+				timer = time.NewTimer(w.opts.Debounce)
+			} else {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(w.opts.Debounce)
+			}
+		case <-timerC:
+			timer = nil
+			flush()
+		}
+	}
+}
+
+// reportError forwards a non-fatal error to the OnError callback (if
+// set) without blocking the caller. Errors during shutdown are dropped.
+func (w *SchemaWatcher) reportError(err error) {
+	if err == nil {
+		return
+	}
+	if w.opts.OnError == nil {
+		return
+	}
+	// Run in a goroutine so a slow handler can't stall the watcher.
+	go w.opts.OnError(err)
+}
+
+// DefaultSchemaFileFilter accepts any .surql file and any .go file that
+// is not a *_test.go file, matching the Go-idiomatic set of schema
+// definitions. Files outside of those extensions are ignored.
+func DefaultSchemaFileFilter(path string) bool {
+	base := filepath.Base(path)
+	ext := filepath.Ext(base)
+	switch ext {
+	case ".surql":
+		return true
+	case ".go":
+		if len(base) >= len("_test.go") &&
+			base[len(base)-len("_test.go"):] == "_test.go" {
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+// IsClosed reports whether err stems from fsnotify.Watcher.Close being
+// called. It is exposed so callers embedding the watcher can filter
+// shutdown noise.
+func IsClosed(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, fsnotify.ErrEventOverflow) ||
+		err.Error() == "fsnotify: watcher already closed"
+}

--- a/pkg/surql/migration/watcher_test.go
+++ b/pkg/surql/migration/watcher_test.go
@@ -1,0 +1,488 @@
+package migration
+
+import (
+	"context"
+	stdErrors "errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// collectReports drains reports from ch until ctx is done or until count
+// reports have been received.
+func collectReports(ctx context.Context, ch <-chan DriftReport, count int) []DriftReport {
+	out := make([]DriftReport, 0, count)
+	for len(out) < count {
+		select {
+		case r, ok := <-ch:
+			if !ok {
+				return out
+			}
+			out = append(out, r)
+		case <-ctx.Done():
+			return out
+		}
+	}
+	return out
+}
+
+func TestDefaultSchemaFileFilter(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"schema.surql", true},
+		{"model.go", true},
+		{"model_test.go", false},
+		{"README.md", false},
+		{"subdir/tables.surql", true},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			if got := DefaultSchemaFileFilter(tc.path); got != tc.want {
+				t.Errorf("DefaultSchemaFileFilter(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewSchemaWatcher_ValidatesInputs(t *testing.T) {
+	_, err := NewSchemaWatcher("", noopChecker, WatcherOptions{})
+	if err == nil {
+		t.Error("expected error for empty dir")
+	}
+
+	dir := t.TempDir()
+	_, err = NewSchemaWatcher(dir, nil, WatcherOptions{})
+	if err == nil {
+		t.Error("expected error for nil checker")
+	}
+
+	// File path, not dir.
+	file := filepath.Join(dir, "a.surql")
+	if err := os.WriteFile(file, []byte(""), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err = NewSchemaWatcher(file, noopChecker, WatcherOptions{})
+	if err == nil {
+		t.Error("expected error for non-directory path")
+	}
+}
+
+func TestNewSchemaWatcher_AppliesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	w, err := NewSchemaWatcher(dir, noopChecker, WatcherOptions{})
+	if err != nil {
+		t.Fatalf("NewSchemaWatcher: %v", err)
+	}
+	if w.opts.Debounce != DefaultWatcherDebounce {
+		t.Errorf("Debounce = %v, want %v", w.opts.Debounce, DefaultWatcherDebounce)
+	}
+	if !w.opts.Recursive {
+		t.Error("Recursive default should be true")
+	}
+	if w.opts.Filter == nil {
+		t.Error("Filter default should be non-nil")
+	}
+	if w.opts.ReportBufferSize != 8 {
+		t.Errorf("ReportBufferSize default = %d, want 8", w.opts.ReportBufferSize)
+	}
+}
+
+func TestNewSchemaWatcher_RespectsExplicitRecursiveFalse(t *testing.T) {
+	dir := t.TempDir()
+	w, err := NewSchemaWatcher(dir, noopChecker, WatcherOptions{
+		RecursiveSet: true,
+		Recursive:    false,
+	})
+	if err != nil {
+		t.Fatalf("NewSchemaWatcher: %v", err)
+	}
+	if w.opts.Recursive {
+		t.Error("explicit Recursive=false should be honoured")
+	}
+}
+
+func TestSchemaWatcher_StartTwiceIsError(t *testing.T) {
+	dir := t.TempDir()
+	w, err := NewSchemaWatcher(dir, noopChecker, WatcherOptions{
+		Debounce: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewSchemaWatcher: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	if err := w.Start(ctx); err == nil {
+		t.Error("expected second Start to fail")
+	}
+}
+
+func TestSchemaWatcher_EmitsDriftReport(t *testing.T) {
+	dir := t.TempDir()
+
+	var invocations int32
+	checker := func(ctx context.Context, events []SchemaChangeEvent) (*DriftReport, error) {
+		atomic.AddInt32(&invocations, 1)
+		return &DriftReport{
+			DriftDetected: true,
+			Issues: []DriftIssue{
+				{
+					Severity:    DriftSeverityInfo,
+					Operation:   DiffOperationAddTable,
+					Table:       "user",
+					Description: "user table appeared",
+				},
+			},
+		}, nil
+	}
+
+	w, err := NewSchemaWatcher(dir, checker, WatcherOptions{
+		Debounce: 80 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewSchemaWatcher: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	// Create a schema file; this should produce one debounced event.
+	time.Sleep(50 * time.Millisecond)
+	path := filepath.Join(dir, "user.surql")
+	if err := os.WriteFile(path, []byte("DEFINE TABLE user SCHEMAFULL;\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer waitCancel()
+	reports := collectReports(waitCtx, w.Reports(), 1)
+	if len(reports) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(reports))
+	}
+	if !reports[0].DriftDetected {
+		t.Error("DriftDetected = false, want true")
+	}
+	if atomic.LoadInt32(&invocations) < 1 {
+		t.Error("checker was not invoked")
+	}
+}
+
+func TestSchemaWatcher_DebouncesBursts(t *testing.T) {
+	dir := t.TempDir()
+
+	var batchSizes []int
+	var mu sync.Mutex
+	checker := func(ctx context.Context, events []SchemaChangeEvent) (*DriftReport, error) {
+		mu.Lock()
+		batchSizes = append(batchSizes, len(events))
+		mu.Unlock()
+		return &DriftReport{DriftDetected: false}, nil
+	}
+
+	w, err := NewSchemaWatcher(dir, checker, WatcherOptions{
+		Debounce: 150 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewSchemaWatcher: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	time.Sleep(30 * time.Millisecond)
+	// Three rapid writes within the debounce window.
+	for i, name := range []string{"a.surql", "b.surql", "c.surql"} {
+		_ = i
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("."), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer waitCancel()
+	reports := collectReports(waitCtx, w.Reports(), 1)
+	if len(reports) == 0 {
+		t.Fatalf("expected at least 1 report")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(batchSizes) == 0 {
+		t.Fatal("checker never called")
+	}
+	// Expect the first flush to batch multiple events.
+	if batchSizes[0] < 2 {
+		t.Errorf("first batch size = %d, want >=2 (debouncing failed)", batchSizes[0])
+	}
+}
+
+func TestSchemaWatcher_FiltersIgnoredFiles(t *testing.T) {
+	dir := t.TempDir()
+	var invocations int32
+	checker := func(ctx context.Context, events []SchemaChangeEvent) (*DriftReport, error) {
+		atomic.AddInt32(&invocations, 1)
+		return nil, nil
+	}
+
+	// Custom filter only accepts files ending in .surql, not .md.
+	w, err := NewSchemaWatcher(dir, checker, WatcherOptions{
+		Debounce: 60 * time.Millisecond,
+		Filter:   DefaultSchemaFileFilter,
+	})
+	if err != nil {
+		t.Fatalf("NewSchemaWatcher: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	time.Sleep(30 * time.Millisecond)
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("ignored"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	if got := atomic.LoadInt32(&invocations); got != 0 {
+		t.Errorf("checker invoked %d times, want 0", got)
+	}
+}
+
+func TestSchemaWatcher_StopClosesReports(t *testing.T) {
+	dir := t.TempDir()
+	w, err := NewSchemaWatcher(dir, noopChecker, WatcherOptions{
+		Debounce: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewSchemaWatcher: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if err := w.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	// Reports must close within a reasonable time.
+	select {
+	case _, ok := <-w.Reports():
+		if ok {
+			// Drain a final report if present, then expect close.
+			select {
+			case _, ok := <-w.Reports():
+				if ok {
+					t.Error("Reports channel did not close")
+				}
+			case <-time.After(2 * time.Second):
+				t.Error("Reports channel did not close after stop")
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("Reports channel did not close after stop")
+	}
+}
+
+func TestSchemaWatcher_DedupesSamePath(t *testing.T) {
+	dir := t.TempDir()
+
+	var lastBatch []SchemaChangeEvent
+	var mu sync.Mutex
+	checker := func(ctx context.Context, events []SchemaChangeEvent) (*DriftReport, error) {
+		mu.Lock()
+		lastBatch = append([]SchemaChangeEvent(nil), events...)
+		mu.Unlock()
+		return &DriftReport{DriftDetected: false}, nil
+	}
+
+	w, err := NewSchemaWatcher(dir, checker, WatcherOptions{
+		Debounce: 120 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewSchemaWatcher: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	time.Sleep(30 * time.Millisecond)
+	path := filepath.Join(dir, "user.surql")
+	// Multiple writes to the same path collapse to a single entry.
+	for i := 0; i < 3; i++ {
+		if err := os.WriteFile(path, []byte{byte('a' + i)}, 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer waitCancel()
+	_ = collectReports(waitCtx, w.Reports(), 1)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(lastBatch) != 1 {
+		t.Errorf("dedupe failed: batch had %d events (want 1): %+v", len(lastBatch), lastBatch)
+	}
+}
+
+func TestSchemaWatcher_NilReportNotSent(t *testing.T) {
+	dir := t.TempDir()
+	checker := func(ctx context.Context, events []SchemaChangeEvent) (*DriftReport, error) {
+		// Returning nil, nil means "no report needed".
+		return nil, nil
+	}
+
+	w, err := NewSchemaWatcher(dir, checker, WatcherOptions{
+		Debounce: 60 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewSchemaWatcher: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	time.Sleep(30 * time.Millisecond)
+	if err := os.WriteFile(filepath.Join(dir, "user.surql"), []byte("."), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	time.Sleep(250 * time.Millisecond)
+
+	select {
+	case r, ok := <-w.Reports():
+		if ok {
+			t.Errorf("unexpected report received: %+v", r)
+		}
+	default:
+		// good: no report
+	}
+}
+
+func TestSchemaWatcher_CheckerErrorReportedViaCallback(t *testing.T) {
+	dir := t.TempDir()
+	sentinelErr := stdErrors.New("checker boom")
+
+	var observed atomic.Value
+	opts := WatcherOptions{
+		Debounce: 60 * time.Millisecond,
+		OnError: func(err error) {
+			observed.Store(err)
+		},
+	}
+	w, err := NewSchemaWatcher(dir, func(ctx context.Context, events []SchemaChangeEvent) (*DriftReport, error) {
+		return nil, sentinelErr
+	}, opts)
+	if err != nil {
+		t.Fatalf("NewSchemaWatcher: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	time.Sleep(30 * time.Millisecond)
+	if err := os.WriteFile(filepath.Join(dir, "user.surql"), []byte("."), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	deadline := time.After(3 * time.Second)
+	for {
+		if v := observed.Load(); v != nil {
+			if !stdErrors.Is(v.(error), sentinelErr) {
+				t.Errorf("observed error does not wrap sentinel: %v", v)
+			}
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("OnError never fired")
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
+func TestSchemaWatcher_CtxCancelShutsDown(t *testing.T) {
+	dir := t.TempDir()
+	w, err := NewSchemaWatcher(dir, noopChecker, WatcherOptions{
+		Debounce: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewSchemaWatcher: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	cancel()
+	// Give the goroutines a moment to observe the cancellation.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-w.Reports():
+			if !ok {
+				return
+			}
+		case <-deadline:
+			t.Fatal("watcher did not shut down after ctx cancel")
+		}
+	}
+}
+
+func TestClassifyEvent(t *testing.T) {
+	cases := []struct {
+		name string
+		op   fsnotify.Op
+		want SchemaChangeType
+	}{
+		{"create", fsnotify.Create, SchemaChangeCreated},
+		{"write", fsnotify.Write, SchemaChangeModified},
+		{"remove", fsnotify.Remove, SchemaChangeDeleted},
+		{"rename", fsnotify.Rename, SchemaChangeRenamed},
+		{"remove+write", fsnotify.Remove | fsnotify.Write, SchemaChangeDeleted},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyEvent(fsnotify.Event{Op: tc.op})
+			if got != tc.want {
+				t.Errorf("classifyEvent(%v) = %q, want %q", tc.op, got, tc.want)
+			}
+		})
+	}
+}
+
+// noopChecker is a DriftChecker that returns no report and no error.
+func noopChecker(ctx context.Context, events []SchemaChangeEvent) (*DriftReport, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## Summary

Closes three migration-module parity gaps vs `surql-py`.

### `squash.go`
- `SquashMigrations(ctx, dir, from, to) (*SquashResult, error)` combines N consecutive migrations into a single `.surql` file with merged UP + reverse-order DOWN, new version, new SHA-256 checksum, `-- @squashed-from: vA..vB` marker.
- Emits a statement optimiser so merged UP/DOWN don't contain duplicates.

### `watcher.go`
- `SchemaWatcher` using `github.com/fsnotify/fsnotify`, debounced (default 500 ms), surfaces drift via `chan DriftReport`.
- Caller-supplied `DriftChecker` keeps the package DB-dependency-free.

### `hooks.go` (extended)
- `CreateSnapshotOnMigration(ctx, dir, migration, SnapshotHook)` wraps `CreateSnapshot` + `StoreSnapshot`.
- `EnableAutoSnapshots`, `DisableAutoSnapshots`, `IsAutoSnapshotEnabled` — global toggle via `atomic.Int32` for lock-free hot-path reads.

## Deviations from py (documented inline)

- Squashed migration DOWN is generated as reverse-concat of source DOWNs (py returns empty) — superset, keeps rollbacks usable.
- `-- @squashed-from` header lives above `-- @up` rather than in a module docstring; unknown header comments round-trip cleanly.
- `SquashError` is a sentinel `surqlerrors.ErrMigrationSquash` (Go idiom; `errors.Is` compatible).
- Watcher surfaces drift via channel, not async callback.
- `SnapshotHook` struct carries `*schema.SchemaRegistry` because Go's `CreateSnapshot` takes a registry (py takes a live client).

## Test plan

- [x] `gofmt -l .` empty
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./... -race -count=1` — 1215 → 1282 (+67)
- [x] `go test -tags=integration ./...` against `surrealdb/surrealdb:v3.0.5` — green

Refs #58, closes #70.