### PR TITLE
chore(release): bump version to 0.1.0

### DIFF
--- a/pkg/surql/surql.go
+++ b/pkg/surql/surql.go
@@ -1,8 +1,4 @@
 package surql
 
 // Version is the current surql-go release.
-//
-// The foundation port is under active development; operations that require
-// the SurrealDB client will land incrementally and are tracked against
-// surql-py as the source-of-truth feature set.
-const Version = "0.1.0-dev"
+const Version = "0.1.0"


### PR DESCRIPTION
Finalise release/0.1.0 with the real version string. Closes the version-constant dev suffix introduced in Oneiriq/surql-go#57.