### PR TITLE
feat(query): query-UX parity wave (type::record, function factories, extract helpers, aggregation)

### DIFF
--- a/pkg/surql/query/aggregate_test.go
+++ b/pkg/surql/query/aggregate_test.go
@@ -1,0 +1,240 @@
+package query
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/types"
+)
+
+func TestSelectExpr_RendersRawExpressions(t *testing.T) {
+	q := Query{}.SelectExpr(CountAll(), MathMean("strength"))
+	q, err := q.FromTable("memory_entry")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q = q.GroupAll()
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "SELECT count(), math::mean(strength) FROM memory_entry GROUP ALL"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSelectExpr_EmptyArgsSelectsStar(t *testing.T) {
+	q := Query{}.SelectExpr()
+	q, err := q.FromTable("t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "SELECT * FROM t" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSelectAliased_RendersAliases(t *testing.T) {
+	q := Query{}.SelectAliased(map[string]types.Operator{
+		"total": MathSum("strength"),
+		"n":     CountAll(),
+	})
+	q, err := q.FromTable("memory_entry")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q = q.GroupAll()
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Keys emit in sorted order: n before total.
+	want := "SELECT count() AS n, math::sum(strength) AS total FROM memory_entry GROUP ALL"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSelectAliased_EmptySelectsStar(t *testing.T) {
+	q := Query{}.SelectAliased(nil)
+	q, err := q.FromTable("t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "SELECT * FROM t" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestFrom_PanicsOnInvalidTable(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on invalid table")
+		}
+	}()
+	_ = Query{}.Select(nil).From("1bad")
+}
+
+func TestFrom_Ok(t *testing.T) {
+	q := Query{}.Select(nil).From("users")
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "SELECT * FROM users" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestAggregateRecords_NilClient(t *testing.T) {
+	// With valid opts, the nil-client check fires after opts
+	// validation.
+	_, err := AggregateRecords(context.Background(), nil, AggregateOpts{
+		Table:  "t",
+		Select: map[string]types.Operator{"n": CountAll()},
+	})
+	if err == nil || !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestAggregateRecords_EmptyTable(t *testing.T) {
+	// Table validation fires before the nil-client check so we can
+	// exercise it without a live connection.
+	_, err := AggregateRecords(context.Background(), nil, AggregateOpts{
+		Select: map[string]types.Operator{"n": CountAll()},
+	})
+	if err == nil || !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestAggregateRecords_EmptySelect(t *testing.T) {
+	_, err := AggregateRecords(context.Background(), nil, AggregateOpts{
+		Table: "t",
+	})
+	if err == nil || !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestAggregateRecords_InvalidTable(t *testing.T) {
+	_, err := AggregateRecords(context.Background(), nil, AggregateOpts{
+		Table:  "1bad",
+		Select: map[string]types.Operator{"n": CountAll()},
+	})
+	if err == nil || !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestAggregateRecords_GroupAllPrecedenceOverGroupBy(t *testing.T) {
+	// When both GroupAll and GroupBy are provided, GroupAll wins; we can
+	// verify this by rendering the assembled query directly.
+	q, err := buildAggregateQuery(AggregateOpts{
+		Table:    "t",
+		Select:   map[string]types.Operator{"n": CountAll()},
+		GroupBy:  []string{"network"},
+		GroupAll: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "SELECT count() AS n FROM t GROUP ALL"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestAggregateRecords_GroupByOnly(t *testing.T) {
+	q, err := buildAggregateQuery(AggregateOpts{
+		Table:   "memory_entry",
+		Select:  map[string]types.Operator{"n": CountAll()},
+		GroupBy: []string{"network"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// SurrealDB requires GROUP BY idioms to appear in the projection;
+	// AggregateRecords prepends them ahead of the aliased aggregations.
+	want := "SELECT network, count() AS n FROM memory_entry GROUP BY network"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// buildAggregateQuery extracts the query assembly from AggregateRecords
+// so unit tests can inspect the rendered SurrealQL without hitting the
+// client.
+func buildAggregateQuery(opts AggregateOpts) (Query, error) {
+	q := Query{}.SelectAliased(opts.Select)
+	if !opts.GroupAll && len(opts.GroupBy) > 0 {
+		grouped := append([]string(nil), opts.GroupBy...)
+		grouped = append(grouped, q.Fields...)
+		q.Fields = grouped
+	}
+	q, err := q.FromTable(opts.Table)
+	if err != nil {
+		return Query{}, err
+	}
+	for _, w := range opts.Where {
+		q, err = q.Where(w)
+		if err != nil {
+			return Query{}, err
+		}
+	}
+	if opts.GroupAll {
+		q = q.GroupAll()
+	} else if len(opts.GroupBy) > 0 {
+		q = q.GroupBy(opts.GroupBy...)
+	}
+	if opts.OrderBy != nil {
+		q, err = q.OrderBy(opts.OrderBy.Field, opts.OrderBy.Direction)
+		if err != nil {
+			return Query{}, err
+		}
+	}
+	if opts.Limit != nil {
+		q, err = q.Limit(*opts.Limit)
+		if err != nil {
+			return Query{}, err
+		}
+	}
+	if opts.Offset != nil {
+		q, err = q.Offset(*opts.Offset)
+		if err != nil {
+			return Query{}, err
+		}
+	}
+	return q, nil
+}
+
+func TestExecute_Method_NilClient(t *testing.T) {
+	q, err := Query{}.Select(nil).FromTable("t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = q.Execute(context.Background(), nil)
+	if err == nil || !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}

--- a/pkg/surql/query/builder.go
+++ b/pkg/surql/query/builder.go
@@ -174,6 +174,68 @@ func (q Query) Select(fields []string) Query {
 	return out
 }
 
+// SelectExpr starts a SELECT query whose projection consists of the
+// supplied [types.SurrealFn] function factories (or any other
+// [types.Operator] implementer). Unlike [Query.Select] which renders
+// each field as a plain identifier, SelectExpr emits each expression's
+// SurrealQL form verbatim — enabling aggregations such as
+// `SELECT count(), math::mean(strength) FROM t GROUP ALL`.
+//
+// Pass zero expressions to select `*` (matching [Query.Select]'s
+// empty-slice behaviour).
+func (q Query) SelectExpr(exprs ...types.Operator) Query {
+	out := q.clone()
+	out.Operation = OpSelect
+	if len(exprs) == 0 {
+		out.Fields = []string{"*"}
+		return out
+	}
+	rendered := make([]string, len(exprs))
+	for i, e := range exprs {
+		rendered[i] = e.ToSurql()
+	}
+	out.Fields = rendered
+	return out
+}
+
+// SelectAliased is SelectExpr with per-expression aliases. The map's
+// insertion order is not preserved in Go, so aliases are emitted in
+// sorted-key order for deterministic output — matching renderDataObject.
+//
+// Accepts any [types.Operator] implementation so both the SurrealFn
+// factories in functions.go and the Expression helpers in
+// expressions.go compose through the same interface.
+func (q Query) SelectAliased(fields map[string]types.Operator) Query {
+	out := q.clone()
+	out.Operation = OpSelect
+	if len(fields) == 0 {
+		out.Fields = []string{"*"}
+		return out
+	}
+	keys := make([]string, 0, len(fields))
+	for k := range fields {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	rendered := make([]string, len(keys))
+	for i, k := range keys {
+		rendered[i] = fields[k].ToSurql() + " AS " + k
+	}
+	out.Fields = rendered
+	return out
+}
+
+// From is an alias for [Query.FromTable] that panics on validation
+// error, matching the fluent `NewQuery().Select(...).From(...)` shape.
+// Prefer [Query.FromTable] when caller code needs to surface the error.
+func (q Query) From(table string) Query {
+	out, err := q.FromTable(table)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
+
 // FromTable sets the table (or record id) the query targets. Returns
 // ErrValidation when the table portion is not a safe identifier.
 func (q Query) FromTable(table string) (Query, error) {

--- a/pkg/surql/query/crud.go
+++ b/pkg/surql/query/crud.go
@@ -500,6 +500,112 @@ func Last(ctx context.Context, client *connection.DatabaseClient, table string, 
 	return First(ctx, client, table, opts)
 }
 
+// AggregateOpts configures a single aggregation query assembled by
+// [AggregateRecords]. At least one aggregation expression must be
+// supplied via Select; GroupBy / GroupAll / Where / Having are all
+// optional.
+type AggregateOpts struct {
+	// Table is the source table. Required.
+	Table string
+	// Select maps result alias -> aggregation expression. Accepts any
+	// [types.Operator] implementation (SurrealFn, Expression, raw
+	// wrappers). Keys are emitted in sorted order for deterministic
+	// rendering.
+	Select map[string]types.Operator
+	// GroupBy lists explicit grouping fields. Mutually exclusive with
+	// GroupAll; if both are supplied, GroupAll wins.
+	GroupBy []string
+	// GroupAll toggles SurrealQL's `GROUP ALL` whole-result aggregation.
+	GroupAll bool
+	// Where is an optional filter applied before grouping. Each entry is
+	// a raw SurrealQL fragment or a types.Operator implementer.
+	Where []any
+	// OrderBy sets an ORDER BY clause when non-nil (field + direction).
+	OrderBy *OrderField
+	// Limit bounds the number of aggregated rows when non-nil.
+	Limit *int
+	// Offset skips the first N aggregated rows when non-nil.
+	Offset *int
+}
+
+// AggregateRecords runs a SELECT projection of aggregation expressions
+// against opts.Table and returns the raw aggregated rows. Each row's
+// keys match the aliases in opts.Select.
+//
+// Example:
+//
+//	opts := query.AggregateOpts{
+//	    Table:   "memory_entry",
+//	    Select:  map[string]types.Operator{
+//	        "count": query.CountAll(),
+//	        "total": query.MathSum("strength"),
+//	    },
+//	    GroupBy: []string{"network"},
+//	}
+//	rows, err := query.AggregateRecords(ctx, client, opts)
+func AggregateRecords(ctx context.Context, client *connection.DatabaseClient, opts AggregateOpts) ([]map[string]any, error) {
+	if opts.Table == "" {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "AggregateOpts.Table cannot be empty")
+	}
+	if len(opts.Select) == 0 {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation,
+			"AggregateOpts.Select must contain at least one aggregation expression")
+	}
+	q := Query{}.SelectAliased(opts.Select)
+	// SurrealDB requires every GROUP BY idiom to appear in the projection;
+	// prepend the group fields verbatim so callers don't have to
+	// remember.
+	if !opts.GroupAll && len(opts.GroupBy) > 0 {
+		grouped := append([]string(nil), opts.GroupBy...)
+		grouped = append(grouped, q.Fields...)
+		q.Fields = grouped
+	}
+	q, err := q.FromTable(opts.Table)
+	if err != nil {
+		return nil, err
+	}
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	for _, w := range opts.Where {
+		q, err = q.Where(w)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if opts.GroupAll {
+		q = q.GroupAll()
+	} else if len(opts.GroupBy) > 0 {
+		q = q.GroupBy(opts.GroupBy...)
+	}
+	if opts.OrderBy != nil {
+		q, err = q.OrderBy(opts.OrderBy.Field, opts.OrderBy.Direction)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if opts.Limit != nil {
+		q, err = q.Limit(*opts.Limit)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if opts.Offset != nil {
+		q, err = q.Offset(*opts.Offset)
+		if err != nil {
+			return nil, err
+		}
+	}
+	raw, err := ExecuteQuery(ctx, client, q)
+	if err != nil {
+		if isTableMissingError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return ExtractResult(raw), nil
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------

--- a/pkg/surql/query/crud.go
+++ b/pkg/surql/query/crud.go
@@ -151,6 +151,143 @@ func UpsertRecord(ctx context.Context, client *connection.DatabaseClient, table 
 	return normaliseSingle(raw), nil
 }
 
+// GetByTarget fetches the single record referenced by a target expression
+// such as [types.TypeRecord] or [types.TypeThing]. Returns (nil, nil) when
+// the underlying record does not exist. Intended to be paired with
+// TypeRecord/TypeThing for callers who already have a composed target.
+func GetByTarget(ctx context.Context, client *connection.DatabaseClient, target types.SurrealFn) (map[string]any, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	expr := target.ToSurql()
+	if expr == "" {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "target cannot be empty")
+	}
+	res, err := client.Query(ctx, "SELECT * FROM "+expr+";")
+	if err != nil {
+		if isTableMissingError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	rows := ExtractResult(res)
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	return rows[0], nil
+}
+
+// UpdateByTarget replaces the record referenced by target (PUT semantics).
+// Mirrors [UpdateRecord] but takes a single target expression so callers
+// can use [types.TypeRecord] / [types.TypeThing] verbatim.
+func UpdateByTarget(ctx context.Context, client *connection.DatabaseClient, target types.SurrealFn, data map[string]any) (map[string]any, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	expr := target.ToSurql()
+	if expr == "" {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "target cannot be empty")
+	}
+	if data == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "data cannot be nil")
+	}
+	if err := validateDataKeys(data); err != nil {
+		return nil, err
+	}
+	// Render as a raw UPDATE so the target expression is splice-safe.
+	surql := "UPDATE " + expr + " CONTENT " + renderDataObject(data) + ";"
+	res, err := client.Query(ctx, surql)
+	if err != nil {
+		return nil, err
+	}
+	if m := ExtractOne(res); m != nil {
+		return m, nil
+	}
+	return normaliseSingle(res), nil
+}
+
+// MergeByTarget partially updates the record referenced by target
+// (PATCH semantics). Mirrors [MergeRecord] for composed targets.
+func MergeByTarget(ctx context.Context, client *connection.DatabaseClient, target types.SurrealFn, data map[string]any) (map[string]any, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	expr := target.ToSurql()
+	if expr == "" {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "target cannot be empty")
+	}
+	if data == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "data cannot be nil")
+	}
+	if err := validateDataKeys(data); err != nil {
+		return nil, err
+	}
+	surql := "UPDATE " + expr + " MERGE " + renderDataObject(data) + ";"
+	res, err := client.Query(ctx, surql)
+	if err != nil {
+		return nil, err
+	}
+	if m := ExtractOne(res); m != nil {
+		return m, nil
+	}
+	return normaliseSingle(res), nil
+}
+
+// UpsertByTarget inserts-or-replaces the record referenced by target.
+// Mirrors [UpsertRecord] for composed targets.
+func UpsertByTarget(ctx context.Context, client *connection.DatabaseClient, target types.SurrealFn, data map[string]any) (map[string]any, error) {
+	if client == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	expr := target.ToSurql()
+	if expr == "" {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "target cannot be empty")
+	}
+	if data == nil {
+		return nil, surqlerrors.New(surqlerrors.ErrValidation, "data cannot be nil")
+	}
+	if err := validateDataKeys(data); err != nil {
+		return nil, err
+	}
+	surql := "UPSERT " + expr + " CONTENT " + renderDataObject(data) + ";"
+	res, err := client.Query(ctx, surql)
+	if err != nil {
+		return nil, err
+	}
+	if m := ExtractOne(res); m != nil {
+		return m, nil
+	}
+	return normaliseSingle(res), nil
+}
+
+// DeleteByTarget removes the record referenced by target. A "table does
+// not exist" error is treated as a no-op for v3 parity.
+func DeleteByTarget(ctx context.Context, client *connection.DatabaseClient, target types.SurrealFn) error {
+	if client == nil {
+		return surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
+	}
+	expr := target.ToSurql()
+	if expr == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "target cannot be empty")
+	}
+	if _, err := client.Query(ctx, "DELETE "+expr+";"); err != nil {
+		if isTableMissingError(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// ExistsByTarget reports whether the record referenced by target exists.
+func ExistsByTarget(ctx context.Context, client *connection.DatabaseClient, target types.SurrealFn) (bool, error) {
+	rec, err := GetByTarget(ctx, client, target)
+	if err != nil {
+		return false, err
+	}
+	return rec != nil, nil
+}
+
 // DeleteRecord removes a single record identified by recordID.
 func DeleteRecord(ctx context.Context, client *connection.DatabaseClient, table string, recordID any) error {
 	if client == nil {

--- a/pkg/surql/query/crud_test.go
+++ b/pkg/surql/query/crud_test.go
@@ -181,6 +181,42 @@ func TestToInt64(t *testing.T) {
 	}
 }
 
+func TestByTargetHelpers_NilClient(t *testing.T) {
+	ctx := context.Background()
+	target := types.TypeRecord("task", "abc")
+	cases := []struct {
+		name string
+		fn   func() error
+	}{
+		{"GetByTarget", func() error { _, err := GetByTarget(ctx, nil, target); return err }},
+		{"UpdateByTarget", func() error {
+			_, err := UpdateByTarget(ctx, nil, target, map[string]any{"a": 1})
+			return err
+		}},
+		{"MergeByTarget", func() error {
+			_, err := MergeByTarget(ctx, nil, target, map[string]any{"a": 1})
+			return err
+		}},
+		{"UpsertByTarget", func() error {
+			_, err := UpsertByTarget(ctx, nil, target, map[string]any{"a": 1})
+			return err
+		}},
+		{"DeleteByTarget", func() error { return DeleteByTarget(ctx, nil, target) }},
+		{"ExistsByTarget", func() error { _, err := ExistsByTarget(ctx, nil, target); return err }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.fn()
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !errors.Is(err, surqlerrors.ErrValidation) {
+				t.Errorf("want ErrValidation, got %v", err)
+			}
+		})
+	}
+}
+
 func TestLast_FlipsOrderDirection(t *testing.T) {
 	opts := QueryOptions{OrderBy: &OrderField{Field: "created_at", Direction: "ASC"}}
 	// Last only flips the direction; it still calls First which requires a

--- a/pkg/surql/query/executor.go
+++ b/pkg/surql/query/executor.go
@@ -26,6 +26,12 @@ func ExecuteQuery(ctx context.Context, client *connection.DatabaseClient, q Quer
 	return client.Query(ctx, surql)
 }
 
+// Execute is the method form of [ExecuteQuery], letting callers chain
+// `NewQuery().Select(...).From(...).GroupAll().Execute(ctx, client)`.
+func (q Query) Execute(ctx context.Context, client *connection.DatabaseClient) (any, error) {
+	return ExecuteQuery(ctx, client, q)
+}
+
 // ExecuteRaw runs a raw SurrealQL statement with the supplied parameter map.
 // Pass a nil vars map for a parameter-less query.
 func ExecuteRaw(ctx context.Context, client *connection.DatabaseClient, surql string, vars map[string]any) (any, error) {

--- a/pkg/surql/query/expressions.go
+++ b/pkg/surql/query/expressions.go
@@ -34,6 +34,11 @@ func (e Expression) ToSurql() string { return e.SQL }
 // String implements fmt.Stringer.
 func (e Expression) String() string { return e.SQL }
 
+// IsRawSurqlValue marks Expression as a [types.RawSurqlValue] so it
+// renders verbatim when used as a value in CREATE/UPDATE/UPSERT set
+// clauses or in quoted operator values.
+func (e Expression) IsRawSurqlValue() {}
+
 // NewRaw builds a raw-kind Expression.
 func NewRaw(sql string) Expression { return Expression{SQL: sql, Kind: ExprRaw} }
 

--- a/pkg/surql/query/functions.go
+++ b/pkg/surql/query/functions.go
@@ -1,0 +1,107 @@
+// Package query — SurrealQL function factories.
+//
+// These builders complement the existing expressions.go helpers. They
+// return [types.SurrealFn] so they are recognised by the raw-value
+// renderer in pkg/surql/types (without relying on
+// [types.RawSurqlValue]) and compose transparently in:
+//
+//   - SET / update payloads (via quoteValue's SurrealFn case)
+//   - WHERE conditions (SurrealFn implements [types.Operator])
+//   - SELECT projections (via [Query.SelectExpr])
+//
+// Naming follows the surql-py port's snake_case camelCased:
+// `math_mean` -> MathMean, `string_len` -> StringLen, `count_if` ->
+// CountIf, etc. Where a name already existed as an [Expression] helper
+// (TimeNow, MathMean, MathSum, Count, StringLower, StringUpper) those
+// originals stay put; Expression now implements [types.RawSurqlValue]
+// so both paths compose identically.
+package query
+
+import (
+	"fmt"
+
+	"github.com/Oneiriq/surql-go/pkg/surql/types"
+)
+
+// ---------------------------------------------------------------------------
+// math::* factories returning types.SurrealFn.
+//
+// MathAbs, MathCeil, MathFloor, MathRound are new (no prior Expression
+// equivalents under those names).
+// ---------------------------------------------------------------------------
+
+// MathAbs returns `math::abs(field)`.
+func MathAbs(fieldName string) types.SurrealFn {
+	return types.NewSurrealFn(fmt.Sprintf("math::abs(%s)", fieldName))
+}
+
+// MathCeil returns `math::ceil(field)`.
+func MathCeil(fieldName string) types.SurrealFn {
+	return types.NewSurrealFn(fmt.Sprintf("math::ceil(%s)", fieldName))
+}
+
+// MathFloor returns `math::floor(field)`.
+func MathFloor(fieldName string) types.SurrealFn {
+	return types.NewSurrealFn(fmt.Sprintf("math::floor(%s)", fieldName))
+}
+
+// MathRound returns `math::round(field)` (integer rounding).
+func MathRound(fieldName string) types.SurrealFn {
+	return types.NewSurrealFn(fmt.Sprintf("math::round(%s)", fieldName))
+}
+
+// ---------------------------------------------------------------------------
+// string::* factories returning types.SurrealFn.
+// ---------------------------------------------------------------------------
+
+// StringLen returns `string::len(field)`.
+func StringLen(fieldName string) types.SurrealFn {
+	return types.NewSurrealFn(fmt.Sprintf("string::len(%s)", fieldName))
+}
+
+// StringLower returns `string::lowercase(field)`.
+func StringLower(fieldName string) types.SurrealFn {
+	return types.NewSurrealFn(fmt.Sprintf("string::lowercase(%s)", fieldName))
+}
+
+// StringUpper returns `string::uppercase(field)`.
+func StringUpper(fieldName string) types.SurrealFn {
+	return types.NewSurrealFn(fmt.Sprintf("string::uppercase(%s)", fieldName))
+}
+
+// StringConcat returns `string::concat(a, b, ...)`. Each arg is rendered
+// verbatim; wrap literal strings with single-quote helpers if needed.
+func StringConcat(args ...string) types.SurrealFn {
+	joined := ""
+	for i, a := range args {
+		if i > 0 {
+			joined += ", "
+		}
+		joined += a
+	}
+	return types.NewSurrealFn(fmt.Sprintf("string::concat(%s)", joined))
+}
+
+// ---------------------------------------------------------------------------
+// Count factories returning types.SurrealFn.
+//
+// The existing [Count] helper in expressions.go takes an optional field
+// name and returns Expression (`COUNT(*)` / `COUNT(id)`). CountAll and
+// CountIf provide SurrealDB-native lowercase `count()` / `count(expr)`
+// forms useful in aggregation queries.
+// ---------------------------------------------------------------------------
+
+// CountAll returns `count()` — the SurrealDB aggregation function with
+// no arguments (one-per-row semantic, useful with `GROUP ALL`).
+func CountAll() types.SurrealFn { return types.NewSurrealFn("count()") }
+
+// CountField returns `count(field)`.
+func CountField(fieldName string) types.SurrealFn {
+	return types.NewSurrealFn(fmt.Sprintf("count(%s)", fieldName))
+}
+
+// CountIf returns `count(condition)` where condition is a SurrealQL
+// boolean expression rendered verbatim (e.g. "active = true").
+func CountIf(condition string) types.SurrealFn {
+	return types.NewSurrealFn(fmt.Sprintf("count(%s)", condition))
+}

--- a/pkg/surql/query/functions_test.go
+++ b/pkg/surql/query/functions_test.go
@@ -1,0 +1,123 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/Oneiriq/surql-go/pkg/surql/types"
+)
+
+func TestMathFactories(t *testing.T) {
+	tests := []struct {
+		name string
+		got  types.SurrealFn
+		want string
+	}{
+		{"MathAbs", MathAbs("temperature"), "math::abs(temperature)"},
+		{"MathCeil", MathCeil("price"), "math::ceil(price)"},
+		{"MathFloor", MathFloor("price"), "math::floor(price)"},
+		{"MathRound", MathRound("price"), "math::round(price)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.got.ToSurql(); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStringFactories(t *testing.T) {
+	tests := []struct {
+		name string
+		got  types.SurrealFn
+		want string
+	}{
+		{"StringLen", StringLen("name"), "string::len(name)"},
+		{"StringLower", StringLower("name"), "string::lowercase(name)"},
+		{"StringUpper", StringUpper("name"), "string::uppercase(name)"},
+		{"StringConcat two", StringConcat("first", "last"), "string::concat(first, last)"},
+		{"StringConcat three", StringConcat("a", "' '", "b"), "string::concat(a, ' ', b)"},
+		{"StringConcat one", StringConcat("solo"), "string::concat(solo)"},
+		{"StringConcat empty", StringConcat(), "string::concat()"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.got.ToSurql(); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCountFactories(t *testing.T) {
+	if got := CountAll().ToSurql(); got != "count()" {
+		t.Errorf("CountAll: %q", got)
+	}
+	if got := CountField("id").ToSurql(); got != "count(id)" {
+		t.Errorf("CountField: %q", got)
+	}
+	if got := CountIf("active = true").ToSurql(); got != "count(active = true)" {
+		t.Errorf("CountIf: %q", got)
+	}
+}
+
+func TestSurrealFnFactories_ComposeInWhere(t *testing.T) {
+	// SurrealFn satisfies types.Operator; passing it into Where should
+	// splice the raw expression.
+	q, err := Query{}.Select(nil).FromTable("t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.Where(MathAbs("balance"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "SELECT * FROM t WHERE (math::abs(balance))"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSurrealFnFactories_ComposeInUpdateSet(t *testing.T) {
+	// When used as a map value in UPDATE data, SurrealFn renders raw.
+	q, err := Query{}.Update("user:alice", map[string]any{
+		"login_count": CountField("id"),
+		"last_seen":   types.NewSurrealFn("time::now()"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "UPDATE user:alice SET last_seen = time::now(), login_count = count(id)"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExpressionRawSurqlValueMarker(t *testing.T) {
+	// Expression is declared as a types.RawSurqlValue so that existing
+	// helpers like MathMean / TimeNow can be passed as UPDATE values and
+	// render raw (not quoted).
+	q, err := Query{}.Update("t:1", map[string]any{
+		"avg_score": MathMean("score"),
+		"updated":   TimeNow(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "UPDATE t:1 SET avg_score = math::mean(score), updated = time::now()"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/pkg/surql/query/integration_test.go
+++ b/pkg/surql/query/integration_test.go
@@ -330,6 +330,101 @@ func TestIntegration_TypeRecordTarget_CRUD(t *testing.T) {
 	}
 }
 
+func TestIntegration_AggregateRecords(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+	cleanupTable(t, client, "surqlgo_agg")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Seed two rows per network so GROUP BY yields two buckets.
+	seeds := []struct {
+		network string
+		name    string
+		score   int
+	}{
+		{"alpha", "a1", 10},
+		{"alpha", "a2", 20},
+		{"beta", "b1", 40},
+		{"beta", "b2", 60},
+	}
+	for _, s := range seeds {
+		if _, err := CreateRecord(ctx, client, "surqlgo_agg", map[string]any{
+			"network": s.network, "name": s.name, "score": s.score,
+		}); err != nil {
+			t.Fatalf("seed %s: %v", s.name, err)
+		}
+	}
+
+	// Group-by test: total + count per network.
+	rows, err := AggregateRecords(ctx, client, AggregateOpts{
+		Table: "surqlgo_agg",
+		Select: map[string]types.Operator{
+			"count": CountAll(),
+			"total": MathSum("score"),
+		},
+		GroupBy: []string{"network"},
+	})
+	if err != nil {
+		t.Fatalf("AggregateRecords: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("want 2 rows, got %d: %+v", len(rows), rows)
+	}
+
+	// GROUP ALL variant yields exactly one aggregated row.
+	total, err := AggregateRecords(ctx, client, AggregateOpts{
+		Table: "surqlgo_agg",
+		Select: map[string]types.Operator{
+			"n":     CountAll(),
+			"total": MathSum("score"),
+		},
+		GroupAll: true,
+	})
+	if err != nil {
+		t.Fatalf("AggregateRecords GROUP ALL: %v", err)
+	}
+	if len(total) != 1 {
+		t.Fatalf("want 1 row, got %d: %+v", len(total), total)
+	}
+}
+
+func TestIntegration_BuilderSelectExprGroupAllExecute(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+	cleanupTable(t, client, "surqlgo_builder_agg")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	for i := 0; i < 3; i++ {
+		if _, err := CreateRecord(ctx, client, "surqlgo_builder_agg", map[string]any{
+			"strength": 10 * (i + 1),
+		}); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	// NewQuery().SelectExpr(...).From(...).GroupAll().Execute(...) — the
+	// fluent chain requested by the spec.
+	raw, err := NewQuery().
+		SelectExpr(CountAll(), MathMean("strength")).
+		From("surqlgo_builder_agg").
+		GroupAll().
+		Execute(ctx, client)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	row := ExtractOne(raw)
+	if row == nil {
+		t.Fatal("ExtractOne: nil row")
+	}
+	if _, ok := row["count"]; !ok {
+		t.Errorf("missing count key: %+v", row)
+	}
+}
+
 func TestIntegration_TypeThingTarget_Get(t *testing.T) {
 	client, cleanup := newIntegrationClient(t)
 	defer cleanup()

--- a/pkg/surql/query/integration_test.go
+++ b/pkg/surql/query/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Oneiriq/surql-go/pkg/surql/connection"
+	"github.com/Oneiriq/surql-go/pkg/surql/types"
 )
 
 // getIntegrationURL reads the SurrealDB URL used by CI's integration job.
@@ -245,5 +246,108 @@ func TestIntegration_ExecuteRawTyped(t *testing.T) {
 	}
 	if len(rows) != 1 || rows[0].Name != "alice" {
 		t.Errorf("got %+v", rows)
+	}
+}
+
+func TestIntegration_TypeRecordTarget_CRUD(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+	cleanupTable(t, client, "surqlgo_type_record")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Seed via CreateRecord so the record id is server-generated, then
+	// use a stable string id for the target-driven assertions.
+	if _, err := client.Query(ctx,
+		"CREATE surqlgo_type_record:alice SET name = 'alice', age = 30;"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// GetByTarget
+	target := types.TypeRecord("surqlgo_type_record", "alice")
+	got, err := GetByTarget(ctx, client, target)
+	if err != nil {
+		t.Fatalf("GetByTarget: %v", err)
+	}
+	if got == nil || got["name"] != "alice" {
+		t.Fatalf("GetByTarget: got %+v", got)
+	}
+
+	// ExistsByTarget
+	present, err := ExistsByTarget(ctx, client, target)
+	if err != nil {
+		t.Fatalf("ExistsByTarget: %v", err)
+	}
+	if !present {
+		t.Fatal("ExistsByTarget: want true")
+	}
+
+	// UpdateByTarget (PUT semantics: age alone replaces the record body)
+	if _, err := UpdateByTarget(ctx, client, target, map[string]any{"age": 40}); err != nil {
+		t.Fatalf("UpdateByTarget: %v", err)
+	}
+	got, err = GetByTarget(ctx, client, target)
+	if err != nil || got == nil {
+		t.Fatalf("after UpdateByTarget: err=%v got=%+v", err, got)
+	}
+	if _, ok := got["name"]; ok {
+		t.Errorf("UpdateByTarget did not replace body: name still present %+v", got)
+	}
+
+	// MergeByTarget restores name alongside age.
+	if _, err := MergeByTarget(ctx, client, target, map[string]any{"name": "alice"}); err != nil {
+		t.Fatalf("MergeByTarget: %v", err)
+	}
+	got, err = GetByTarget(ctx, client, target)
+	if err != nil || got == nil {
+		t.Fatalf("after MergeByTarget: err=%v got=%+v", err, got)
+	}
+	if got["name"] != "alice" {
+		t.Errorf("MergeByTarget: name=%v", got["name"])
+	}
+
+	// UpsertByTarget on a new id inserts.
+	newTarget := types.TypeRecord("surqlgo_type_record", "carol")
+	if _, err := UpsertByTarget(ctx, client, newTarget, map[string]any{"name": "carol"}); err != nil {
+		t.Fatalf("UpsertByTarget insert: %v", err)
+	}
+	got, err = GetByTarget(ctx, client, newTarget)
+	if err != nil || got == nil {
+		t.Fatalf("after UpsertByTarget insert: err=%v got=%+v", err, got)
+	}
+
+	// DeleteByTarget removes.
+	if err := DeleteByTarget(ctx, client, target); err != nil {
+		t.Fatalf("DeleteByTarget: %v", err)
+	}
+	present, err = ExistsByTarget(ctx, client, target)
+	if err != nil {
+		t.Fatalf("ExistsByTarget after delete: %v", err)
+	}
+	if present {
+		t.Fatal("ExistsByTarget after delete: want false")
+	}
+}
+
+func TestIntegration_TypeThingTarget_Get(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+	cleanupTable(t, client, "surqlgo_type_thing")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if _, err := client.Query(ctx,
+		"CREATE surqlgo_type_thing:xyz SET name = 'xyz';"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	got, err := GetByTarget(ctx, client, types.TypeThing("surqlgo_type_thing", "xyz"))
+	if err != nil {
+		t.Fatalf("GetByTarget: %v", err)
+	}
+	if got == nil || got["name"] != "xyz" {
+		t.Errorf("got %+v", got)
 	}
 }

--- a/pkg/surql/surql.go
+++ b/pkg/surql/surql.go
@@ -1,4 +1,83 @@
+// Package surql re-exports the most commonly used builders, CRUD
+// helpers, and result-extraction utilities from the sub-packages so
+// consumers can import a single path.
+//
+// The extraction helpers (ExtractOne, ExtractMany, ExtractScalar,
+// HasResult) normalise the raw response envelope emitted by the
+// SurrealDB client:
+//
+//   - db.query returns [{"result": [...], "status": "OK"}, ...]
+//   - db.select returns [{...}, {...}]
+//
+// Both shapes collapse to a flat []map[string]any record list.
 package surql
+
+import (
+	"encoding/json"
+	"fmt"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+	"github.com/Oneiriq/surql-go/pkg/surql/query"
+)
 
 // Version is the current surql-go release.
 const Version = "0.1.0"
+
+// ExtractOne returns the first record from a raw response or
+// (nil, nil) when the envelope is empty. Mirrors the Python
+// `extract_one` helper.
+func ExtractOne(raw any) (map[string]any, error) {
+	return query.ExtractOne(raw), nil
+}
+
+// ExtractMany returns every record from a raw response as a flat slice
+// of maps. Returns (nil, nil) when the envelope is empty. Mirrors the
+// Python `extract_many` helper.
+func ExtractMany(raw any) ([]map[string]any, error) {
+	return query.ExtractResult(raw), nil
+}
+
+// HasResult reports whether the raw response carries at least one
+// record. Mirrors the Python `has_result` helper.
+func HasResult(raw any) bool {
+	return query.HasResults(raw)
+}
+
+// ExtractScalar pulls a single scalar value identified by key from the
+// first row of a raw response and decodes it into T. Returns the zero
+// value of T and ErrValidation when the envelope is empty or the key
+// is missing. Mirrors the Python `extract_scalar` helper, generalised
+// via Go generics.
+//
+// Numeric coercion follows encoding/json's loose rules: JSON numbers
+// decode into any numeric T via a round-trip.
+func ExtractScalar[T any](raw any, key string) (T, error) {
+	var zero T
+	row := query.ExtractOne(raw)
+	if row == nil {
+		return zero, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"ExtractScalar: response contains no rows for key %q", key)
+	}
+	v, ok := row[key]
+	if !ok {
+		return zero, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"ExtractScalar: key %q not present in row", key)
+	}
+	// Fast path: the underlying value is already a T.
+	if typed, ok := v.(T); ok {
+		return typed, nil
+	}
+	// Slow path: round-trip through encoding/json so float64 coerces
+	// into int / int64 / uint / etc without caller-side casts.
+	buf, err := json.Marshal(v)
+	if err != nil {
+		return zero, surqlerrors.Wrap(surqlerrors.ErrSerialization,
+			fmt.Sprintf("ExtractScalar: marshal value for key %q", key), err)
+	}
+	var out T
+	if err := json.Unmarshal(buf, &out); err != nil {
+		return zero, surqlerrors.Wrap(surqlerrors.ErrSerialization,
+			fmt.Sprintf("ExtractScalar: decode value for key %q into target type", key), err)
+	}
+	return out, nil
+}

--- a/pkg/surql/surql_integration_test.go
+++ b/pkg/surql/surql_integration_test.go
@@ -1,0 +1,139 @@
+//go:build integration
+// +build integration
+
+package surql
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Oneiriq/surql-go/pkg/surql/connection"
+)
+
+func getIntegrationURL(t *testing.T) string {
+	t.Helper()
+	url := os.Getenv("SURREAL_URL")
+	if url == "" {
+		t.Skip("SURREAL_URL not set; skipping integration test")
+	}
+	return url
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func newIntegrationClient(t *testing.T) (*connection.DatabaseClient, func()) {
+	t.Helper()
+	cfg := connection.DefaultConfig()
+	cfg.DBURL = getIntegrationURL(t)
+	cfg.DBNS = "surqlgo_test"
+	cfg.DB = "surql_extract"
+	cfg.DBRetryMaxAttempts = 3
+	cfg.DBRetryMinWait = 0.5
+	cfg.DBRetryMaxWait = 2.0
+	cfg.DBRetryMultiplier = 2.0
+
+	client, err := connection.NewDatabaseClient(cfg)
+	if err != nil {
+		t.Fatalf("NewDatabaseClient: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	user := envOr("SURREAL_USER", "root")
+	pass := envOr("SURREAL_PASS", "root")
+	if _, err := client.Signin(ctx, connection.NewRootCredentials(user, pass)); err != nil {
+		_ = client.Disconnect()
+		t.Fatalf("Signin: %v", err)
+	}
+	return client, func() { _ = client.Disconnect() }
+}
+
+func TestIntegration_ExtractScalar_CountRoundTrip(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Fresh table so we know the row count.
+	if _, err := client.Query(ctx,
+		"REMOVE TABLE IF EXISTS surqlgo_extract_scalar;"); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	for _, n := range []string{"alice", "bob", "carol", "dave"} {
+		if _, err := client.Query(ctx,
+			"CREATE surqlgo_extract_scalar CONTENT { name: '"+n+"' };"); err != nil {
+			t.Fatalf("seed %s: %v", n, err)
+		}
+	}
+
+	// COUNT() with GROUP ALL yields one row with key "count".
+	raw, err := client.Query(ctx,
+		"SELECT count() FROM surqlgo_extract_scalar GROUP ALL;")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+
+	if !HasResult(raw) {
+		t.Fatal("HasResult returned false for populated response")
+	}
+
+	// Decode as int64 via ExtractScalar[T]'s json round-trip.
+	n, err := ExtractScalar[int64](raw, "count")
+	if err != nil {
+		t.Fatalf("ExtractScalar[int64]: %v", err)
+	}
+	if n != 4 {
+		t.Errorf("want 4, got %d", n)
+	}
+
+	// ExtractOne should return the same row map.
+	row, err := ExtractOne(raw)
+	if err != nil {
+		t.Fatalf("ExtractOne: %v", err)
+	}
+	if row == nil {
+		t.Fatal("ExtractOne returned nil")
+	}
+}
+
+func TestIntegration_ExtractMany_ListRows(t *testing.T) {
+	client, cleanup := newIntegrationClient(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if _, err := client.Query(ctx,
+		"REMOVE TABLE IF EXISTS surqlgo_extract_many;"); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	names := []string{"x", "y", "z"}
+	for _, n := range names {
+		if _, err := client.Query(ctx,
+			"CREATE surqlgo_extract_many CONTENT { name: '"+n+"' };"); err != nil {
+			t.Fatalf("seed %s: %v", n, err)
+		}
+	}
+
+	raw, err := client.Query(ctx, "SELECT name FROM surqlgo_extract_many;")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	rows, err := ExtractMany(raw)
+	if err != nil {
+		t.Fatalf("ExtractMany: %v", err)
+	}
+	if len(rows) != len(names) {
+		t.Errorf("want %d rows, got %d", len(names), len(rows))
+	}
+}

--- a/pkg/surql/surql_test.go
+++ b/pkg/surql/surql_test.go
@@ -1,0 +1,208 @@
+package surql
+
+import (
+	"errors"
+	"testing"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+func TestExtractOne_Nested(t *testing.T) {
+	raw := []any{map[string]any{
+		"result": []any{map[string]any{"id": "u:1", "name": "Alice"}},
+	}}
+	row, err := ExtractOne(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row == nil || row["name"] != "Alice" {
+		t.Errorf("got %+v", row)
+	}
+}
+
+func TestExtractOne_Flat(t *testing.T) {
+	raw := []any{map[string]any{"id": "u:1", "name": "Bob"}}
+	row, err := ExtractOne(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row == nil || row["name"] != "Bob" {
+		t.Errorf("got %+v", row)
+	}
+}
+
+func TestExtractOne_Empty(t *testing.T) {
+	row, err := ExtractOne([]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row != nil {
+		t.Errorf("got %+v", row)
+	}
+}
+
+func TestExtractOne_Nil(t *testing.T) {
+	row, err := ExtractOne(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row != nil {
+		t.Errorf("got %+v", row)
+	}
+}
+
+func TestExtractMany_Nested(t *testing.T) {
+	raw := []any{map[string]any{
+		"result": []any{
+			map[string]any{"id": "u:1"},
+			map[string]any{"id": "u:2"},
+		},
+	}}
+	rows, err := ExtractMany(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("got %d rows", len(rows))
+	}
+}
+
+func TestExtractMany_Empty(t *testing.T) {
+	rows, err := ExtractMany(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows != nil {
+		t.Errorf("got %+v", rows)
+	}
+}
+
+func TestHasResult(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  any
+		want bool
+	}{
+		{"nested populated", []any{map[string]any{"result": []any{map[string]any{"id": "u:1"}}}}, true},
+		{"nested empty", []any{map[string]any{"result": []any{}}}, false},
+		{"flat populated", []any{map[string]any{"id": "u:1"}}, true},
+		{"nil", nil, false},
+		{"empty slice", []any{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasResult(tc.raw); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractScalar_Int(t *testing.T) {
+	// encoding/json decodes integer literals as float64; ExtractScalar
+	// round-trips through json to coerce into the caller's T.
+	raw := []any{map[string]any{"result": []any{map[string]any{"count": 42}}}}
+	got, err := ExtractScalar[int](raw, "count")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 42 {
+		t.Errorf("got %d", got)
+	}
+}
+
+func TestExtractScalar_Int64FromFloat(t *testing.T) {
+	raw := []any{map[string]any{"result": []any{map[string]any{"total": float64(9001)}}}}
+	got, err := ExtractScalar[int64](raw, "total")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 9001 {
+		t.Errorf("got %d", got)
+	}
+}
+
+func TestExtractScalar_String(t *testing.T) {
+	raw := []any{map[string]any{"result": []any{map[string]any{"name": "Alice"}}}}
+	got, err := ExtractScalar[string](raw, "name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "Alice" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractScalar_Bool(t *testing.T) {
+	raw := []any{map[string]any{"active": true}}
+	got, err := ExtractScalar[bool](raw, "active")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Error("expected true")
+	}
+}
+
+func TestExtractScalar_Float64(t *testing.T) {
+	raw := []any{map[string]any{"result": []any{map[string]any{"avg": 25.5}}}}
+	got, err := ExtractScalar[float64](raw, "avg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 25.5 {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestExtractScalar_EmptyResponse(t *testing.T) {
+	_, err := ExtractScalar[int]([]any{}, "count")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestExtractScalar_MissingKey(t *testing.T) {
+	raw := []any{map[string]any{"id": "u:1"}}
+	_, err := ExtractScalar[int](raw, "count")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Errorf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestExtractScalar_FastPath(t *testing.T) {
+	// When the stored value already matches T, the fast path returns it
+	// without a json round-trip.
+	raw := []any{map[string]any{"name": "Alice"}}
+	got, err := ExtractScalar[string](raw, "name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "Alice" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractScalar_IncompatibleType(t *testing.T) {
+	// A string value decoding into int should fail via json.Unmarshal.
+	raw := []any{map[string]any{"count": "not-a-number"}}
+	_, err := ExtractScalar[int](raw, "count")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, surqlerrors.ErrSerialization) {
+		t.Errorf("want ErrSerialization, got %v", err)
+	}
+}
+
+func TestVersion(t *testing.T) {
+	if Version == "" {
+		t.Error("version must not be empty")
+	}
+}

--- a/pkg/surql/types/operators.go
+++ b/pkg/surql/types/operators.go
@@ -11,6 +11,20 @@ type Operator interface {
 	ToSurql() string
 }
 
+// RawSurqlValue is an opt-in marker that causes [quoteValue] to emit
+// `ToSurql()` verbatim instead of quoting the value. Any type from
+// outside this package can participate in raw-value rendering by
+// implementing the single [IsRawSurqlValue] marker method alongside
+// `ToSurql() string`.
+//
+// The marker guard stops arbitrary [fmt.Stringer] implementations from
+// accidentally opting in — a type must intentionally declare raw-render
+// semantics by implementing both methods.
+type RawSurqlValue interface {
+	ToSurql() string
+	IsRawSurqlValue()
+}
+
 // quoteValue renders v as a SurrealQL literal.
 //
 // Rules (matching the Python port):
@@ -20,6 +34,7 @@ type Operator interface {
 //   - string            -> 'single-quoted' with \ and ' escaped
 //   - SurrealFn         -> raw expression
 //   - RecordRef         -> type::record(...) raw expression
+//   - RawSurqlValue     -> raw expression (opt-in via marker interface)
 //   - []any             -> '[' + quoted elements + ']'
 //   - fmt.Stringer      -> quoted string form
 func quoteValue(v any) string {
@@ -46,6 +61,8 @@ func quoteValue(v any) string {
 	case SurrealFn:
 		return x.ToSurql()
 	case RecordRef:
+		return x.ToSurql()
+	case RawSurqlValue:
 		return x.ToSurql()
 	case []any:
 		parts := make([]string, len(x))

--- a/pkg/surql/types/surreal_fn.go
+++ b/pkg/surql/types/surreal_fn.go
@@ -40,3 +40,69 @@ func SurqlFn(name string, args ...any) SurrealFn {
 	}
 	return SurrealFn{Expression: fmt.Sprintf("%s(%s)", name, strings.Join(parts, ", "))}
 }
+
+// TypeRecord returns a SurrealFn wrapping `type::record(table, id)`. When
+// used as the target of a CRUD helper or as a value in SET / WHERE it
+// renders as raw SurrealQL and evaluates to the record id at query time.
+//
+// id may be a string, any integer kind, or a RecordIDValue. Strings are
+// single-quoted (with backslashes and single quotes escaped) to match the
+// surql-py renderer.
+func TypeRecord(table string, id any) SurrealFn {
+	return SurrealFn{Expression: renderTypeRecord("record", table, id)}
+}
+
+// TypeThing is an alias for TypeRecord provided for API parity with
+// downstream code that prefers the `thing` nomenclature.
+//
+// SurrealDB v3+ removed `type::thing` in favour of `type::record`; both
+// helpers therefore emit `type::record(...)` under the hood. The pre-v3
+// spelling would fail parsing with "Invalid function/constant path, did
+// you maybe mean `type::record`".
+func TypeThing(table string, id any) SurrealFn {
+	return SurrealFn{Expression: renderTypeRecord("record", table, id)}
+}
+
+// renderTypeRecord shares the rendering path between TypeRecord and
+// TypeThing; the only difference is the function name.
+func renderTypeRecord(kind, table string, id any) string {
+	switch v := id.(type) {
+	case RecordIDValue:
+		if v.IsInt() {
+			return fmt.Sprintf("type::%s('%s', %d)", kind, table, v.Int())
+		}
+		return fmt.Sprintf("type::%s('%s', %s)", kind, table, quoteTypeRecordString(v.String()))
+	case string:
+		return fmt.Sprintf("type::%s('%s', %s)", kind, table, quoteTypeRecordString(v))
+	case int:
+		return fmt.Sprintf("type::%s('%s', %d)", kind, table, v)
+	case int8:
+		return fmt.Sprintf("type::%s('%s', %d)", kind, table, v)
+	case int16:
+		return fmt.Sprintf("type::%s('%s', %d)", kind, table, v)
+	case int32:
+		return fmt.Sprintf("type::%s('%s', %d)", kind, table, v)
+	case int64:
+		return fmt.Sprintf("type::%s('%s', %d)", kind, table, v)
+	case uint:
+		return fmt.Sprintf("type::%s('%s', %d)", kind, table, v)
+	case uint8:
+		return fmt.Sprintf("type::%s('%s', %d)", kind, table, v)
+	case uint16:
+		return fmt.Sprintf("type::%s('%s', %d)", kind, table, v)
+	case uint32:
+		return fmt.Sprintf("type::%s('%s', %d)", kind, table, v)
+	case uint64:
+		return fmt.Sprintf("type::%s('%s', %d)", kind, table, v)
+	case fmt.Stringer:
+		return fmt.Sprintf("type::%s('%s', %s)", kind, table, quoteTypeRecordString(v.String()))
+	default:
+		return fmt.Sprintf("type::%s('%s', %s)", kind, table, quoteTypeRecordString(fmt.Sprint(v)))
+	}
+}
+
+func quoteTypeRecordString(s string) string {
+	escaped := strings.ReplaceAll(s, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+	return "'" + escaped + "'"
+}

--- a/pkg/surql/types/surreal_fn_test.go
+++ b/pkg/surql/types/surreal_fn_test.go
@@ -55,3 +55,82 @@ func TestSurqlFn_IntegerArg(t *testing.T) {
 		t.Errorf("got %q", got)
 	}
 }
+
+func TestTypeRecord(t *testing.T) {
+	tests := []struct {
+		name  string
+		table string
+		id    any
+		want  string
+	}{
+		{"string id", "task", "abc", "type::record('task', 'abc')"},
+		{"int id", "post", 123, "type::record('post', 123)"},
+		{"int64 id", "post", int64(9001), "type::record('post', 9001)"},
+		{"uint id", "post", uint(42), "type::record('post', 42)"},
+		{"string with quote", "user", "o'malley", `type::record('user', 'o\'malley')`},
+		{"string with backslash", "user", `a\b`, `type::record('user', 'a\\b')`},
+		{"RecordIDValue string", "task", StringID("abc"), "type::record('task', 'abc')"},
+		{"RecordIDValue int", "task", IntID(7), "type::record('task', 7)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := TypeRecord(tc.table, tc.id).ToSurql()
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTypeThing_AliasesTypeRecord(t *testing.T) {
+	// type::thing was removed in SurrealDB v3+; the helper emits
+	// type::record(...) so downstream callers that prefer the "thing"
+	// nomenclature still produce v3-valid SurrealQL.
+	tests := []struct {
+		name  string
+		table string
+		id    any
+		want  string
+	}{
+		{"string id", "task", "abc", "type::record('task', 'abc')"},
+		{"int id", "post", 42, "type::record('post', 42)"},
+		{"RecordIDValue int", "user", IntID(7), "type::record('user', 7)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := TypeThing(tc.table, tc.id).ToSurql()
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTypeRecord_Composes(t *testing.T) {
+	// TypeRecord must compose as a raw value in operator renderings.
+	fn := TypeRecord("task", "abc")
+	if fn.String() != fn.ToSurql() {
+		t.Errorf("String=%q ToSurql=%q", fn.String(), fn.ToSurql())
+	}
+	// Using TypeRecord as a value in an Eq operator should emit raw.
+	eq := EqOp("task_id", fn).ToSurql()
+	want := "task_id = type::record('task', 'abc')"
+	if eq != want {
+		t.Errorf("got %q, want %q", eq, want)
+	}
+}
+
+func TestTypeRecord_Stringer(t *testing.T) {
+	// Any fmt.Stringer-implementing id falls through to string quoting.
+	rec, err := NewStringRecordID("task", "abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := TypeRecord("wrapper", rec).ToSurql()
+	// RecordID.String() renders "task:abc"; the quote-escaper does not
+	// special-case colons, so the full string is quoted as an id.
+	want := "type::record('wrapper', 'task:abc')"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Four query-UX improvements eliminating the remaining raw-SurrealQL fallbacks consumers still needed.

### New public surface

- `pkg/surql/types`: `TypeRecord(table, id)`, `TypeThing(table, id)` (v3-safe alias emitting `type::record`), `RawSurqlValue` marker interface.
- `pkg/surql/query/functions.go`: `MathAbs`, `MathCeil`, `MathFloor`, `MathRound`, `StringLen`, `StringLower`, `StringUpper`, `StringConcat`, `CountAll`, `CountField`, `CountIf` — plus existing `MathMean`, `MathSum`, `TimeNow` now compose as raw values via `Expression.IsRawSurqlValue()`.
- `pkg/surql/query/crud.go`: `GetByTarget`, `UpdateByTarget`, `MergeByTarget`, `UpsertByTarget`, `DeleteByTarget`, `ExistsByTarget`, `AggregateOpts`, `AggregateRecords`.
- `pkg/surql/query`: `Query.SelectExpr(...Operator)`, `Query.SelectAliased(map[string]Operator)`, `Query.From(table)`, `Query.Execute(ctx, client)`.
- `pkg/surql`: `ExtractOne`, `ExtractMany`, `HasResult`, `ExtractScalar[T any]` (Go 1.18+ generics).

### Design notes

- `TypeThing` is a documented alias for `TypeRecord` because v3 rejects `type::thing`. Name kept for py-parity; output is v3-valid SurrealQL.
- `*ByTarget` CRUD helpers added as parallel API rather than overloading existing `UpdateRecord(table, recordID, data)` — preserves additivity.
- `CountAll` / `CountField` / `CountIf` introduced because existing `Count(fieldName string)` occupied the bare `Count` name.
- `AggregateRecords` auto-prepends `GroupBy` fields into the projection (v3 rejects `SELECT count()… GROUP BY network` without `network` in the projection).

### Test plan

- [x] `gofmt -l .` empty
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./... -race -count=1` — 1234 → **1275** (+41)
- [x] `go test -tags=integration ./...` vs `surrealdb/surrealdb:v3.0.5` — 1271 → **1318** (+47)
- [x] `go mod tidy` no diff (no new deps)

Refs #76.