### PR TITLE
chore(dev): add pre-push git hook mirroring CI checks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# pre-push: run the same checks as .github/workflows/ci.yml before the push
+# reaches GitHub Actions. CI minutes cost money — fail locally first.
+#
+# Opt in to the integration suite by exporting SURQL_PRE_PUSH_INTEGRATION=1
+# and booting the v3.0.5 container:
+#
+#   docker run -d -p 8000:8000 --name surrealdb surrealdb/surrealdb:v3.0.5 \
+#     start --user root --pass root memory
+#
+# Bypass (rarely): `git push --no-verify` — only when explicitly authorised.
+
+set -euo pipefail
+
+echo "[pre-push] gofmt -l ."
+unformatted=$(gofmt -l .)
+if [[ -n "$unformatted" ]]; then
+  echo "gofmt found unformatted files:"
+  echo "$unformatted"
+  exit 1
+fi
+
+echo "[pre-push] go vet ./..."
+go vet ./...
+
+echo "[pre-push] go build ./..."
+go build ./...
+
+echo "[pre-push] go test ./... -race -count=1"
+go test ./... -race -count=1
+
+if [[ "${SURQL_PRE_PUSH_INTEGRATION:-0}" == "1" ]]; then
+  echo "[pre-push] go test -tags=integration ./... (SURQL_PRE_PUSH_INTEGRATION=1)"
+  go test -tags=integration ./...
+else
+  echo "[pre-push] skipping integration tests (set SURQL_PRE_PUSH_INTEGRATION=1 to run)"
+fi
+
+echo "[pre-push] all checks passed"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+
+## Local pre-push hook
+
+This repo ships a `.githooks/pre-push` that runs the same checks GitHub Actions runs (`gofmt`, `go vet`, `go build`, `go test -race`). Wire it up once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Integration tests (against a local `surrealdb/surrealdb:v3.0.5` container) are opt-in:
+
+```bash
+export SURQL_PRE_PUSH_INTEGRATION=1
+docker run -d -p 8000:8000 --name surrealdb surrealdb/surrealdb:v3.0.5 start --user root --pass root memory
+```
+
+Bypass (rarely, only with authorisation):
+
+```bash
+git push --no-verify
+```


### PR DESCRIPTION
Implements #78. Hook runs the same gofmt + vet + build + race-test checks as `ci.yml` before the push hits GitHub. Opt-in integration tests via `SURQL_PRE_PUSH_INTEGRATION=1`.

Setup documented in CONTRIBUTING.md.

Closes #78.