### PR TITLE
chore(release): bump version to 0.2.0

### DIFF
--- a/pkg/surql/surql.go
+++ b/pkg/surql/surql.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Version is the current surql-go release.
-const Version = "0.1.0"
+const Version = "0.2.0"
 
 // ExtractOne returns the first record from a raw response or
 // (nil, nil) when the envelope is empty. Mirrors the Python


### PR DESCRIPTION
Finalise release/0.2.0 with the real version string. Query-UX parity wave + pre-push hook.