### PR TITLE
chore(release): v0.2.1 — docs refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,22 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Go Version](https://img.shields.io/badge/go-1.26%2B-00ADD8)](https://go.dev/)
-[![SurrealDB](https://img.shields.io/badge/SurrealDB-2.0%2B-ff00a0)](https://surrealdb.com/)
+[![SurrealDB](https://img.shields.io/badge/SurrealDB-3.0%2B-ff00a0)](https://surrealdb.com/)
 
 A code-first database toolkit for [SurrealDB](https://surrealdb.com/). Define schemas, generate migrations, build queries, and perform typed CRUD -- all from Go.
 
 ## Features
 
-- **Code-First Migrations** - Schema changes defined in code with automatic migration generation (auto-diff + `.surql` file output with `-- @up` / `-- @down` sections)
-- **Type-Safe Query Builder** - Immutable fluent API with operator-typed `Where`, expression helpers, and `encoding/json` struct tags
-- **Vector Search** - HNSW and MTREE index support with 8 distance metrics and EFC/M tuning
-- **Graph Traversal** - Native SurrealDB graph features with edge relationships
-- **Schema Visualization** - Mermaid, GraphViz, and ASCII diagrams with theming
-- **CLI Tools** - Migrations, schema inspection, validation, database management *(planned)*
-- **Stdlib-First** - Minimal dependencies; stdlib `net/http` + official SurrealDB SDK *(planned)*
+- **Code-First Migrations** -- Schema changes defined in code with automatic migration generation (auto-diff + `.surql` file output with `-- @up` / `-- @down` sections, squash, watcher, auto-snapshot hooks)
+- **Type-Safe Query Builder** -- Immutable fluent API with operator-typed `Where`, `SelectExpr` / `SelectAliased` aggregations, function factories, and `encoding/json` struct tags
+- **v3 Interactive Transactions** -- Native `BEGIN` / `COMMIT` / `ROLLBACK` via `DatabaseClient.Begin`, plus raw record-id targets and `GROUP ALL`
+- **Vector Search** -- HNSW and MTREE index support with 8 distance metrics and EFC/M tuning
+- **Graph Traversal** -- Native SurrealDB graph features with edge relationships and a fluent `GraphQuery` builder
+- **Schema Visualization** -- Mermaid, GraphViz, and ASCII diagrams with theming
+- **Full CLI** -- `surql migrate` / `schema` / `db` / `orchestrate` subcommands for the entire lifecycle
+- **Cache + Orchestration** -- Memory + Redis cache backends, sequential / parallel / rolling / canary deployment strategies
 
-## Quick Start
+## Install
 
 ```shell
 go get github.com/Oneiriq/surql-go
@@ -27,6 +28,10 @@ With the CLI:
 ```shell
 go install github.com/Oneiriq/surql-go/cmd/surql@latest
 ```
+
+## Quick Start
+
+### Define a schema
 
 ```go
 package main
@@ -47,18 +52,72 @@ func main() {
         ),
         schema.WithIndexes(schema.UniqueIndex("email_idx", []string{"email"})),
     )
-    // ...
+    _ = user
 }
+```
+
+### Fetch a record by id (v3 raw target)
+
+```go
+import (
+    "github.com/Oneiriq/surql-go/pkg/surql/query"
+    "github.com/Oneiriq/surql-go/pkg/surql/types"
+)
+
+target := types.TypeRecord("user", "alice")
+record, err := query.GetByTarget(ctx, client, target)
+```
+
+### Aggregate with `GROUP ALL`
+
+```go
+opts := query.AggregateOpts{
+    Table: "match",
+    Select: map[string]types.Operator{
+        "count": query.CountAll(),
+        "avg":   query.MathMean("score"),
+    },
+    GroupAll: true,
+}
+rows, _ := query.AggregateRecords(ctx, client, opts)
+```
+
+### Extract a scalar from a raw query
+
+```go
+import "github.com/Oneiriq/surql-go/pkg/surql"
+
+raw, _ := client.Query(ctx, "SELECT count() AS n FROM user GROUP ALL")
+count, _ := surql.ExtractScalar[int64](raw, "n")
+```
+
+### Interactive transaction
+
+```go
+tx, _ := client.Begin(ctx)
+if _, err := tx.Execute(ctx, "UPDATE user:alice SET status = 'active'"); err != nil {
+    _ = tx.Rollback(ctx)
+    return err
+}
+return tx.Commit(ctx)
 ```
 
 ## Documentation
 
 Full documentation at **[oneiriq.github.io/surql-go](https://oneiriq.github.io/surql-go/)**.
 
+Key pages:
+
+- [Features & Package Layout](https://oneiriq.github.io/surql-go/features/)
+- [v3 Patterns](https://oneiriq.github.io/surql-go/v3-patterns/)
+- [Query UX Helpers](https://oneiriq.github.io/surql-go/query-ux/)
+- [CLI Reference](https://oneiriq.github.io/surql-go/cli/)
+- [Upgrading](https://oneiriq.github.io/surql-go/migration/)
+
 ## Requirements
 
 - Go 1.26+
-- SurrealDB 2.0+
+- SurrealDB 3.0+ (CI runs against `surrealdb/surrealdb:v3.0.5`)
 
 ## License
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,17 +1,112 @@
-# CLI
+# CLI Reference
 
-The `surql` binary is under active development. When it ships (0.2), it
-will provide:
+The `surql` binary wraps the library's migration, schema, database, and
+orchestration surface behind a single cobra CLI.
 
-- `surql migrate create <description>` -- blank migration template.
-- `surql migrate up [--steps N] [--dry-run]` -- apply pending migrations.
-- `surql migrate down [--steps N] [--yes]` -- roll back.
-- `surql migrate status` -- applied vs pending.
-- `surql schema show [--format json|mermaid|graphviz|ascii]` -- inspect the
-  running schema.
-- `surql schema diff [--compare-live]` -- drift detection.
-- `surql schema validate [--fail-on-drift]` -- CI validation.
-- `surql db init` / `surql db reset` / `surql db health` -- management.
+```shell
+go install github.com/Oneiriq/surql-go/cmd/surql@latest
+```
 
-The target surface mirrors `surql-py`'s CLI. Track progress on
-[GitHub Issues](https://github.com/Oneiriq/surql-go/issues).
+## Global flags
+
+| Flag            | Shorthand | Purpose                                                             |
+|-----------------|-----------|---------------------------------------------------------------------|
+| `--config PATH` |           | Explicit path to `surql.yaml` / `surql.toml` (overrides discovery). |
+| `--verbose`     |           | Enable verbose logging.                                             |
+| `--quiet`       | `-q`      | Suppress informational output.                                      |
+| `--no-color`    |           | Disable ANSI color output.                                          |
+| `--json`        |           | Emit JSON output where supported.                                   |
+| `--version`     | `-v`      | Print the CLI version.                                              |
+
+`version`, `help`, and `completion` run without requiring a resolvable
+config file. Every other subcommand hydrates settings via
+`pkg/surql/settings.LoadSettings` (searches for `surql.yaml` / `surql.toml`
+up the directory tree, falling back to `SURQL_*` env vars).
+
+## `surql migrate`
+
+| Subcommand                              | Purpose                                                    |
+|-----------------------------------------|------------------------------------------------------------|
+| `migrate up [--steps N] [--target V]`   | Apply pending migrations; `--dry-run` previews the plan.   |
+| `migrate down [--steps N] [--target V]` | Roll back applied migrations; `--dry-run` previews.        |
+| `migrate status`                        | Applied vs pending counts (`--json` for machine output).   |
+| `migrate history`                       | Table of applied migrations (version, description, when).  |
+| `migrate create <description>`          | Write a blank `.surql` file with metadata / @up / @down.   |
+| `migrate validate [version]`            | Structural validation over every migration file.           |
+| `migrate generate <description>`        | Blank generator stub (schema-diff path not yet wired in).  |
+| `migrate squash <from> <to>`            | Collapse a range into one file; `--dry-run` previews.      |
+
+Common flags: `--directory / -d <path>` overrides the configured
+migrations directory per invocation.
+
+## `surql schema`
+
+| Subcommand                     | Purpose                                                          |
+|--------------------------------|------------------------------------------------------------------|
+| `schema show [table]`          | Dump `INFO FOR DB` (or `INFO FOR TABLE <table>`) as JSON.        |
+| `schema diff --from A --to B`  | Compare two stored snapshots (version or explicit path).         |
+| `schema generate [-o PATH]`    | Render DEFINE statements from the code registry.                 |
+| `schema sync [--dry-run]`      | Push the code registry directly to the database (destructive).   |
+| `schema export [-f json/yaml]` | Export the live `INFO FOR DB` payload.                           |
+| `schema tables`                | List tables in the configured database.                          |
+| `schema inspect <table>`       | Dump field / index / event details for one table.                |
+| `schema validate [--strict]`   | Run the schema validator over the code registry.                 |
+| `schema check`                 | Compare the code registry against the live DB; fails on drift.   |
+| `schema hook-config`           | Emit a pre-commit hook YAML snippet for `schema check`.          |
+| `schema watch [--debounce d]`  | Watch a directory for `.surql` changes with debounced batches.   |
+| `schema visualize`             | Render Mermaid / GraphViz / ASCII diagrams from the registry.    |
+
+`schema visualize` accepts `--theme modern|dark|forest|minimal` and
+`--format mermaid|graphviz|ascii`.
+
+## `surql db`
+
+| Subcommand                | Purpose                                                                    |
+|---------------------------|----------------------------------------------------------------------------|
+| `db init`                 | Create the migration history table.                                        |
+| `db ping`                 | Verify connectivity against the resolved settings.                         |
+| `db info`                 | Print resolved database configuration (password masked).                   |
+| `db reset --yes`          | REMOVE every table in the configured DB (destructive; requires `--yes`).   |
+| `db query <surql>`        | Execute a raw SurrealQL statement; JSON output by default.                 |
+| `db query -f FILE`        | Read SurrealQL from `FILE`.                                                |
+| `db version`              | Print the connected SurrealDB server version.                              |
+
+## `surql orchestrate`
+
+Multi-environment deployment commands (aliased as `surql orch`). Each
+reads an `environments.json` registry via the `--plan` flag.
+
+| Subcommand                                                         | Purpose                                               |
+|--------------------------------------------------------------------|-------------------------------------------------------|
+| `orchestrate deploy --plan plan.json -e dev,staging`               | Apply migrations across named environments.           |
+| `orchestrate status --plan plan.json [-e a,b]`                     | Render health of each environment.                    |
+| `orchestrate validate --plan plan.json`                            | Verify every environment can connect + has the table. |
+
+Deploy strategies: `sequential` (default), `parallel` (`--max-concurrent`),
+`rolling` (`--batch-size`), `canary` (`--canary-percent`). Rollback is on
+by default; pass `--no-rollback` to disable. `--dry-run` traces the plan
+without executing.
+
+## `surql version`
+
+Prints the library version plus (if built with goreleaser-style ldflags)
+the commit and build date:
+
+```shell
+$ surql version
+surql 0.2.1 (commit abc1234) built 2026-04-18T19:00:00Z
+```
+
+## Exit codes
+
+| Code | Meaning                                                   |
+|------|-----------------------------------------------------------|
+| 0    | Success.                                                  |
+| 1    | Runtime failure (validation, IO, execution).              |
+| 2    | Usage error (missing flag, bad argument, unknown command).|
+
+## What's next
+
+- **[Migrations](migrations.md)** — the library-side of what `surql migrate` drives.
+- **[Query UX](query-ux.md)** — helpers that underpin `surql db query` output.
+- **[v3 Patterns](v3-patterns.md)** — v3 semantics surfaced by `schema` and `db` subcommands.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,181 @@
+# Features & Package Layout
+
+surql-go is organised as one module with subpackages under
+`pkg/surql/`. The top-level `pkg/surql` package re-exports the most
+commonly used helpers so consumers can import a single path for the
+common case.
+
+## Module map
+
+```
+github.com/Oneiriq/surql-go
+├── cmd/surql             # cobra-based CLI binary
+├── internal/cli          # CLI implementation (root, migrate, schema, db, orchestrate)
+└── pkg/surql             # top-level re-exports (ExtractOne / ExtractScalar[T] / ...)
+    ├── types             # operators, record ids, SurrealFn, reserved words, coerce
+    ├── query             # query builder, executor, CRUD, batch, graph, hints, results
+    ├── schema            # code-first DSL: fields, tables, edges, indexes, events
+    ├── migration         # discovery, diff, generator, versioning, squash, watcher, hooks
+    ├── connection        # DatabaseClient, Transaction, LiveQuery, AuthManager, StreamingManager
+    ├── cache             # memory + redis cache backends and decorators
+    ├── orchestration     # multi-environment deployment coordinator, strategies, health
+    ├── settings          # yaml / toml / .env settings loader + Option API
+    └── errors            # sentinel errors + typed SurqlError with errors.Is/As
+```
+
+## Per-package summary
+
+### `pkg/surql/types`
+
+Type-safe primitives shared by the builder and CRUD layers:
+
+- `Operator` interface + concrete `EqOp`, `GtOp`, `ContainsOp`, `AndOp`,
+  `OrOp`, `NotOp`, `InsideOp`, `IsNullOp`, and more.
+- `RecordID`, `RecordIDValue`, `RecordRef` for typed record identifiers.
+- `SurrealFn` + factories (`NewSurrealFn`, `SurqlFn`, `TypeRecord`,
+  `TypeThing`) for raw function expressions.
+- `RawSurqlValue` marker interface so `Expression` / `SurrealFn` emit
+  verbatim in SET / SELECT / WHERE without caller-side casts.
+- `CoerceDatetime` / `CoerceRecordDatetimes` for v3 ISO-8601 handling.
+- `SurrealReservedWords` + `CheckReservedWord` for DDL safety.
+
+### `pkg/surql/query`
+
+The immutable fluent builder, executor, and CRUD surface:
+
+- `Query` type with `Select`, `Insert`, `Update`, `Upsert`, `Delete`,
+  `Relate`, plus `SelectExpr`, `SelectAliased`, `From`, `Execute`
+  (v0.2.0 additions).
+- `Expression` helpers (`Field`, `Value`, `Raw`, `Func`, `MathMean`,
+  `Count`, `Concat`, …) and the new `types.SurrealFn` factories
+  (`MathAbs/Ceil/Floor/Round`, `StringLen/Lower/Upper/Concat`,
+  `CountAll/Field/If`).
+- Hints: `IndexHint`, `ParallelHint`, `TimeoutHint`, `FetchHint`,
+  `ExplainHint` with `MergeHints` / `RenderHints` / `ValidateHint`.
+- Executor: `ExecuteQuery`, `ExecuteRaw`, `FetchOne`, `FetchAll`,
+  `FetchMany`, plus generic `ExecuteRawTyped`, `FetchRecords[T]`,
+  `QueryRecordsWrapped`.
+- CRUD: `CreateRecord` / `GetRecord` / `UpdateRecord` / `UpsertRecord` /
+  `DeleteRecord`, generic `CreateTyped[T]` / `GetTyped[T]` /
+  `UpdateTyped[T]`, and the new `*ByTarget` helpers
+  (`GetByTarget`, `UpdateByTarget`, `UpsertByTarget`, `DeleteByTarget`,
+  `ExistsByTarget`).
+- Aggregation: `AggregateRecords` + `AggregateOpts` wrapping the
+  projection + grouping in one call.
+- Batch: `UpsertMany`, `InsertMany`, `RelateMany`, `DeleteMany`.
+- Graph: `Traverse`, `TraverseWithDepth`, `CreateRelation`,
+  `GetOutgoingEdges`, `GetIncomingEdges`, `ShortestPath`, plus
+  `GraphQuery` fluent builder.
+- Results: `QueryResult[T]`, `RecordResult[T]`, `ListResult[T]`,
+  `PaginatedResult[T]`, `CountResult`, `AggregateResult` + raw-envelope
+  extractors `ExtractOne`, `ExtractResult`, `ExtractScalar`, `HasResults`.
+
+### `pkg/surql/schema`
+
+Code-first DSL for every `DEFINE` statement SurrealDB emits:
+
+- Tables (`NewTableDefinition`, `WithMode`, `WithFields`, `WithIndexes`,
+  `WithEvents`, `WithPermissions`).
+- Edges (`NewEdgeDefinition`, `WithEdgeFrom`, `WithEdgeTo`,
+  `WithEdgeMode`).
+- Fields (`StringField`, `IntField`, `FloatField`, `BoolField`,
+  `DatetimeField`, `DurationField`, `DecimalField`, `ObjectField`,
+  `ArrayField`, `RecordField`, `ComputedField`) with chainable
+  `WithAssertion / WithDefault / WithValue / WithReadonly /
+  WithPermissions`.
+- Indexes (`Index`, `UniqueIndex`, `SearchIndex`, `MTreeIndex`,
+  `HnswIndex`).
+- Events (`Event().WithWhen().WithThen()`).
+- Access (`NewAccessDefinition`, `AccessTypeJwt`, `AccessTypeRecord`).
+- Registry + SQL generation (`NewSchemaRegistry`, `RegisterTable`,
+  `RegisterEdge`, `GenerateSchemaSQL`).
+- Parser (`ParseDBInfo`, `ParseTableInfo`, `ParseEdgeInfo`).
+- Validator (`ValidateSchema`, `ValidationReport` with severity
+  filtering, `CompareSchemas`).
+- Visualizer (`GenerateMermaid`, `GenerateGraphViz`, `GenerateASCII`)
+  with modern / dark / forest / minimal themes via `GetTheme(name)`.
+
+### `pkg/surql/migration`
+
+Full migration lifecycle:
+
+- Discovery + file format (`DiscoverMigrations`, `LoadMigration`,
+  SHA-256-checksummed `.surql` files with metadata / @up / @down
+  markers).
+- Diff engine (`DiffSchemas`, `DiffTables`, `DiffFields`, `DiffIndexes`,
+  `DiffEvents`, `DiffPermissions`, `DiffEdges`).
+- Generator (`GenerateMigration`, `GenerateInitialMigration`,
+  `GenerateMigrationFromDiffs`, `CreateBlankMigration`).
+- Executor (`MigrateUp`, `MigrateDown`, `ExecuteMigrationPlan`,
+  `ExecuteRollback`, `PlanRollbackToVersion`).
+- Status + history (`GetMigrationStatus`, `GetMigrationHistory`,
+  `GetAppliedMigrationsOrdered`).
+- Versioning (`SchemaSnapshot`, `VersionGraph`, `CreateSnapshot`,
+  `StoreSnapshot`, `ListSnapshots`, `CompareSnapshots`).
+- Squash + watcher + hooks (`SquashMigrationsWithOptions`,
+  `NewSchemaWatcher`, atomic auto-snapshot hooks with a global toggle).
+
+### `pkg/surql/connection`
+
+Runtime connection surface:
+
+- `DatabaseClient` wrapping `*surrealdb.DB` with `Connect` /
+  `Disconnect` / `Query` / `QueryWithVars` / `Health` / full CRUD.
+- Credentials: `RootCredentials`, `NamespaceCredentials`,
+  `DatabaseCredentials`, `ScopeCredentials`, `TokenAuth`.
+- Interactive transactions via `DatabaseClient.Begin` returning a
+  `Transaction` with `Execute` / `ExecuteWithVars` / `Commit` /
+  `Rollback` / `State` (WebSocket only; see
+  [v3 Patterns](v3-patterns.md)).
+- Live queries via `DatabaseClient.Live` returning a `LiveQuery` with
+  notification channel + `Close`.
+- `AuthManager` for signin / signup / authenticate / invalidate /
+  refresh lifecycle bookkeeping.
+- `StreamingManager` for spawning + tracking multiple live queries.
+- Context helpers (`SetDB` / `GetDB` / `ConnectionScope` /
+  `ConnectionOverride`).
+- Registry (`GetRegistry`, `Registry.Register`, `Registry.Get`) for
+  multi-environment clients shared across packages.
+
+### `pkg/surql/cache`
+
+Memory + Redis cache backends, a `Manager` that fans out to multiple
+backends, a decorator helper (`Cached(...)`) for wrapping a function
+in a cache, and a stats tracker.
+
+### `pkg/surql/orchestration`
+
+Multi-environment deployment coordinator:
+
+- `MigrationCoordinator.DeployToEnvironments` with four strategies
+  (sequential, parallel, rolling, canary).
+- `DeployOptions` (strategy, batch size, canary percent, max
+  concurrency, dry-run, verify-health, auto-rollback).
+- `EnvironmentConfig` + `Registry` (`LoadRegistryFromFile`,
+  `Get`, `List`).
+- `HealthCheck.VerifyAllEnvironments` for pre-deploy probes.
+- `DeploymentResult` / `DeploymentStatus` for result reporting.
+
+### `pkg/surql/settings`
+
+Unified settings loader:
+
+- `LoadSettings(opts...)` walks `surql.yaml` / `surql.toml` up the tree
+  and falls back to `SURQL_*` env vars.
+- `Settings` struct exposes `Database`, `MigrationPath`, `Cache`,
+  `Orchestration`.
+- `WithConfigFile`, `WithEnvPrefix`, `WithSource` options for
+  test fixtures + explicit overrides.
+
+### `pkg/surql/errors`
+
+Sentinel errors (`ErrValidation`, `ErrConnection`, `ErrNotFound`,
+`ErrTransaction`, `ErrStreaming`, `ErrSerialization`, …) plus a typed
+`SurqlError` that composes through `errors.Is` / `errors.As` and
+preserves the underlying cause.
+
+## What's next
+
+- **[CLI Reference](cli.md)** — the `surql` subcommand surface.
+- **[v3 Patterns](v3-patterns.md)** — v3 behaviour per package.
+- **[Query UX](query-ux.md)** — the new first-class helpers.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,19 +12,24 @@ Define schemas, generate migrations, build queries, and perform typed CRUD
 
 - **Code-First Migrations** -- Schema changes defined in code with automatic
   migration generation. Files use a portable `.surql` format with
-  `-- @up` / `-- @down` section markers.
+  `-- @up` / `-- @down` section markers. Squash, watcher, and auto-snapshot
+  hooks included.
 - **Type-Safe Query Builder** -- Immutable fluent API with operator-typed
-  `Where`, expression helpers, and `encoding/json` struct tags.
+  `Where`, expression helpers, `SelectExpr` / `SelectAliased` aggregations,
+  and `encoding/json` struct tags.
+- **v3 Transactions** -- Native interactive `BEGIN` / `COMMIT` / `ROLLBACK`
+  via `DatabaseClient.Begin`, plus raw record-id targets
+  (`types.TypeRecord` / `types.TypeThing`) and `GROUP ALL` aggregation.
 - **Vector Search** -- HNSW and MTREE index support with 8 distance metrics
   and EFC/M tuning.
 - **Graph Traversal** -- Native SurrealDB graph features with edge
-  relationships.
+  relationships + fluent `GraphQuery` builder.
 - **Schema Visualization** -- Mermaid, GraphViz, and ASCII diagrams with
   modern / dark / forest / minimal themes.
-- **CLI Tools** -- Migrations, schema inspection, validation, database
-  management *(planned)*.
-- **Stdlib-First** -- Minimal dependencies; stdlib `net/http` + official
-  SurrealDB SDK *(planned for 0.2)*.
+- **CLI Tools** -- Full `surql` binary for migrations, schema inspection,
+  validation, database management, and multi-environment orchestration.
+- **Cache + Orchestration** -- Memory + Redis cache backends,
+  sequential / parallel / rolling / canary deployment strategies.
 
 ## Quick Start
 
@@ -57,15 +62,20 @@ func main() {
 
 - **[Installation](installation.md)** -- getting the module installed.
 - **[Quick Start](quickstart.md)** -- your first schema and migration.
+- **[Features & Package Layout](features.md)** -- per-package surface map.
 - **[Schema Definition](schema.md)** -- the schema DSL in depth.
 - **[Migrations](migrations.md)** -- diff-based migration generation, file
   format, and versioning.
 - **[Query Builder](queries.md)** -- immutable fluent queries.
+- **[Query UX](query-ux.md)** -- first-class helpers added in v0.2.0.
 - **[Query Hints](query_hints.md)** -- INDEX / PARALLEL / TIMEOUT / FETCH /
   EXPLAIN hints.
+- **[v3 Patterns](v3-patterns.md)** -- interactive transactions,
+  `GROUP ALL`, raw record-id targets, known upstream SDK limitations.
 - **[Visualization](visualization.md)** -- Mermaid / GraphViz / ASCII
   diagrams.
-- **[CLI](cli.md)** -- the `surql` binary *(planned)*.
+- **[CLI Reference](cli.md)** -- the `surql` subcommand surface.
+- **[Upgrading](migration.md)** -- version-to-version upgrade notes.
 - **[Changelog](changelog.md)** -- release history.
 - **[API reference](https://pkg.go.dev/github.com/Oneiriq/surql-go)** --
   generated godoc.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ go get github.com/Oneiriq/surql-go
 Or in `go.mod`:
 
 ```go
-require github.com/Oneiriq/surql-go v0.1.0
+require github.com/Oneiriq/surql-go v0.2.1
 ```
 
 ## CLI
@@ -32,9 +32,13 @@ go test -tags=integration ./...
 ## Requirements
 
 - Go 1.26 or newer.
-- For the client feature: SurrealDB 2.0 or newer.
+- SurrealDB **v3.0+** for the full feature set (CI runs against
+  `surrealdb/surrealdb:v3.0.5`). Interactive transactions
+  (`DatabaseClient.Begin`) and `GROUP ALL` aggregations require v3.
+  See [v3 Patterns](v3-patterns.md) for the v3-specific surface.
 
 ## What's next
 
 - **[Quick Start](quickstart.md)** -- your first schema and migration.
 - **[Schema Definition](schema.md)** -- the full schema DSL reference.
+- **[CLI Reference](cli.md)** -- the `surql` subcommand surface.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,110 @@
+# Upgrading
+
+## v0.1.0 → v0.2.0
+
+v0.2.0 is an **additive** release — no APIs were removed or renamed, so
+a straight `go get -u github.com/Oneiriq/surql-go` should be enough for
+existing code to keep compiling.
+
+That said, the wave adds a set of first-class helpers that can simplify
+your call sites significantly. This page highlights the patterns worth
+migrating to.
+
+### New query UX helpers
+
+See [Query UX](query-ux.md) for the full list. Quick before/after:
+
+Hand-built record-id target →
+
+```go
+res, _ := client.Query(ctx, "SELECT * FROM user:alice")
+record, _ := surql.ExtractOne(res)
+```
+
+becomes
+
+```go
+record, _ := query.GetByTarget(ctx, client, types.TypeRecord("user", "alice"))
+```
+
+Manual JSON envelope flattening →
+
+```go
+raw, _ := client.Query(ctx, "SELECT count() AS n FROM user GROUP ALL")
+envelope, _ := raw.([]any)
+first, _    := envelope[0].(map[string]any)
+result, _   := first["result"].([]any)
+row, _      := result[0].(map[string]any)
+n, _        := row["n"].(float64)
+```
+
+becomes
+
+```go
+raw, _  := client.Query(ctx, "SELECT count() AS n FROM user GROUP ALL")
+n, _    := surql.ExtractScalar[int64](raw, "n")
+```
+
+Aggregation projections →
+
+```go
+q, _ := query.Select([]string{"count() AS total", "math::mean(score) AS avg"}).FromTable("match")
+```
+
+becomes
+
+```go
+q := query.NewQuery().SelectAliased(map[string]types.Operator{
+    "total": query.CountAll(),
+    "avg":   query.MathMean("score"),
+}).From("match").GroupAll()
+```
+
+### Interactive transactions (v3)
+
+`DatabaseClient.Begin` is new in v0.1.0 — code written against an earlier
+pre-release scratch branch that rolled its own WS transactions can now
+be switched to the built-in handle.
+
+See [v3 Patterns](v3-patterns.md#interactive-transactions) for the
+reference flow.
+
+### Settings loader
+
+`pkg/surql/settings` gained a unified `LoadSettings(...Option)` entry
+point that accepts explicit `WithConfigFile(...)` overrides and falls
+back to `SURQL_*` env-var discovery. Existing callers that hand-wired
+env vars via `connection.LoadConfigFromEnv` still work, but settings-
+driven CLI reuse (and the new orchestration plan files) is a lot less
+boilerplate.
+
+### Pre-push hook
+
+`/.githooks/pre-push` mirrors CI (`gofmt -l`, `go vet`, `go test -race`).
+Enable it in your local checkout:
+
+```shell
+git config core.hooksPath .githooks
+```
+
+See [CONTRIBUTING.md](https://github.com/Oneiriq/surql-go/blob/main/CONTRIBUTING.md)
+for the full dev workflow.
+
+## v0.2.0 → v0.2.1
+
+**Documentation-only release.** No functional changes — this build
+rebuilds the narrative mkdocs site around the v0.2 surface:
+
+- New **[v3 Patterns](v3-patterns.md)** reference covering interactive
+  transactions, datetime coercion, `GROUP ALL`, raw record-id targets,
+  the v3 missing-table error shape, and the surrealdb.go#398 live-query
+  teardown race.
+- New **[Query UX](query-ux.md)** reference with before/after Go
+  examples for every helper added in v0.2.0.
+- New **[CLI Reference](cli.md)** enumerating every `surql` subcommand
+  (previously a "planned" placeholder).
+- New **[Features](features.md)** page with the package layout.
+- README top-level examples updated to use the new first-class
+  helpers.
+
+No upgrade steps required beyond `go get -u`.

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -67,13 +67,38 @@ so only the latest value survives.
 
 ## Result wrappers
 
-Once the SurrealDB client lands, queries produce typed
-`QueryResult[T]` / `RecordResult[T]` / `ListResult[T]` /
-`PaginatedResult[T]` values via the raw-response helpers in
-`pkg/surql/query`: `ExtractResult`, `ExtractOne`, `ExtractScalar`,
-`HasResults`.
+Queries produce typed `QueryResult[T]` / `RecordResult[T]` /
+`ListResult[T]` / `PaginatedResult[T]` values via the raw-response
+helpers in `pkg/surql/query` (or the top-level re-exports in
+`pkg/surql`): `ExtractResult`, `ExtractOne`, `ExtractScalar`,
+`HasResults`. See **[Query UX](query-ux.md)** for worked examples.
+
+## Aggregations (`GROUP ALL` + `SelectExpr`)
+
+The builder's `SelectExpr` / `SelectAliased` / `GroupAll` methods
+compose with the `types.SurrealFn` factories (`CountAll`, `MathAbs`,
+`StringLen`, …) to render v3 aggregation queries directly:
+
+```go
+q := query.NewQuery().
+    SelectAliased(map[string]types.Operator{
+        "count": query.CountAll(),
+        "avg":   query.MathMean("score"),
+    }).
+    From("match").
+    GroupAll()
+
+rows, _ := q.Execute(ctx, client)
+```
+
+For the same pattern without the builder boilerplate, use
+`AggregateRecords` + `AggregateOpts` (see
+[Query UX](query-ux.md)).
 
 ## What's next
 
+- **[Query UX](query-ux.md)** -- first-class helpers added in v0.2.0.
 - **[Query Hints](query_hints.md)** -- every supported optimization hint.
+- **[v3 Patterns](v3-patterns.md)** -- interactive transactions, `GROUP ALL`,
+  raw record-id targets.
 - **[Visualization](visualization.md)** -- schema diagrams.

--- a/docs/query-ux.md
+++ b/docs/query-ux.md
@@ -1,0 +1,183 @@
+# Query UX Helpers
+
+The v0.2 "query UX" wave adds a handful of first-class helpers that
+collapse previously verbose patterns into one-liners. This page walks
+each one with a before/after Go example.
+
+## `types.TypeRecord` / `types.TypeThing`
+
+Construct a v3 raw-record-id target that any CRUD or query helper will
+accept. Both implement `types.Operator`, so they compose inside WHERE
+clauses, SET bodies, and SELECT projections.
+
+Before:
+
+```go
+// Hand-rolled record target: no type safety, quoting bugs waiting to happen.
+res, err := client.Query(ctx, "SELECT * FROM type::record('user:alice')")
+```
+
+After:
+
+```go
+target := types.TypeRecord("user", "alice")
+record, err := query.GetByTarget(ctx, client, target)
+```
+
+`TypeThing(table, id)` is the right pick when `id` is already a typed
+value (int, UUID, nested object):
+
+```go
+user := types.TypeThing("user", 42)
+```
+
+## `types.RawSurqlValue`
+
+Marker interface that tells surql-go to emit the wrapped value verbatim
+rather than JSON-quoting it. `types.SurrealFn` and `query.Expression`
+both implement it so math / string / count builders drop into SET /
+WHERE / SELECT without extra casts:
+
+```go
+payload := map[string]any{
+    "updated_at": types.SurqlFn("time::now"), // emits bare time::now()
+    "score":      query.MathMean("scores"),   // emits math::mean(scores)
+}
+_, _ = query.UpdateByTarget(ctx, client, target, payload)
+```
+
+## Function factories (`MathAbs`, `StringLen`, `CountAll`, …)
+
+Each factory returns a `types.SurrealFn` that composes through the same
+`types.Operator` interface as the existing `Expression` helpers.
+
+| Factory                 | Rendering                          |
+|-------------------------|------------------------------------|
+| `MathAbs(f)`            | `math::abs(f)`                     |
+| `MathCeil(f)`           | `math::ceil(f)`                    |
+| `MathFloor(f)`          | `math::floor(f)`                   |
+| `MathRound(f)`          | `math::round(f)`                   |
+| `StringLen(f)`          | `string::len(f)`                   |
+| `StringLower(f)`        | `string::lowercase(f)`             |
+| `StringUpper(f)`        | `string::uppercase(f)`             |
+| `StringConcat(a, b...)` | `string::concat(a, b, ...)`        |
+| `CountAll()`            | `count()`                          |
+| `CountField(f)`         | `count(f)`                         |
+| `CountIf(expr)`         | `count(<expr>)`                    |
+
+Before:
+
+```go
+q, _ := query.Select([]string{"name", "math::abs(score) AS abs_score"}).FromTable("match")
+```
+
+After:
+
+```go
+q := query.NewQuery().
+    Select([]string{"name"}).
+    From("match")
+q = q.SelectAliased(map[string]types.Operator{
+    "abs_score": query.MathAbs("score"),
+})
+```
+
+## `Query.SelectExpr` / `Query.SelectAliased` / `Query.From` / `Query.Execute`
+
+Four new methods on the immutable builder:
+
+- `SelectExpr(exprs ...types.Operator)` — project raw expressions.
+- `SelectAliased(map[string]types.Operator)` — project with `AS alias`
+  suffixes (alphabetical-key ordering for deterministic rendering).
+- `From(table string)` — non-returning variant of `FromTable` intended
+  for chains that don't need to fork on validation.
+- `Execute(ctx, client)` — runs the query against a
+  `*connection.DatabaseClient` without hopping through the package-level
+  `ExecuteQuery`.
+
+```go
+q := query.NewQuery().
+    SelectExpr(query.CountAll(), query.MathMean("score")).
+    From("match").
+    GroupAll()
+
+rows, _ := q.Execute(ctx, client)
+```
+
+## `ExtractOne` / `ExtractMany` / `ExtractScalar[T]` / `HasResult`
+
+The Python port shipped `extract_one` / `extract_scalar` helpers that
+flatten the SurrealDB envelope. The Go equivalents live at the package
+root (`pkg/surql`) so a single import handles the common case:
+
+```go
+import "github.com/Oneiriq/surql-go/pkg/surql"
+
+raw, _ := client.Query(ctx, "SELECT count() AS n FROM user GROUP ALL")
+
+first,  _ := surql.ExtractOne(raw)                 // map[string]any
+all,    _ := surql.ExtractMany(raw)                // []map[string]any
+count,  _ := surql.ExtractScalar[int64](raw, "n")  // int64, via JSON round-trip
+hasAny    := surql.HasResult(raw)                  // bool
+```
+
+`ExtractScalar[T]` uses `encoding/json`'s loose numeric coercion so a
+SurrealDB count (`float64` in the JSON envelope) decodes cleanly into an
+`int`, `int64`, `uint`, etc. Missing keys surface as `ErrValidation`.
+
+## `AggregateRecords` + `AggregateOpts`
+
+High-level helper that wraps SELECT-with-aggregations in a single call.
+Accepts any `types.Operator` value as the aggregation expression.
+
+```go
+opts := query.AggregateOpts{
+    Table: "memory_entry",
+    Select: map[string]types.Operator{
+        "count":    query.CountAll(),
+        "strength": query.MathSum("strength"),
+    },
+    GroupBy: []string{"network"},
+}
+rows, _ := query.AggregateRecords(ctx, client, opts)
+```
+
+`GroupAll: true` switches the helper to v3 `GROUP ALL`. `Where`,
+`OrderBy`, `Limit`, and `Offset` are all optional; set at least one
+aggregation expression via `Select`.
+
+## `*ByTarget` CRUD helpers
+
+Sibling of the table-oriented CRUD functions, but accepting a raw
+target expression (`types.TypeRecord` / `types.TypeThing`) so callers
+don't have to split a known record id into `(table, id)` pairs.
+
+| Helper              | Behaviour                                                    |
+|---------------------|--------------------------------------------------------------|
+| `GetByTarget`       | `SELECT * FROM <target>` returning the first record or nil.  |
+| `UpdateByTarget`    | `UPDATE <target> CONTENT {...}` (full replace).              |
+| `UpsertByTarget`    | `UPSERT <target> CONTENT {...}`.                             |
+| `DeleteByTarget`    | `DELETE <target>`; missing-table errors collapse to no-op.   |
+| `ExistsByTarget`    | `SELECT id FROM <target> LIMIT 1` returning a bool.          |
+
+```go
+target := types.TypeRecord("user", "alice")
+
+// Check existence
+exists, _ := query.ExistsByTarget(ctx, client, target)
+
+// Partial update (merge semantics via UpdateByTarget + full payload)
+_, _ = query.UpdateByTarget(ctx, client, target, map[string]any{
+    "status":     "active",
+    "updated_at": types.SurqlFn("time::now"),
+})
+
+// Delete
+_ = query.DeleteByTarget(ctx, client, target)
+```
+
+## What's next
+
+- **[v3 Patterns](v3-patterns.md)** — the v3 surface these helpers build on.
+- **[Query Builder](queries.md)** — the fluent builder reference.
+- **[CLI](cli.md)** — `surql` subcommands that surface these helpers.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -96,3 +96,7 @@ for _, d := range diffs {
   events, access rules.
 - **[Migrations](migrations.md)** -- the full migration lifecycle.
 - **[Query Builder](queries.md)** -- immutable fluent queries.
+- **[Query UX](query-ux.md)** -- first-class CRUD / aggregation helpers.
+- **[v3 Patterns](v3-patterns.md)** -- interactive transactions + v3-only
+  features.
+- **[CLI Reference](cli.md)** -- the `surql` subcommand surface.

--- a/docs/v3-patterns.md
+++ b/docs/v3-patterns.md
@@ -1,0 +1,135 @@
+# SurrealDB v3 Patterns
+
+surql-go targets SurrealDB **v3.0+**. CI runs against `surrealdb/surrealdb:v3.0.5`.
+This page covers the v3-specific surface you can rely on today and the
+single upstream SDK rough edge we currently work around.
+
+## Interactive transactions
+
+v3 added a native `begin` / `commit` / `rollback` RPC. `DatabaseClient.Begin`
+returns a live `Transaction` (WebSocket transports only — the RPC is not
+exposed over HTTP):
+
+```go
+import (
+    "context"
+    "github.com/Oneiriq/surql-go/pkg/surql/connection"
+)
+
+func transfer(ctx context.Context, client *connection.DatabaseClient, from, to string, amount int) error {
+    tx, err := client.Begin(ctx)
+    if err != nil {
+        return err
+    }
+    // Always finalise exactly once — Commit or Rollback.
+    if _, err := tx.Execute(ctx, "UPDATE "+from+" SET balance -= "+amountStr(amount)); err != nil {
+        _ = tx.Rollback(ctx)
+        return err
+    }
+    if _, err := tx.Execute(ctx, "UPDATE "+to+" SET balance += "+amountStr(amount)); err != nil {
+        _ = tx.Rollback(ctx)
+        return err
+    }
+    return tx.Commit(ctx)
+}
+```
+
+`Transaction.State()` + `Transaction.IsActive()` let you inspect whether the
+handle has already been finalised; calling Commit/Rollback twice returns
+`ErrTransaction` from `pkg/surql/errors`.
+
+## `GROUP ALL` aggregations
+
+v3 accepts `GROUP ALL` for whole-result aggregation (no explicit grouping
+columns needed). The builder exposes it via `Query.GroupAll()` and the
+high-level helper `AggregateRecords`:
+
+```go
+q := query.NewQuery().
+    SelectExpr(query.CountAll(), query.MathMean("score")).
+    From("match").
+    GroupAll()
+
+rows, _ := q.Execute(ctx, client)
+```
+
+See [Query UX](query-ux.md) for the `AggregateOpts` / `AggregateRecords`
+helper that wraps this pattern end-to-end.
+
+## Datetime coercion
+
+v3 rejects implicit string-to-datetime coercion in some contexts. Whenever
+you hand-build payloads that contain ISO-8601 timestamps, use
+`types.CoerceRecordDatetimes` to wrap the relevant fields in `<datetime>`
+casts before sending:
+
+```go
+record := map[string]any{
+    "created_at": "2026-04-18T19:33:00Z",
+    "updated_at": "2026-04-18T19:34:00Z",
+}
+record, _ = types.CoerceRecordDatetimes(record, []string{"created_at", "updated_at"})
+```
+
+The code-first CRUD helpers (`CreateRecord`, `UpdateRecord`, …) already do
+this for any `time.Time` value in the payload.
+
+## Raw record-id targets
+
+v3 lets you pass raw record ids — `table:id` — as SELECT / UPDATE / DELETE
+targets. surql-go surfaces this via `types.TypeRecord` / `types.TypeThing`
+plus the `*ByTarget` CRUD helpers:
+
+```go
+id := types.TypeRecord("user", "alice")
+
+record, _ := query.GetByTarget(ctx, client, id)
+_, err    := query.UpdateByTarget(ctx, client, id, map[string]any{"status": "active"})
+err       := query.DeleteByTarget(ctx, client, id)
+exists, _ := query.ExistsByTarget(ctx, client, id)
+```
+
+`TypeRecord(table, id)` emits `type::record('<table>:<id>')`; `TypeThing`
+emits `type::thing('<table>', <id>)` for cases where the id value is
+already a typed value (int, UUID, etc). Both implement `types.Operator`
+and render verbatim wherever surql-go accepts an expression.
+
+## Missing-table error shape
+
+v2 treated queries against an undefined table as returning zero rows. v3
+raises an error of the form `The table 'foo' does not exist`. surql-go
+absorbs this in the CRUD path so that the zero-rows semantics is
+preserved: any error containing `does not exist` (or the defensive
+fallback `table not found`) collapses to an empty result in
+`QueryRecords`, `First`, `Last`, `Exists`, `CountRecords`, and the
+graph/batch helpers.
+
+If you need the raw error for schema-assertion code, call
+`DatabaseClient.Query` directly instead of going through `query.*`.
+
+## Known upstream SDK limitation
+
+**Live-query teardown race in `surrealdb.go` v1.4.0.** When a subscription
+is closed while the SDK is still draining its internal notification
+channel, the shutdown path in `CloseLiveNotifications` can race with the
+receiver goroutine and panic or deadlock. Tracked upstream as
+[surrealdb.go#398](https://github.com/surrealdb/surrealdb.go/issues/398).
+
+While the fix lands upstream we:
+
+- Skip the two live-query integration tests that exercise the teardown
+  sequence (`connection.TestIntegration_Live*`). The build still covers
+  `Live` subscription startup and event delivery, only the explicit
+  `Close` / `Kill` path is skipped.
+- Document this limitation here so downstream consumers know not to rely
+  on deterministic `LiveQuery.Close` teardown in production under
+  surrealdb.go v1.4.0.
+
+`StreamingManager.DrainAll` will suffer from the same race once the
+bug triggers; prefer relying on client-level disconnection (which tears
+down the WebSocket wholesale) until the SDK releases the fix.
+
+## What's next
+
+- **[Query UX](query-ux.md)** — the helpers unlocked by the v3 surface.
+- **[CLI](cli.md)** — `surql` subcommands that lean on v3 behaviour.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,14 +71,18 @@ nav:
   - Getting Started:
       - Installation: installation.md
       - Quick Start: quickstart.md
+      - Features: features.md
   - Guides:
       - Schema Definition: schema.md
       - Migrations: migrations.md
       - Query Builder: queries.md
+      - Query UX Helpers: query-ux.md
       - Query Hints: query_hints.md
+      - v3 Patterns: v3-patterns.md
       - Visualization: visualization.md
   - Reference:
       - CLI: cli.md
+      - Upgrading: migration.md
       - API (pkg.go.dev): https://pkg.go.dev/github.com/Oneiriq/surql-go
   - Changelog: changelog.md
 

--- a/pkg/surql/surql.go
+++ b/pkg/surql/surql.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Version is the current surql-go release.
-const Version = "0.2.0"
+const Version = "0.2.1"
 
 // ExtractOne returns the first record from a raw response or
 // (nil, nil) when the envelope is empty. Mirrors the Python


### PR DESCRIPTION
Docs-only patch: mkdocs site synced with v0.1 + v0.2 surface. New v3-patterns/query-ux/cli/migration/features pages + refreshed README + README snippets for AggregateRecords / ExtractScalar / interactive tx. Refs #82.