### PR TITLE
feat(#87): point CI at aur0 org self-hosted runner

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   govulncheck:
     name: govulncheck
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   lint:
     name: golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     # golangci-lint v2.1.x is built with Go 1.24 and panics ("package
     # requires newer Go version go1.26") when linting a module with
     # `go 1.26` in go.mod. Marked continue-on-error until a
@@ -90,7 +90,7 @@ jobs:
 
   integration:
     name: Integration
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
 
@@ -133,7 +133,7 @@ jobs:
 
   goreleaser-check:
     name: goreleaser check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.base_ref, 'release/')
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   coverage:
     name: go test -coverprofile
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   dep-review:
     name: Dependency Review
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
 
@@ -46,7 +46,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,7 +49,7 @@ jobs:
 
   nightly-lint:
     name: Nightly golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -68,7 +68,7 @@ jobs:
 
   nightly-audit:
     name: Nightly govulncheck
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   lint-pr-title:
     name: Conventional Commit PR title
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Closes #87. Retargets `ubuntu-latest` -> `[self-hosted, Linux, X64]` so CI runs on aur0-oneiriq (org-level self-hosted). Zero GitHub-hosted minutes for these jobs.

Merged after this lands: every push/PR on surql-go hits aur0, no billed minutes.