### PR TITLE
feat(#89): drop macOS nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,12 +7,11 @@ on:
 
 jobs:
   nightly-ci:
-    name: Nightly sanity (${{ matrix.os }}, Go ${{ matrix.go }})
-    runs-on: ${{ matrix.os }}
+    name: Nightly sanity (ubuntu-latest, Go ${{ matrix.go }})
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
         go: ['1.26', 'stable']
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Closes #89.

Drops `macos-latest` from the nightly matrix. Solo dev tests macOS locally; this removes the last GitHub-billed runner minutes (weekly macOS ~30 min/month -> 0). Ubuntu still runs on every nightly trigger (`0 6 * * *`).

## Diff summary
- `.github/workflows/nightly.yml`: matrix `os: [ubuntu-latest, macos-latest]` -> hardcoded `runs-on: ubuntu-latest`. Go version matrix retained. +2 / -3.

## Verification
- `actionlint .github/workflows/*.yml`: clean.