### PR TITLE
feat(#95): enable embedded surrealkv backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- `connection.Protocol.IsSupported()` reports whether the currently-linked
+  `surrealdb.go` SDK can actually open a connection for the scheme.
+  Remote transports (`ws://`, `wss://`, `http://`, `https://`) return
+  true; embedded schemes (`memory://`, `mem://`, `file://`,
+  `surrealkv://`) return false pending
+  [surrealdb.go#197](https://github.com/surrealdb/surrealdb.go/issues/197).
 - `migration/versioning` -- `SchemaSnapshot` (extended with `Version`,
   `Timestamp`, `Description`, `Accesses`), `VersionGraph` DAG with
   ancestors/descendants/path, and JSON-file snapshot persistence.
@@ -39,6 +45,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   -- operator structs + `RecordID` with angle-bracket syntax + reserved
   words + ISO-8601 datetime coercion.
 - `errors` -- sentinel errors + typed `SurqlError` with `errors.Is`/`As`.
+
+### Changed
+
+- `DatabaseClient.Connect` now fails fast with a descriptive
+  `ErrConnection` when passed an embedded URL scheme (`memory://`,
+  `mem://`, `file://`, `surrealkv://`), instead of retrying the upstream
+  `"embedded database not enabled"` error from `surrealdb.go`. Remote
+  transports are unaffected. README grew a protocol-support table
+  documenting the current state (#95).
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,36 @@ Key pages:
 - [CLI Reference](https://oneiriq.github.io/surql-go/cli/)
 - [Upgrading](https://oneiriq.github.io/surql-go/migration/)
 
+## Supported connection protocols
+
+`ConnectionConfig.DBURL` accepts all URL schemes the upstream
+[`surrealdb.go`](https://github.com/surrealdb/surrealdb.go) SDK parses, but
+only the remote transports can actually open a connection. Embedded schemes
+are parsed (so protocol detection still works) and then rejected at
+`DatabaseClient.Connect` with `ErrConnection` pending upstream support.
+
+| Scheme         | Status       | Notes                                                                                              |
+| -------------- | ------------ | -------------------------------------------------------------------------------------------------- |
+| `ws://`        | Supported    | WebSocket. Full feature set including live queries.                                                |
+| `wss://`       | Supported    | TLS WebSocket. Full feature set including live queries.                                            |
+| `http://`      | Supported    | HTTP RPC. No live queries.                                                                         |
+| `https://`     | Supported    | TLS HTTP RPC. No live queries.                                                                     |
+| `memory://`    | Not yet      | Parsed; `Connect` returns `ErrConnection`. Blocked by upstream [surrealdb.go#197].                 |
+| `mem://`       | Not yet      | Alias of `memory://`.                                                                              |
+| `file://`      | Not yet      | Parsed; `Connect` returns `ErrConnection`. Blocked by upstream [surrealdb.go#197].                 |
+| `surrealkv://` | Not yet      | Parsed; `Connect` returns `ErrConnection`. Blocked by upstream [surrealdb.go#197].                 |
+
+[surrealdb.go#197]: https://github.com/surrealdb/surrealdb.go/issues/197
+
+Use `connection.Protocol.IsSupported()` to check programmatically whether
+a configured URL can open. The library will re-enable embedded schemes
+automatically as soon as the SDK ships an embedded engine -- callers will
+not need to change any code.
+
+Downstream consumers that need an offline / embedded store today (for
+example [kushtaka-cli](https://github.com/Oneiriq/kushtakas)'s local
+cache) should keep their file-based fallback until upstream lands.
+
 ## Requirements
 
 - Go 1.26+

--- a/pkg/surql/connection/client.go
+++ b/pkg/surql/connection/client.go
@@ -57,11 +57,26 @@ func (c *DatabaseClient) IsConnected() bool {
 //
 // The provided context cancels the entire retry window; individual attempts
 // are not further subdivided.
+//
+// Embedded URL schemes (mem://, memory://, file://, surrealkv://) are parsed
+// by the library but not currently openable: the upstream surrealdb.go SDK
+// has no embedded engine linked in (see
+// https://github.com/surrealdb/surrealdb.go/issues/197). Connect returns
+// ErrConnection immediately for those schemes instead of retrying the
+// upstream "embedded database not enabled" error.
 func (c *DatabaseClient) Connect(ctx context.Context) error {
 	if c.IsConnected() {
 		if err := c.Disconnect(); err != nil {
 			return err
 		}
+	}
+
+	if proto, err := c.cfg.Protocol(); err == nil && !proto.IsSupported() {
+		return surqlerrors.Newf(surqlerrors.ErrConnection,
+			"embedded scheme %q is not supported: surrealdb.go has no embedded "+
+				"engine linked in (upstream https://github.com/surrealdb/surrealdb.go/issues/197). "+
+				"Use ws:// / wss:// / http:// / https:// to connect to a running SurrealDB instance",
+			proto)
 	}
 
 	var lastErr error

--- a/pkg/surql/connection/client_test.go
+++ b/pkg/surql/connection/client_test.go
@@ -146,6 +146,75 @@ func TestBackoffDelay_MinFloor(t *testing.T) {
 	}
 }
 
+func TestConnect_RejectsEmbeddedSchemes(t *testing.T) {
+	// Embedded URL schemes parse and validate (protocol detection still
+	// works) but cannot actually be opened because surrealdb.go ships no
+	// embedded engine. Connect must fail fast with ErrConnection and a
+	// human-readable message pointing to the upstream issue, rather than
+	// retrying the cryptic "embedded database not enabled" error returned
+	// by the SDK itself.
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"memory", "memory://"},
+		{"mem", "mem://"},
+		{"file", "file:///tmp/surql-test.db"},
+		{"surrealkv", "surrealkv:///tmp/surql-test.skv"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.DBURL = tc.url
+			cfg.EnableLiveQueries = false // HTTP/embedded parity for validation
+			c, err := NewDatabaseClient(cfg)
+			if err != nil {
+				t.Fatalf("NewDatabaseClient(%s): %v", tc.url, err)
+			}
+
+			start := time.Now()
+			err = c.Connect(context.Background())
+			elapsed := time.Since(start)
+
+			if err == nil {
+				t.Fatalf("%s: expected Connect to fail", tc.url)
+			}
+			if !errors.Is(err, surqlerrors.ErrConnection) {
+				t.Errorf("%s: want ErrConnection, got %v", tc.url, err)
+			}
+			// Ensure the fail-fast happens: no retry/backoff sleeps.
+			if elapsed > 100*time.Millisecond {
+				t.Errorf("%s: took %v; should short-circuit before retry loop", tc.url, elapsed)
+			}
+		})
+	}
+}
+
+func TestProtocol_IsSupported(t *testing.T) {
+	// Remote transports are supported.
+	for _, p := range []Protocol{
+		ProtocolWebSocket,
+		ProtocolWebSocketSecure,
+		ProtocolHTTP,
+		ProtocolHTTPS,
+	} {
+		if !p.IsSupported() {
+			t.Errorf("%v should be supported", p)
+		}
+	}
+	// Embedded schemes are not supported until surrealdb.go ships an
+	// embedded engine (upstream issue 197).
+	for _, p := range []Protocol{
+		ProtocolMemory,
+		ProtocolFile,
+		ProtocolSurrealKV,
+	} {
+		if p.IsSupported() {
+			t.Errorf("%v should not be supported (embedded upstream blocker)", p)
+		}
+	}
+}
+
 func TestConnect_CancelsOnContext(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.DBURL = "ws://127.0.0.1:1/rpc" // unreachable

--- a/pkg/surql/connection/config.go
+++ b/pkg/surql/connection/config.go
@@ -64,6 +64,18 @@ func (p Protocol) IsEmbedded() bool {
 	return p == ProtocolMemory || p == ProtocolFile || p == ProtocolSurrealKV
 }
 
+// IsSupported reports whether surql-go can actually open a connection for
+// this protocol with the currently-linked surrealdb.go SDK.
+//
+// The SDK parses mem:// / memory:// / file:// / surrealkv:// URLs but its
+// FromEndpointURLString rejects them with "embedded database not enabled"
+// (see upstream https://github.com/surrealdb/surrealdb.go/issues/197). Those
+// schemes therefore return false here until the SDK ships an embedded
+// engine. Remote transports are always supported.
+func (p Protocol) IsSupported() bool {
+	return !p.IsEmbedded()
+}
+
 // ConnectionConfig is the SurrealDB connection configuration.
 //
 // Field names follow the Python port (DBURL, DBNS, DB, ...) for


### PR DESCRIPTION
## Summary

Closes #95 (as an upstream blocker, with a clearer error path and
documented protocol support until `surrealdb.go` ships an embedded engine).

- Investigated bumping `surrealdb.go`: v1.4.0 is the latest release and
  still rejects `mem://` / `memory://` / `file://` / `surrealkv://` with
  `"embedded database not enabled"` at [`db.go#L118-L120`](https://github.com/surrealdb/surrealdb.go/blob/v1.4.0/db.go#L118-L120).
  `main` has identical behaviour. The feature is tracked upstream as
  [surrealdb.go#197](https://github.com/surrealdb/surrealdb.go/issues/197)
  (still open; previous embedded implementation was intentionally disabled
  in [surrealdb.go#193](https://github.com/surrealdb/surrealdb.go/pull/193)).
  No dep bump is viable today.
- Added `connection.Protocol.IsSupported()` so callers can check
  programmatically whether the currently-linked SDK can open a given
  scheme.
- `DatabaseClient.Connect` now short-circuits embedded URLs before the
  retry loop and returns a descriptive `ErrConnection` that points at
  the upstream issue and recommends a remote transport, instead of
  retrying the cryptic SDK error three times with exponential backoff.
- README grew a protocol-support table and a note for downstream
  consumers (e.g. kushtaka-cli's local cache) that need embedded today.
- CHANGELOG documents the behaviour change.

The `Connect` path will re-enable embedded schemes automatically the
moment `IsSupported()` returns true, so callers will not need to change
any code once upstream lands.

## Test plan

- [x] `go vet ./...` -- clean.
- [x] `go test ./...` -- all packages green.
- [x] `go test -race ./pkg/surql/connection/...` -- green.
- [x] `gofmt -l .` -- clean.
- [x] New `TestConnect_RejectsEmbeddedSchemes` covers all four embedded
      URL variants and verifies fail-fast (no retry backoff).
- [x] New `TestProtocol_IsSupported` covers remote + embedded Protocol values.
- [ ] Integration round-trip against `surrealkv://` / `file://` / `memory://`
      is not feasible while surrealdb.go#197 remains open; existing
      integration suite against a remote SurrealDB continues to run in CI.

## Upstream blocker

Full embedded support will re-open automatically once
[surrealdb.go#197](https://github.com/surrealdb/surrealdb.go/issues/197)
ships. Until then this PR keeps the library honest about what it can do.