### PR TITLE
chore(hooks): mirror ci.yml lint + audit jobs in pre-push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -26,8 +26,30 @@ go vet ./...
 echo "[pre-push] go build ./..."
 go build ./...
 
+# golangci-lint: matches the `lint` job in .github/workflows/ci.yml.
+# That job is `continue-on-error: true` because golangci-lint v2.1.x is
+# built with Go 1.24 and panics on `go 1.26` modules. We mirror that
+# stance locally: run if installed, never hard-block on it. Set
+# SURQL_PRE_PUSH_LINT=0 to skip entirely.
+if [[ "${SURQL_PRE_PUSH_LINT:-1}" == "1" ]] && command -v golangci-lint >/dev/null 2>&1; then
+  echo "[pre-push] golangci-lint run (non-blocking; mirrors CI continue-on-error)"
+  golangci-lint run || echo "[pre-push] golangci-lint reported issues (non-blocking)"
+else
+  echo "[pre-push] skipping golangci-lint (binary not found or SURQL_PRE_PUSH_LINT=0)"
+fi
+
 echo "[pre-push] go test ./... -race -count=1"
 go test ./... -race -count=1
+
+# govulncheck: matches .github/workflows/audit.yml. Runs on a path-filter
+# in CI (go.mod / go.sum changes) and on a nightly cron. Run locally if
+# installed; install with `go install golang.org/x/vuln/cmd/govulncheck@latest`.
+if command -v govulncheck >/dev/null 2>&1; then
+  echo "[pre-push] govulncheck ./..."
+  govulncheck ./...
+else
+  echo "[pre-push] skipping govulncheck (binary not found; install with: go install golang.org/x/vuln/cmd/govulncheck@latest)"
+fi
 
 if [[ "${SURQL_PRE_PUSH_INTEGRATION:-0}" == "1" ]]; then
   echo "[pre-push] go test -tags=integration ./... (SURQL_PRE_PUSH_INTEGRATION=1)"


### PR DESCRIPTION
## Summary
- Two CI gates were not mirrored locally: the `lint` job in `.github/workflows/ci.yml` (golangci-lint, currently `continue-on-error` due to the Go 1.26 panic in v2.1.x) and the `govulncheck` job in `.github/workflows/audit.yml`.
- Add both to `.githooks/pre-push` as **soft** steps: they run only when the binary is on `PATH`, and golangci-lint never hard-fails the push (it just logs) so it matches the CI `continue-on-error: true` stance. govulncheck behaves the same way — runs if installed, otherwise prints the install command and skips.
- No new dependencies, no CI changes, integration tests stay opt-in via `SURQL_PRE_PUSH_INTEGRATION=1`.

## CI <-> hook coverage after this change

| ci.yml job/step | hook step |
|---|---|
| gofmt -l . | covered |
| go vet ./... | covered |
| go build ./... | covered |
| golangci-lint run *(continue-on-error in CI)* | **added (non-blocking, opt-out via `SURQL_PRE_PUSH_LINT=0`)** |
| go test ./... -race | covered (`-count=1` locally) |
| govulncheck ./... *(audit.yml, path-filter + nightly)* | **added (runs if installed)** |
| Integration (`-tags=integration`, Docker SurrealDB) | opt-in via `SURQL_PRE_PUSH_INTEGRATION=1` |
| goreleaser check (release branches only) | not gated locally |

## Why soft, not hard?
- golangci-lint v2.1.x panics on `go 1.26` modules; CI itself marks it `continue-on-error`. Hard-blocking pushes on a tool the CI deliberately doesn't trust would be worse than CI.
- govulncheck is a runtime install (`go install golang.org/x/vuln/cmd/govulncheck@latest`). Hard-requiring it on every clone would silently break devs without it — instead we surface the install command in the skip message.

## Manual install reminder
`.githooks/` is opt-in per clone (per `CONTRIBUTING.md`):

```bash
git config core.hooksPath .githooks
```

To get full local coverage:

```bash
go install golang.org/x/vuln/cmd/govulncheck@latest
# golangci-lint: brew install golangci-lint  (or use the install script)
```

## Test plan
- [ ] `bash .githooks/pre-push` runs gofmt + vet + build + (lint if installed) + test + (govulncheck if installed)
- [ ] With both binaries missing, hook still passes (skip messages only)
- [ ] With `SURQL_PRE_PUSH_LINT=0`, golangci-lint is skipped explicitly
- [ ] With `SURQL_PRE_PUSH_INTEGRATION=1`, integration tests run after the unit tests