### PR TITLE
chore(license): Apache-2.0 with NOTICE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -175,7 +176,18 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 Shon Thomas
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,18 @@
+surql-go (oneiriq-surql)
+Copyright (c) 2026 Shon Thomas
+
+This product includes software developed by Shon Thomas
+(https://github.com/Oneiriq/surql-go).
+
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Per Section 4 of the License, redistributions of source code or binary
+forms must retain this NOTICE file in any distribution. If you
+substantially modify surql-go, you must clearly mark the modified
+files. You must not use the names "surql-go", "oneiriq-surql", or
+"Shon Thomas" to endorse or promote derivative products without prior
+written permission.


### PR DESCRIPTION
LICENSE on disk was GPL-3.0 while README badge already said Apache 2.0 — fixing the mismatch by replacing LICENSE with Apache-2.0 verbatim. Adds NOTICE file with attribution + endorsement clause. go.mod doesn't carry a license field per Go convention; the LICENSE/NOTICE files are the canonical source.