### PR TITLE
fix(ci): switch CI to aur0 self-hosted runner; drop macOS from push/PR

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   govulncheck:
     name: govulncheck
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   lint:
     name: golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     # golangci-lint v2.1.x is built with Go 1.24 and panics ("package
     # requires newer Go version go1.26") when linting a module with
     # `go 1.26` in go.mod. Marked continue-on-error until a
@@ -38,12 +38,13 @@ jobs:
           version: v2.1.6
 
   quality:
-    name: Lint and Test (${{ matrix.os }}, Go ${{ matrix.go }})
-    runs-on: ${{ matrix.os }}
+    # macOS coverage moved to nightly.yml; PR-time runs Linux only on the
+    # aur0 self-hosted runner to avoid burning GitHub-hosted minutes.
+    name: Lint and Test (Go ${{ matrix.go }})
+    runs-on: [self-hosted, aur0]
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
         go: ['1.26', 'stable']
     steps:
       - uses: actions/checkout@v6
@@ -75,7 +76,7 @@ jobs:
 
   integration:
     name: Integration
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v6
 
@@ -118,7 +119,7 @@ jobs:
 
   goreleaser-check:
     name: goreleaser check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.base_ref, 'release/')
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   coverage:
     name: go test -coverprofile
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   dep-review:
     name: Dependency Review
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - name: Get PR metadata
         id: meta

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v6
 
@@ -46,7 +46,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   lint-pr-title:
     name: Conventional Commit PR title
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Stops the GitHub-hosted minute bleed by routing every push/PR-triggered job to the org's `[self-hosted, aur0]` runner. macOS coverage stays on the nightly schedule.

## Per-workflow changes

| Workflow | Before | After |
|---|---|---|
| `ci.yml` | `runs-on: ubuntu-latest` for lint/integration/goreleaser-check; `quality` matrix `os: [ubuntu-latest, macos-latest]` | All Linux jobs on `[self-hosted, aur0]`; macOS dropped from `quality` matrix (kept in nightly) |
| `audit.yml` | `runs-on: ubuntu-latest` | `runs-on: [self-hosted, aur0]` |
| `coverage.yml` | `runs-on: ubuntu-latest` | `runs-on: [self-hosted, aur0]` |
| `dep-review.yml` | `runs-on: ubuntu-latest` | `runs-on: [self-hosted, aur0]` |
| `dependabot-auto-merge.yml` | `runs-on: ubuntu-latest` | `runs-on: [self-hosted, aur0]` |
| `docs.yml` | `runs-on: ubuntu-latest` (build + deploy) | `runs-on: [self-hosted, aur0]` |
| `pr-title.yml` | `runs-on: ubuntu-latest` | `runs-on: [self-hosted, aur0]` |
| `release.yml` | `runs-on: ubuntu-latest` | `runs-on: [self-hosted, aur0]` |

## Untouched

- `nightly.yml` — keeps the `os: [ubuntu-latest, macos-latest]` matrix as the cross-platform safety net for macOS coverage we drop from PR-time.

## Test plan

- [ ] aur0 runner picks up the Linux jobs
- [ ] `quality` matrix runs Go 1.26 + stable on aur0 only (no macOS rows)
- [ ] integration job still spins SurrealDB v3 successfully