### PR TITLE
feat: full-text BM25 search (1:1 with surql-rs 0.29.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,33 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 This is a pre-release port of [surql-py](https://github.com/Oneiriq/surql-py)
 targeting 1:1 feature parity. The runtime SurrealDB client, CRUD
 executor, and CLI land in the 0.1 -> 0.2 window.
+
+## [0.3.0] - 2026-06-17
+
+### Added
+
+- **Full-text search (BM25) is now first-class -- the sparse leg of hybrid
+  retrieval.** Define a `DEFINE ANALYZER` in code with `Analyzer(name, opts...)` /
+  `StandardAnalyzer(name, opts...)` (`AnalyzerDefinition` + `Tokenizer` +
+  `TokenFilter`, rendered via `GenerateAnalyzerSQL` /
+  `GenerateAnalyzerSQLIfNotExists`); build a BM25-scored full-text index with
+  `BM25Index(name, columns, analyzer)` (or
+  `SearchIndex(...).WithAnalyzer(...).WithBM25().WithHighlights()`); and run the
+  lexical query with `Query.FullTextSearch(field, reference, query)` +
+  `Query.SearchScore(reference, alias)`, or the `FullTextSearchQuery(...)`
+  helper. `GenerateSchemaSQLFromSlicesWithAnalyzers` emits analyzer DDL before
+  the tables that reference it. Pair it with `Query.VectorSearch` and fuse the
+  two result orders by rank (Reciprocal Rank Fusion).
+
+### Fixed
+
+- **Full-text index now emits the SurrealDB 3.x `FULLTEXT` keyword.** The
+  full-text index keyword was renamed from `SEARCH` to `FULLTEXT` in SurrealDB
+  3.0, so the previous output (`... SEARCH ANALYZER ascii`) was a parse error on
+  v3. `IndexTypeSearch` / `SearchIndex` / `IndexDefinition.ToSurql*` and the
+  migration diff now emit `FULLTEXT`, and the `INFO FOR TABLE` index parser
+  recognises both spellings (and extracts the analyzer / BM25 / HIGHLIGHTS
+  clauses). See `docs/v3-patterns.md` "Full-text search (BM25)" -- including the
+  note that the v3 streaming executor's full-text scan returns rows in BM25
+  relevance order but `search::score` is not plumbed through it (returns 0), so
+  rank by the scan's natural order.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A code-first database toolkit for [SurrealDB](https://surrealdb.com/). Define sc
 - **Type-Safe Query Builder** -- Immutable fluent API with operator-typed `Where`, `SelectExpr` / `SelectAliased` aggregations, function factories, and `encoding/json` struct tags
 - **v3 Interactive Transactions** -- Native `BEGIN` / `COMMIT` / `ROLLBACK` via `DatabaseClient.Begin`, plus raw record-id targets and `GROUP ALL`
 - **Vector Search** -- HNSW and MTREE index support with 8 distance metrics and EFC/M tuning
+- **Full-Text Search (BM25)** -- the lexical leg of hybrid retrieval: `DEFINE ANALYZER` in code (`Analyzer` / `StandardAnalyzer`), BM25-scored `FULLTEXT` indexes (`BM25Index`), and `Query.FullTextSearch` / `Query.SearchScore` to query and rank
 - **Graph Traversal** -- Native SurrealDB graph features with edge relationships and a fluent `GraphQuery` builder
 - **Schema Visualization** -- Mermaid, GraphViz, and ASCII diagrams with theming
 - **Full CLI** -- `surql migrate` / `schema` / `db` / `orchestrate` subcommands for the entire lifecycle

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -44,9 +44,40 @@ Chainable setters: `WithAssertion`, `WithDefault`, `WithValue`,
 
 - `Index(name, cols)`
 - `UniqueIndex(name, cols)`
-- `SearchIndex(name, cols)`
-- `MTreeIndex(name, col, opts)` with `MTreeIndexOptions{Dimension, Distance, Capacity, Cache}`
-- `HnswIndex(name, col, opts)` with `HnswIndexOptions{Dimension, Distance, EFC, M}`
+- `SearchIndex(name, cols)` -- full-text index; renders the SurrealDB 3.x
+  `FULLTEXT` keyword (see [v3 Patterns](v3-patterns.md#full-text-search-bm25))
+- `BM25Index(name, cols, analyzer)` -- BM25-scored full-text index
+- `MTreeIndex(name, col, dimension, opts)` with `MTreeIndexOptions{Distance, VectorType}`
+- `HnswIndex(name, col, dimension, opts)` with `HnswIndexOptions{Distance, VectorType, EFC, M}`
+
+Full-text indexes are chainable: `SearchIndex("s", []string{"content"}).WithAnalyzer("text_en").WithBM25().WithHighlights()`.
+`WithBM25` is required for `search::score` to return a value; `WithHighlights`
+stores positional data for `search::highlight` / `search::offsets`. With no
+analyzer set, the index renders the historical `ascii` default.
+
+## Analyzers
+
+A full-text index references an *analyzer* that turns stored and query text into
+comparable tokens (a tokenizer chain + a filter chain). Define it in code rather
+than hand-authoring SurrealQL:
+
+```go
+import "github.com/Oneiriq/surql-go/pkg/surql/schema"
+
+// class tokenizer + lowercase + ascii, plus English stemming.
+a := schema.StandardAnalyzer("text_en", schema.WithFilter(schema.Snowball("english")))
+// DEFINE ANALYZER text_en TOKENIZERS class FILTERS lowercase,ascii,snowball(english);
+ddl := a.ToSurql()
+```
+
+- Tokenizers: `TokenizerBlank` / `TokenizerCamel` / `TokenizerClass` / `TokenizerPunct`.
+- Filters: `ASCII()` / `Lowercase()` / `Uppercase()` / `EdgeNgram(min,max)` / `Ngram(min,max)` / `Snowball(lang)`.
+- `Analyzer(name, opts...)` builds an empty analyzer; `StandardAnalyzer(name, opts...)`
+  is `class` + `lowercase` + `ascii` — a sensible default for BM25 lexical recall.
+- `GenerateAnalyzerSQL(a)` / `GenerateAnalyzerSQLIfNotExists(a)` render the
+  `DEFINE ANALYZER` statement, which **must be applied before** the index that
+  references it. `GenerateSchemaSQLFromSlicesWithAnalyzers(analyzers, tables, edges, ifNotExists)`
+  emits analyzer DDL first, then tables, then edges.
 
 ## Events
 

--- a/docs/v3-patterns.md
+++ b/docs/v3-patterns.md
@@ -94,6 +94,95 @@ emits `type::thing('<table>', <id>)` for cases where the id value is
 already a typed value (int, UUID, etc). Both implement `types.Operator`
 and render verbatim wherever surql-go accepts an expression.
 
+## Full-text search (BM25)
+
+Full-text (BM25) search is the **sparse / lexical leg of hybrid retrieval** —
+pair it with `Query.VectorSearch` (the dense leg) and fuse the two result
+orders by rank (Reciprocal Rank Fusion).
+
+### `SEARCH` was renamed `FULLTEXT`
+
+SurrealDB 3.0 renamed the full-text index keyword. The v1/v2 form is a parse
+error on v3 (`Unexpected token, expected Eof` at `SEARCH`):
+
+```text
+DEFINE INDEX idx ON TABLE t COLUMNS content SEARCH ANALYZER ascii BM25;  -- parse error on v3
+```
+
+v3 spells it `FULLTEXT`:
+
+```text
+DEFINE INDEX idx ON TABLE t COLUMNS content FULLTEXT ANALYZER ascii BM25 HIGHLIGHTS;
+```
+
+surql-go emits the `FULLTEXT` keyword from `IndexTypeSearch` / `SearchIndex` /
+`BM25Index` (and the migration diff renders it the same way); the `INFO FOR
+TABLE` index parser recognises **both** spellings so historical schemas still
+round-trip. `COLUMNS` and `FIELDS` are interchangeable in this statement.
+
+Bare `BM25` uses the engine defaults (`k1 = 1.2`, `b = 0.75`); the analyzer
+defaults to `ascii` when the clause is omitted — define and name one explicitly
+for real lexical recall.
+
+### Defining the analyzer + index
+
+The analyzer is defined separately with `DEFINE ANALYZER` and **must be applied
+before** the index that references it:
+
+```go
+import "github.com/Oneiriq/surql-go/pkg/surql/schema"
+
+analyzer := schema.StandardAnalyzer("text_en") // class + lowercase + ascii
+idx := schema.BM25Index("content_bm25", []string{"content"}, "text_en")
+
+// Analyzer DDL is emitted first, then the table (with its FULLTEXT index):
+script, _ := schema.GenerateSchemaSQLFromSlicesWithAnalyzers(
+    []schema.AnalyzerDefinition{analyzer},
+    []schema.TableDefinition{
+        schema.NewTable("memory", schema.WithIndexes(idx)),
+    },
+    nil,   // edges
+    false, // ifNotExists
+)
+// DEFINE ANALYZER text_en TOKENIZERS class FILTERS lowercase,ascii;
+// DEFINE TABLE memory SCHEMAFULL;
+// DEFINE INDEX content_bm25 ON TABLE memory COLUMNS content FULLTEXT ANALYZER text_en BM25;
+```
+
+### Querying
+
+`Query.FullTextSearch(field, reference, query)` renders the `@reference@`
+matches operator in the `WHERE` clause; `Query.SearchScore(reference, alias)`
+projects `search::score(reference)`. The `FullTextSearchQuery` helper wires both
+together:
+
+```go
+import "github.com/Oneiriq/surql-go/pkg/surql/query"
+
+q, _ := query.FullTextSearchQuery(
+    "memory", "content", 1, "insider buying", nil, "score",
+)
+// SELECT *, search::score(1) AS score FROM memory WHERE content @1@ 'insider buying'
+```
+
+### `search::score` and scan ordering
+
+The v3 streaming executor's full-text scan yields matching rows **already in
+BM25 relevance order**, but does not (in 3.0.x) plumb the per-row score through
+to `search::score(<ref>)`, which returns `0` there. So **rank by the scan's
+natural order rather than `ORDER BY search::score(...)`**. This is sufficient
+for Reciprocal Rank Fusion, which fuses *ranks*, not raw scores:
+
+```go
+// The sparse leg: rows come back in relevance order; cap the candidate set.
+q, _ := query.FullTextSearchQuery("memory", "content", 1, "insider buying", nil, "score")
+q, _ = q.Limit(100)
+// Fuse the returned order with the dense (VectorSearch) order via RRF.
+```
+
+v3 also ships a native `search::rrf([$dense, $sparse], k, 60)` function that
+fuses two result lists server-side, if you prefer in-engine fusion.
+
 ## Missing-table error shape
 
 v2 treated queries against an undefined table as returning zero rows. v3

--- a/pkg/surql/migration/diff.go
+++ b/pkg/surql/migration/diff.go
@@ -813,10 +813,12 @@ func fieldToSQL(tableName string, f schema.FieldDefinition) (string, error) {
 	return b.String(), nil
 }
 
-// indexToSQL renders a DEFINE INDEX statement. Standard / UNIQUE / SEARCH
-// indexes use the basic form; MTREE and HNSW flavours route through their
-// dedicated helpers. Returns ErrValidation for MTREE / HNSW indexes missing
-// a dimension.
+// indexToSQL renders a DEFINE INDEX statement. Standard / UNIQUE / full-text
+// (FULLTEXT) indexes delegate to the canonical IndexDefinition.ToSurql so the
+// diff and the schema generator stay byte-for-byte consistent (a full-text
+// index emits the SurrealDB 3.x FULLTEXT keyword plus its analyzer / BM25 /
+// HIGHLIGHTS clauses); MTREE and HNSW flavours route through their dedicated
+// helpers. Returns ErrValidation for MTREE / HNSW indexes missing a dimension.
 func indexToSQL(tableName string, idx schema.IndexDefinition) (string, error) {
 	switch idx.Type {
 	case schema.IndexTypeMTree:
@@ -825,20 +827,7 @@ func indexToSQL(tableName string, idx schema.IndexDefinition) (string, error) {
 		return hnswIndexToSQL(tableName, idx)
 	}
 
-	var b strings.Builder
-	b.WriteString("DEFINE INDEX ")
-	b.WriteString(idx.Name)
-	b.WriteString(" ON TABLE ")
-	b.WriteString(tableName)
-	b.WriteString(" COLUMNS ")
-	b.WriteString(strings.Join(idx.Columns, ", "))
-
-	if string(idx.Type) != string(schema.IndexTypeStandard) && idx.Type != "" {
-		b.WriteString(" ")
-		b.WriteString(string(idx.Type))
-	}
-	b.WriteString(";")
-	return b.String(), nil
+	return idx.ToSurql(tableName), nil
 }
 
 func mtreeIndexToSQL(tableName string, idx schema.IndexDefinition) (string, error) {

--- a/pkg/surql/query/builder.go
+++ b/pkg/surql/query/builder.go
@@ -99,6 +99,17 @@ type Query struct {
 	VectorDistance  VectorDistanceType
 	VectorThreshold *float64
 
+	// Full-text search parameters (the `@@` / `@n@` matches operator).
+	// FulltextField is the matched column; FulltextReference is the match
+	// reference number tying the predicate to `search::score(n)` (the `@n@`
+	// form); FulltextQuery is the query text, inlined as a quoted, escaped
+	// literal. FulltextSet marks the predicate as configured so a zero
+	// reference is distinguishable from "unset".
+	FulltextField     string
+	FulltextReference int
+	FulltextQuery     string
+	FulltextSet       bool
+
 	// Hints accumulates optimization comments rendered by [RenderHints].
 	Hints []QueryHint
 }
@@ -469,6 +480,45 @@ func (q Query) SimilarityScore(field string, vector []float64, metric VectorDist
 	return out
 }
 
+// ---------------------------------------------------------------------------
+// Full-text search
+// ---------------------------------------------------------------------------
+
+// FullTextSearch configures a full-text SEARCH predicate rendered as
+// `<field> @<reference>@ <query>` in the WHERE clause.
+//
+// The reference integer ties the match to a [Query.SearchScore] (or
+// search::highlight) call, so a row's BM25 relevance can be projected and
+// ordered on. It requires a BM25 SEARCH index on field (see
+// schema.BM25Index). The query text is inlined as a quoted, escaped literal.
+// An empty field or query yields an ErrValidation error.
+func (q Query) FullTextSearch(field string, reference int, queryText string) (Query, error) {
+	if field == "" {
+		return Query{}, surqlerrors.New(surqlerrors.ErrValidation,
+			"Full-text search field cannot be empty")
+	}
+	if queryText == "" {
+		return Query{}, surqlerrors.New(surqlerrors.ErrValidation,
+			"Full-text search query cannot be empty")
+	}
+	out := q.clone()
+	out.FulltextField = field
+	out.FulltextReference = reference
+	out.FulltextQuery = queryText
+	out.FulltextSet = true
+	return out, nil
+}
+
+// SearchScore appends `search::score(<reference>) AS <alias>` to the projected
+// fields — the BM25 relevance for the match registered at reference by
+// [Query.FullTextSearch]. Order by alias to rank.
+func (q Query) SearchScore(reference int, alias string) Query {
+	expr := fmt.Sprintf("search::score(%d) AS %s", reference, alias)
+	out := q.clone()
+	out.Fields = append(out.Fields, expr)
+	return out
+}
+
 // WithReturnFormat sets the RETURN clause to a specific format.
 func (q Query) WithReturnFormat(f ReturnFormat) Query {
 	out := q.clone()
@@ -648,6 +698,10 @@ func (q Query) buildSelect() (string, error) {
 			op = fmt.Sprintf("<|%d,%s|>", *q.VectorK, string(q.VectorDistance))
 		}
 		whereParts = append(whereParts, fmt.Sprintf("%s %s %s", q.VectorField, op, vec))
+	}
+	if q.FulltextSet && q.FulltextField != "" && q.FulltextQuery != "" {
+		quoted := quoteValueExpr(q.FulltextQuery)
+		whereParts = append(whereParts, fmt.Sprintf("%s @%d@ %s", q.FulltextField, q.FulltextReference, quoted))
 	}
 	for _, c := range q.Conditions {
 		whereParts = append(whereParts, "("+c+")")

--- a/pkg/surql/query/builder_test.go
+++ b/pkg/surql/query/builder_test.go
@@ -512,3 +512,127 @@ func TestExplain_Hint(t *testing.T) {
 		t.Errorf("explain full missing: %q", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Full-text search
+// ---------------------------------------------------------------------------
+
+func TestFullTextSearch_RendersMatchOperator(t *testing.T) {
+	q, err := Query{}.Select(nil).FromTable("memory")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.FullTextSearch("content", 1, "insider buying")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := "SELECT * FROM memory WHERE content @1@ 'insider buying'"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestFullTextSearch_WithScoreAndOrder(t *testing.T) {
+	q, err := Query{}.Select(nil).SearchScore(1, "score").FromTable("memory")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.FullTextSearch("content", 1, "form 4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.OrderBy("score", "DESC")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.Limit(5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	want := "SELECT *, search::score(1) AS score FROM memory " +
+		"WHERE content @1@ 'form 4' ORDER BY score DESC LIMIT 5"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestFullTextSearch_EscapesSingleQuotes(t *testing.T) {
+	q, err := Query{}.Select(nil).FromTable("memory")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.FullTextSearch("content", 0, "o'brien")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if want := `SELECT * FROM memory WHERE content @0@ 'o\'brien'`; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestFullTextSearch_EmptyFieldRejected(t *testing.T) {
+	q, err := Query{}.Select(nil).FromTable("memory")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := q.FullTextSearch("", 1, "x"); err == nil {
+		t.Fatal("expected error for empty field")
+	} else if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestFullTextSearch_EmptyQueryRejected(t *testing.T) {
+	q, err := Query{}.Select(nil).FromTable("memory")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := q.FullTextSearch("content", 1, ""); err == nil {
+		t.Fatal("expected error for empty query")
+	} else if !errors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestFullTextSearch_AndVectorBothRenderInWhere(t *testing.T) {
+	q, err := Query{}.Select(nil).FromTable("memory")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.VectorSearch("embedding", []float64{0.1, 0.2}, 5, DistanceCosine, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err = q.FullTextSearch("content", 1, "term")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	if !strings.Contains(got, "embedding <|5,COSINE|> [0.1, 0.2]") {
+		t.Errorf("vector predicate missing in %q", got)
+	}
+	if !strings.Contains(got, "content @1@ 'term'") {
+		t.Errorf("fulltext predicate missing in %q", got)
+	}
+	if !strings.Contains(got, " AND ") {
+		t.Errorf("expected AND join in %q", got)
+	}
+}
+
+func TestSearchScore_ImmutabilityPreserved(t *testing.T) {
+	base, err := Query{}.Select(nil).FromTable("memory")
+	if err != nil {
+		t.Fatal(err)
+	}
+	scored := base.SearchScore(2, "rel")
+	baseSQL, _ := base.ToSurql()
+	if baseSQL != "SELECT * FROM memory" {
+		t.Errorf("base query mutated: %q", baseSQL)
+	}
+	scoredSQL, _ := scored.ToSurql()
+	if want := "SELECT *, search::score(2) AS rel FROM memory"; scoredSQL != want {
+		t.Errorf("got %q want %q", scoredSQL, want)
+	}
+}

--- a/pkg/surql/query/helpers.go
+++ b/pkg/surql/query/helpers.go
@@ -200,3 +200,24 @@ func SimilaritySearchQuery(
 	q = q.SimilarityScore(field, vector, distance, alias)
 	return q.VectorSearch(field, vector, k, distance, threshold)
 }
+
+// FullTextSearchQuery is the convenience builder for a full-text (BM25) search
+// — the lexical leg of hybrid retrieval. It wraps [Query.FullTextSearch] +
+// [Query.SearchScore] into `SELECT ..., search::score(reference) AS
+// <scoreAlias> FROM <table> WHERE <field> @reference@ <query>`. Pair with a
+// schema.BM25Index on field, then ORDER BY <scoreAlias> DESC to rank by
+// relevance.
+func FullTextSearchQuery(
+	table, field string,
+	reference int,
+	queryText string,
+	fields []string,
+	scoreAlias string,
+) (Query, error) {
+	q := Select(fields).SearchScore(reference, scoreAlias)
+	q, err := q.FromTable(table)
+	if err != nil {
+		return Query{}, err
+	}
+	return q.FullTextSearch(field, reference, queryText)
+}

--- a/pkg/surql/query/helpers_test.go
+++ b/pkg/surql/query/helpers_test.go
@@ -199,6 +199,34 @@ func TestHelper_SimilaritySearchQuery(t *testing.T) {
 	}
 }
 
+func TestHelper_FullTextSearchQuery(t *testing.T) {
+	q, err := FullTextSearchQuery(
+		"memory", "content", 1, "insider buying", nil, "score",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	want := "SELECT *, search::score(1) AS score FROM memory WHERE content @1@ 'insider buying'"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestHelper_FullTextSearchQuery_WithFields(t *testing.T) {
+	q, err := FullTextSearchQuery(
+		"memory", "content", 2, "form 4", []string{"id", "content"}, "rel",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := q.ToSurql()
+	want := "SELECT id, content, search::score(2) AS rel FROM memory WHERE content @2@ 'form 4'"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
 func TestReturnFormat_Values(t *testing.T) {
 	if ReturnNone.String() != "NONE" {
 		t.Error("none")

--- a/pkg/surql/schema/analyzer.go
+++ b/pkg/surql/schema/analyzer.go
@@ -1,0 +1,246 @@
+package schema
+
+import (
+	"strconv"
+	"strings"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+// A SurrealDB full-text index references an analyzer that turns stored text
+// and query text into comparable tokens — the lexical side of hybrid
+// (sparse + dense) retrieval. An analyzer is a tokenizer chain (how the text
+// is split) followed by a filter chain (how each token is normalised).
+//
+// This file renders the DEFINE ANALYZER statement from a typed
+// AnalyzerDefinition, so callers define the analyzer in code rather than
+// hand-authoring SurrealQL — exactly as TableDefinition does for tables. Pair
+// it with a BM25 SearchIndex (see BM25Index) and the
+// query.Query.FullTextSearch builder for end-to-end lexical recall.
+
+// Tokenizer splits text into terms before the filter chain runs.
+//
+// It renders as the lowercase SurrealQL keyword used inside the
+// TOKENIZERS ... clause.
+type Tokenizer string
+
+// Tokenizer values.
+const (
+	// TokenizerBlank splits on whitespace (`blank`).
+	TokenizerBlank Tokenizer = "blank"
+	// TokenizerCamel splits on case transitions (`camelCase` -> `camel`, `Case`).
+	TokenizerCamel Tokenizer = "camel"
+	// TokenizerClass splits on Unicode character-class transitions — letters,
+	// digits, and punctuation become separate tokens (`class`). The
+	// general-purpose default for prose and identifiers.
+	TokenizerClass Tokenizer = "class"
+	// TokenizerPunct splits on punctuation (`punct`).
+	TokenizerPunct Tokenizer = "punct"
+)
+
+// IsValid reports whether the Tokenizer is recognised.
+func (t Tokenizer) IsValid() bool {
+	switch t {
+	case TokenizerBlank, TokenizerCamel, TokenizerClass, TokenizerPunct:
+		return true
+	}
+	return false
+}
+
+// String renders the tokenizer as its SurrealQL keyword.
+func (t Tokenizer) String() string { return string(t) }
+
+// TokenFilterKind tags the variant of a TokenFilter.
+type TokenFilterKind string
+
+// TokenFilterKind values.
+const (
+	// FilterASCII folds accented / Unicode characters to their nearest ASCII
+	// equivalent (`ascii`).
+	FilterASCII TokenFilterKind = "ascii"
+	// FilterLowercase lowercases every token (`lowercase`).
+	FilterLowercase TokenFilterKind = "lowercase"
+	// FilterUppercase uppercases every token (`uppercase`).
+	FilterUppercase TokenFilterKind = "uppercase"
+	// FilterEdgeNgram emits edge n-grams (prefixes) of length min..=max for
+	// prefix / typeahead matching (`edgengram(min,max)`).
+	FilterEdgeNgram TokenFilterKind = "edgengram"
+	// FilterNgram emits n-grams of length min..=max (`ngram(min,max)`).
+	FilterNgram TokenFilterKind = "ngram"
+	// FilterSnowball reduces each token to its Snowball stem for the given
+	// language, e.g. `snowball(english)` — improves recall by matching word
+	// variants.
+	FilterSnowball TokenFilterKind = "snowball"
+)
+
+// TokenFilter normalises or expands each token after tokenization.
+//
+// Filters run in declaration order; each renders as the SurrealQL keyword (or
+// parameterised call) used inside the FILTERS ... clause. Use the constructor
+// helpers (ASCII, Lowercase, Uppercase, EdgeNgram, Ngram, Snowball) rather
+// than building the struct directly.
+type TokenFilter struct {
+	// Kind selects the filter variant.
+	Kind TokenFilterKind
+	// Min is the lower bound for EdgeNgram / Ngram filters.
+	Min int
+	// Max is the upper bound for EdgeNgram / Ngram filters.
+	Max int
+	// Language is the Snowball stemmer language (e.g. "english").
+	Language string
+}
+
+// ASCII builds an `ascii` token filter.
+func ASCII() TokenFilter { return TokenFilter{Kind: FilterASCII} }
+
+// Lowercase builds a `lowercase` token filter.
+func Lowercase() TokenFilter { return TokenFilter{Kind: FilterLowercase} }
+
+// Uppercase builds an `uppercase` token filter.
+func Uppercase() TokenFilter { return TokenFilter{Kind: FilterUppercase} }
+
+// EdgeNgram builds an `edgengram(min,max)` token filter spanning min..=max.
+func EdgeNgram(minLen, maxLen int) TokenFilter {
+	return TokenFilter{Kind: FilterEdgeNgram, Min: minLen, Max: maxLen}
+}
+
+// Ngram builds an `ngram(min,max)` token filter spanning min..=max.
+func Ngram(minLen, maxLen int) TokenFilter {
+	return TokenFilter{Kind: FilterNgram, Min: minLen, Max: maxLen}
+}
+
+// Snowball builds a `snowball(language)` token filter (e.g. "english").
+func Snowball(language string) TokenFilter {
+	return TokenFilter{Kind: FilterSnowball, Language: language}
+}
+
+// ToSurql renders the filter as its SurrealQL keyword / call.
+func (f TokenFilter) ToSurql() string {
+	switch f.Kind {
+	case FilterASCII, FilterLowercase, FilterUppercase:
+		return string(f.Kind)
+	case FilterEdgeNgram:
+		return "edgengram(" + strconv.Itoa(f.Min) + "," + strconv.Itoa(f.Max) + ")"
+	case FilterNgram:
+		return "ngram(" + strconv.Itoa(f.Min) + "," + strconv.Itoa(f.Max) + ")"
+	case FilterSnowball:
+		return "snowball(" + f.Language + ")"
+	default:
+		return string(f.Kind)
+	}
+}
+
+// String implements fmt.Stringer, matching ToSurql.
+func (f TokenFilter) String() string { return f.ToSurql() }
+
+// AnalyzerDefinition is an immutable DEFINE ANALYZER schema definition: a named
+// tokenizer + filter chain referenced by a full-text SearchIndex.
+type AnalyzerDefinition struct {
+	// Name is the analyzer name (referenced by a full-text index's
+	// ANALYZER <name> clause).
+	Name string
+	// Tokenizers are applied, in order, to split the text.
+	Tokenizers []Tokenizer
+	// Filters are applied, in order, to normalise each token.
+	Filters []TokenFilter
+}
+
+// AnalyzerOption customises an AnalyzerDefinition created via Analyzer /
+// StandardAnalyzer.
+type AnalyzerOption func(*AnalyzerDefinition)
+
+// WithTokenizer appends one tokenizer to the analyzer definition.
+func WithTokenizer(tokenizer Tokenizer) AnalyzerOption {
+	return func(a *AnalyzerDefinition) { a.Tokenizers = append(a.Tokenizers, tokenizer) }
+}
+
+// WithTokenizers appends several tokenizers to the analyzer definition.
+func WithTokenizers(tokenizers ...Tokenizer) AnalyzerOption {
+	return func(a *AnalyzerDefinition) { a.Tokenizers = append(a.Tokenizers, tokenizers...) }
+}
+
+// WithFilter appends one filter to the analyzer definition.
+func WithFilter(filter TokenFilter) AnalyzerOption {
+	return func(a *AnalyzerDefinition) { a.Filters = append(a.Filters, filter) }
+}
+
+// WithFilters appends several filters to the analyzer definition.
+func WithFilters(filters ...TokenFilter) AnalyzerOption {
+	return func(a *AnalyzerDefinition) { a.Filters = append(a.Filters, filters...) }
+}
+
+// Analyzer constructs an AnalyzerDefinition with the given name and options.
+// With no options it is an empty analyzer (no tokenizers or filters yet),
+// which renders just `DEFINE ANALYZER <name>;`.
+func Analyzer(name string, opts ...AnalyzerOption) AnalyzerDefinition {
+	a := AnalyzerDefinition{Name: name}
+	for _, opt := range opts {
+		opt(&a)
+	}
+	return a
+}
+
+// StandardAnalyzer is a sensible general-purpose analyzer for BM25 lexical
+// recall: the `class` tokenizer with `lowercase` + `ascii` filters. Apply
+// WithFilter(Snowball("english")) for language-specific stemming.
+func StandardAnalyzer(name string, opts ...AnalyzerOption) AnalyzerDefinition {
+	base := []AnalyzerOption{
+		WithTokenizer(TokenizerClass),
+		WithFilters(Lowercase(), ASCII()),
+	}
+	return Analyzer(name, append(base, opts...)...)
+}
+
+// Validate checks the analyzer definition.
+//
+// It returns an ErrValidation error when the name is empty.
+func (a AnalyzerDefinition) Validate() error {
+	if a.Name == "" {
+		return surqlerrors.New(surqlerrors.ErrValidation, "analyzer name cannot be empty")
+	}
+	return nil
+}
+
+// ToSurql renders the DEFINE ANALYZER statement.
+func (a AnalyzerDefinition) ToSurql() string {
+	return a.toSurql(false)
+}
+
+// ToSurqlIfNotExists renders the DEFINE ANALYZER statement with IF NOT EXISTS
+// so it can be re-applied idempotently (e.g. a persistent store applying its
+// schema on every connect). Empty tokenizer / filter chains omit their clause
+// entirely.
+func (a AnalyzerDefinition) ToSurqlIfNotExists() string {
+	return a.toSurql(true)
+}
+
+func (a AnalyzerDefinition) toSurql(ifNotExists bool) string {
+	var b strings.Builder
+	b.WriteString("DEFINE ANALYZER")
+	if ifNotExists {
+		b.WriteString(" IF NOT EXISTS")
+	}
+	b.WriteString(" ")
+	b.WriteString(a.Name)
+
+	if len(a.Tokenizers) > 0 {
+		toks := make([]string, len(a.Tokenizers))
+		for i, t := range a.Tokenizers {
+			toks[i] = string(t)
+		}
+		b.WriteString(" TOKENIZERS ")
+		b.WriteString(strings.Join(toks, ","))
+	}
+
+	if len(a.Filters) > 0 {
+		filters := make([]string, len(a.Filters))
+		for i, f := range a.Filters {
+			filters[i] = f.ToSurql()
+		}
+		b.WriteString(" FILTERS ")
+		b.WriteString(strings.Join(filters, ","))
+	}
+
+	b.WriteString(";")
+	return b.String()
+}

--- a/pkg/surql/schema/analyzer_test.go
+++ b/pkg/surql/schema/analyzer_test.go
@@ -1,0 +1,102 @@
+package schema
+
+import (
+	stdErrors "errors"
+	"testing"
+
+	surqlerrors "github.com/Oneiriq/surql-go/pkg/surql/errors"
+)
+
+func TestTokenizer_Strings(t *testing.T) {
+	cases := map[Tokenizer]string{
+		TokenizerBlank: "blank",
+		TokenizerCamel: "camel",
+		TokenizerClass: "class",
+		TokenizerPunct: "punct",
+	}
+	for tok, want := range cases {
+		if got := tok.String(); got != want {
+			t.Errorf("Tokenizer(%v).String() = %q, want %q", tok, got, want)
+		}
+	}
+}
+
+func TestTokenFilter_Renders(t *testing.T) {
+	cases := []struct {
+		filter TokenFilter
+		want   string
+	}{
+		{ASCII(), "ascii"},
+		{Lowercase(), "lowercase"},
+		{Uppercase(), "uppercase"},
+		{EdgeNgram(2, 10), "edgengram(2,10)"},
+		{Ngram(1, 3), "ngram(1,3)"},
+		{Snowball("english"), "snowball(english)"},
+	}
+	for _, c := range cases {
+		if got := c.filter.ToSurql(); got != c.want {
+			t.Errorf("filter.ToSurql() = %q, want %q", got, c.want)
+		}
+	}
+}
+
+func TestAnalyzer_MinimalRendersNameOnly(t *testing.T) {
+	got := Analyzer("plain").ToSurql()
+	if want := "DEFINE ANALYZER plain;"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestAnalyzer_RendersTokenizersAndFilters(t *testing.T) {
+	a := Analyzer("text_en",
+		WithTokenizers(TokenizerClass, TokenizerCamel),
+		WithFilters(Lowercase(), ASCII()),
+	)
+	got := a.ToSurql()
+	want := "DEFINE ANALYZER text_en TOKENIZERS class,camel FILTERS lowercase,ascii;"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestAnalyzer_IfNotExists(t *testing.T) {
+	got := StandardAnalyzer("std").ToSurqlIfNotExists()
+	want := "DEFINE ANALYZER IF NOT EXISTS std TOKENIZERS class FILTERS lowercase,ascii;"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestStandardAnalyzer_IsClassLowercaseAscii(t *testing.T) {
+	got := StandardAnalyzer("std").ToSurql()
+	want := "DEFINE ANALYZER std TOKENIZERS class FILTERS lowercase,ascii;"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestAnalyzer_WithSnowball(t *testing.T) {
+	a := StandardAnalyzer("text_en", WithFilter(Snowball("english")))
+	got := a.ToSurql()
+	want := "DEFINE ANALYZER text_en TOKENIZERS class FILTERS lowercase,ascii,snowball(english);"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestAnalyzer_ValidateRejectsEmptyName(t *testing.T) {
+	a := Analyzer("")
+	err := a.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for empty name")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestAnalyzer_ValidatePassesWithName(t *testing.T) {
+	if err := StandardAnalyzer("text_en").Validate(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/pkg/surql/schema/parser.go
+++ b/pkg/surql/schema/parser.go
@@ -191,6 +191,11 @@ func ParseIndex(indexName, definition string) (IndexDefinition, error) {
 		idx.HnswDistance = extractHnswDistance(definition)
 		idx.EFC = extractHnswEFC(definition)
 		idx.M = extractHnswM(definition)
+	case IndexTypeSearch:
+		idx.Analyzer = extractIndexAnalyzer(definition)
+		up := strings.ToUpper(definition)
+		idx.BM25 = strings.Contains(up, "BM25")
+		idx.Highlights = strings.Contains(up, "HIGHLIGHTS")
 	}
 
 	return idx, nil
@@ -496,13 +501,14 @@ func extractFlexible(def string) bool {
 // -----------------------------------------------------------------------------
 
 var (
-	reIndexColumns = regexp.MustCompile(`(?i)COLUMNS\s+([^;]+?)(?:\s+UNIQUE\b|\s+SEARCH\b|\s+HNSW\b|\s+MTREE\b|\s*;|\s*$)`)
-	reIndexFields  = regexp.MustCompile(`(?i)FIELDS\s+([^;]+?)(?:\s+UNIQUE\b|\s+SEARCH\b|\s+HNSW\b|\s+MTREE\b|\s*;|\s*$)`)
+	reIndexColumns = regexp.MustCompile(`(?i)COLUMNS\s+([^;]+?)(?:\s+UNIQUE\b|\s+FULLTEXT\b|\s+SEARCH\b|\s+HNSW\b|\s+MTREE\b|\s*;|\s*$)`)
+	reIndexFields  = regexp.MustCompile(`(?i)FIELDS\s+([^;]+?)(?:\s+UNIQUE\b|\s+FULLTEXT\b|\s+SEARCH\b|\s+HNSW\b|\s+MTREE\b|\s*;|\s*$)`)
 	reIndexDim     = regexp.MustCompile(`(?i)DIMENSION\s+(\d+)`)
 	reIndexDist    = regexp.MustCompile(`(?i)(?:DIST|DISTANCE)\s+([A-Za-z_]\w*)`)
 	reVectorType   = regexp.MustCompile(`(?i)TYPE\s+([A-Za-z_]\w*)`)
 	reIndexEFC     = regexp.MustCompile(`(?i)\bEFC\s+(\d+)`)
 	reIndexM       = regexp.MustCompile(`(?i)\bM\s+(\d+)`)
+	reIndexAnlzr   = regexp.MustCompile(`(?i)ANALYZER\s+(\w+)`)
 )
 
 func splitColumns(raw string) []string {
@@ -540,11 +546,27 @@ func extractIndexType(def string) IndexType {
 		return IndexTypeHNSW
 	case strings.Contains(up, "MTREE"):
 		return IndexTypeMTree
-	case strings.Contains(up, "SEARCH"):
+	case strings.Contains(up, "FULLTEXT"), strings.Contains(up, "SEARCH"):
+		// SurrealDB 3.x renamed the full-text keyword SEARCH -> FULLTEXT;
+		// recognise both spellings so v1/v2 and v3 INFO output round-trip.
 		return IndexTypeSearch
 	default:
 		return IndexTypeStandard
 	}
+}
+
+// extractIndexAnalyzer pulls the `ANALYZER <name>` analyzer name out of a
+// full-text DEFINE INDEX statement. The historical `ascii` default (what a
+// plain SearchIndex renders) normalises back to "" so a round-trip of the
+// default form is an identity, leaving an explicit non-`ascii` analyzer set.
+func extractIndexAnalyzer(def string) string {
+	if m := reIndexAnlzr.FindStringSubmatch(def); len(m) == 2 {
+		if strings.EqualFold(m[1], "ascii") {
+			return ""
+		}
+		return m[1]
+	}
+	return ""
 }
 
 func extractMtreeDimension(def string) int {

--- a/pkg/surql/schema/parser_test.go
+++ b/pkg/surql/schema/parser_test.go
@@ -486,6 +486,114 @@ func TestParseIndex_RoundTripHnsw(t *testing.T) {
 	}
 }
 
+func TestParseIndex_FulltextKeyword(t *testing.T) {
+	idx, err := ParseIndex("s",
+		"DEFINE INDEX s ON TABLE doc COLUMNS content FULLTEXT ANALYZER text_en BM25 HIGHLIGHTS;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx.Type != IndexTypeSearch {
+		t.Errorf("Type = %q, want SEARCH", idx.Type)
+	}
+	if !reflect.DeepEqual(idx.Columns, []string{"content"}) {
+		t.Errorf("Columns = %v", idx.Columns)
+	}
+	if idx.Analyzer != "text_en" {
+		t.Errorf("Analyzer = %q, want text_en", idx.Analyzer)
+	}
+	if !idx.BM25 {
+		t.Error("expected BM25 = true")
+	}
+	if !idx.Highlights {
+		t.Error("expected Highlights = true")
+	}
+}
+
+func TestParseIndex_LegacySearchKeyword(t *testing.T) {
+	// The v1/v2 SEARCH spelling is still recognised so historical INFO output
+	// round-trips into the same IndexTypeSearch.
+	idx, err := ParseIndex("s",
+		"DEFINE INDEX s ON TABLE doc COLUMNS content SEARCH ANALYZER text_en BM25;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx.Type != IndexTypeSearch {
+		t.Errorf("Type = %q, want SEARCH", idx.Type)
+	}
+	if idx.Analyzer != "text_en" {
+		t.Errorf("Analyzer = %q, want text_en", idx.Analyzer)
+	}
+	if !idx.BM25 {
+		t.Error("expected BM25 = true")
+	}
+	if idx.Highlights {
+		t.Error("expected Highlights = false")
+	}
+}
+
+func TestParseIndex_FulltextAsciiNormalizesToUnset(t *testing.T) {
+	// The historical `ascii` default normalises back to "" so the default
+	// SearchIndex form round-trips as an identity.
+	idx, err := ParseIndex("content_search",
+		"DEFINE INDEX content_search ON TABLE post COLUMNS title, content FULLTEXT ANALYZER ascii;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx.Type != IndexTypeSearch {
+		t.Errorf("Type = %q, want SEARCH", idx.Type)
+	}
+	if idx.Analyzer != "" {
+		t.Errorf("Analyzer = %q, want \"\" (ascii normalises to unset)", idx.Analyzer)
+	}
+	if idx.BM25 || idx.Highlights {
+		t.Errorf("expected no BM25/HIGHLIGHTS, got bm25=%v highlights=%v", idx.BM25, idx.Highlights)
+	}
+}
+
+func TestParseIndex_RoundTripSearchDefault(t *testing.T) {
+	orig := SearchIndex("content_search", []string{"title", "content"})
+	parsed, err := ParseIndex(orig.Name, orig.ToSurql("post"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Type != orig.Type {
+		t.Errorf("Type: got %q, want %q", parsed.Type, orig.Type)
+	}
+	if !reflect.DeepEqual(parsed.Columns, orig.Columns) {
+		t.Errorf("Columns: got %v, want %v", parsed.Columns, orig.Columns)
+	}
+	if parsed.Analyzer != orig.Analyzer {
+		t.Errorf("Analyzer: got %q, want %q", parsed.Analyzer, orig.Analyzer)
+	}
+	if parsed.BM25 != orig.BM25 || parsed.Highlights != orig.Highlights {
+		t.Errorf("flags differ: parsed bm25=%v hl=%v, orig bm25=%v hl=%v",
+			parsed.BM25, parsed.Highlights, orig.BM25, orig.Highlights)
+	}
+}
+
+func TestParseIndex_RoundTripBM25(t *testing.T) {
+	orig := BM25Index("content_bm25", []string{"content"}, "text_en").WithHighlights()
+	parsed, err := ParseIndex(orig.Name, orig.ToSurql("memory"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Type != IndexTypeSearch {
+		t.Errorf("Type = %q, want SEARCH", parsed.Type)
+	}
+	if !reflect.DeepEqual(parsed.Columns, orig.Columns) {
+		t.Errorf("Columns: got %v, want %v", parsed.Columns, orig.Columns)
+	}
+	if parsed.Analyzer != "text_en" {
+		t.Errorf("Analyzer = %q, want text_en", parsed.Analyzer)
+	}
+	if !parsed.BM25 {
+		t.Error("expected BM25 = true")
+	}
+	if !parsed.Highlights {
+		t.Error("expected Highlights = true")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // ParseEvent
 // ---------------------------------------------------------------------------

--- a/pkg/surql/schema/sql.go
+++ b/pkg/surql/schema/sql.go
@@ -39,6 +39,31 @@ func GenerateAccessSQL(access AccessDefinition) []string {
 	return []string{access.ToSurql()}
 }
 
+// GenerateAnalyzerSQL emits the DEFINE ANALYZER statement(s) for an analyzer
+// definition. It validates first, returning an ErrValidation error for an
+// invalid definition (e.g. an empty name), and otherwise returns a
+// single-element slice so the output type matches the other generators.
+//
+// A full-text index defined with BM25Index / SearchIndex references its
+// analyzer by name; the DEFINE ANALYZER statement must be applied BEFORE the
+// DEFINE INDEX that references it.
+func GenerateAnalyzerSQL(analyzer AnalyzerDefinition) ([]string, error) {
+	if err := analyzer.Validate(); err != nil {
+		return nil, err
+	}
+	return []string{analyzer.ToSurql()}, nil
+}
+
+// GenerateAnalyzerSQLIfNotExists is like GenerateAnalyzerSQL but emits the
+// DEFINE ANALYZER statement with IF NOT EXISTS for idempotent re-application
+// (e.g. a persistent store applying its schema on every connect).
+func GenerateAnalyzerSQLIfNotExists(analyzer AnalyzerDefinition) ([]string, error) {
+	if err := analyzer.Validate(); err != nil {
+		return nil, err
+	}
+	return []string{analyzer.ToSurqlIfNotExists()}, nil
+}
+
 // GenerateSchemaSQL composes a full SurrealQL schema script from every table
 // and edge registered in r. Tables are emitted first (in sorted order),
 // followed by edges (also sorted). Each definition group is separated by a
@@ -58,7 +83,7 @@ func GenerateSchemaSQL(r *SchemaRegistry, ifNotExists bool) (string, error) {
 	tables := r.Tables()
 	edges := r.Edges()
 
-	return generateSchemaScript(tables, edges, ifNotExists)
+	return generateSchemaScript(nil, tables, edges, ifNotExists)
 }
 
 // GenerateSchemaSQLFromSlices composes a full SurrealQL schema script from the
@@ -66,15 +91,43 @@ func GenerateSchemaSQL(r *SchemaRegistry, ifNotExists bool) (string, error) {
 // emitted in the order provided (callers sort first if determinism is
 // required).
 func GenerateSchemaSQLFromSlices(tables []TableDefinition, edges []EdgeDefinition, ifNotExists bool) (string, error) {
-	return generateSchemaScript(tables, edges, ifNotExists)
+	return generateSchemaScript(nil, tables, edges, ifNotExists)
 }
 
-func generateSchemaScript(tables []TableDefinition, edges []EdgeDefinition, ifNotExists bool) (string, error) {
-	if len(tables) == 0 && len(edges) == 0 {
+// GenerateSchemaSQLFromSlicesWithAnalyzers is GenerateSchemaSQLFromSlices with
+// a leading slice of DEFINE ANALYZER definitions. Analyzer DDL is emitted
+// FIRST — before any table — because a full-text index references its analyzer
+// by name and the DEFINE ANALYZER must already exist when the DEFINE INDEX is
+// applied. An invalid analyzer (e.g. an empty name) yields an ErrValidation
+// error. Inputs are emitted in the order provided.
+func GenerateSchemaSQLFromSlicesWithAnalyzers(analyzers []AnalyzerDefinition, tables []TableDefinition, edges []EdgeDefinition, ifNotExists bool) (string, error) {
+	return generateSchemaScript(analyzers, tables, edges, ifNotExists)
+}
+
+func generateSchemaScript(analyzers []AnalyzerDefinition, tables []TableDefinition, edges []EdgeDefinition, ifNotExists bool) (string, error) {
+	if len(analyzers) == 0 && len(tables) == 0 && len(edges) == 0 {
 		return "", nil
 	}
 
-	stmts := make([]string, 0, len(tables)*3+len(edges)*3)
+	stmts := make([]string, 0, len(analyzers)+len(tables)*3+len(edges)*3)
+
+	for _, a := range analyzers {
+		var (
+			analyzerStmts []string
+			err           error
+		)
+		if ifNotExists {
+			analyzerStmts, err = GenerateAnalyzerSQLIfNotExists(a)
+		} else {
+			analyzerStmts, err = GenerateAnalyzerSQL(a)
+		}
+		if err != nil {
+			return "", surqlerrors.Wrapf(surqlerrors.ErrValidation, err,
+				"failed to generate SQL for analyzer %q", a.Name)
+		}
+		stmts = append(stmts, analyzerStmts...)
+		stmts = append(stmts, "")
+	}
 
 	for _, t := range tables {
 		stmts = append(stmts, GenerateTableSQL(t, ifNotExists)...)

--- a/pkg/surql/schema/sql_test.go
+++ b/pkg/surql/schema/sql_test.go
@@ -96,6 +96,33 @@ func TestGenerateTableSQL_WithStandardIndex(t *testing.T) {
 	}
 }
 
+func TestGenerateTableSQL_WithSearchIndex(t *testing.T) {
+	tbl := NewTable("post",
+		WithIndexes(SearchIndex("content_search", []string{"content"})),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, "FULLTEXT ANALYZER ascii") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected FULLTEXT ANALYZER clause in stmts = %v", stmts)
+	}
+}
+
+func TestGenerateTableSQL_WithBM25Index(t *testing.T) {
+	tbl := NewTable("memory",
+		WithIndexes(BM25Index("content_bm25", []string{"content"}, "text_en")),
+	)
+	stmts := GenerateTableSQL(tbl, false)
+	want := "DEFINE INDEX content_bm25 ON TABLE memory COLUMNS content FULLTEXT ANALYZER text_en BM25;"
+	if !hasExact(stmts, want) {
+		t.Errorf("expected %q in stmts = %v", want, stmts)
+	}
+}
+
 func TestGenerateTableSQL_WithEvent(t *testing.T) {
 	tbl := NewTable("user",
 		WithEvents(NewEvent("email_changed",
@@ -406,6 +433,77 @@ func TestGenerateSchemaSQLFromSlices_PreservesOrder(t *testing.T) {
 	}
 	if zIdx > aIdx {
 		t.Errorf("slice order not preserved: z at %d, a at %d", zIdx, aIdx)
+	}
+}
+
+// ---------- GenerateAnalyzerSQL ----------
+
+func TestGenerateAnalyzerSQL_Standard(t *testing.T) {
+	stmts, err := GenerateAnalyzerSQL(StandardAnalyzer("text_en"))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1 statement, got %d: %v", len(stmts), stmts)
+	}
+	want := "DEFINE ANALYZER text_en TOKENIZERS class FILTERS lowercase,ascii;"
+	if stmts[0] != want {
+		t.Errorf("got %q want %q", stmts[0], want)
+	}
+}
+
+func TestGenerateAnalyzerSQL_IfNotExists(t *testing.T) {
+	stmts, err := GenerateAnalyzerSQLIfNotExists(Analyzer("plain"))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if want := "DEFINE ANALYZER IF NOT EXISTS plain;"; stmts[0] != want {
+		t.Errorf("got %q want %q", stmts[0], want)
+	}
+}
+
+func TestGenerateAnalyzerSQL_Validates(t *testing.T) {
+	_, err := GenerateAnalyzerSQL(Analyzer(""))
+	if err == nil {
+		t.Fatal("expected validation error for empty analyzer name")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestGenerateSchemaSQLFromSlicesWithAnalyzers_AnalyzerBeforeTables(t *testing.T) {
+	analyzers := []AnalyzerDefinition{StandardAnalyzer("text_en")}
+	tables := []TableDefinition{
+		NewTable("memory", WithIndexes(BM25Index("content_bm25", []string{"content"}, "text_en"))),
+	}
+	sql, err := GenerateSchemaSQLFromSlicesWithAnalyzers(analyzers, tables, nil, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	analyzerIdx := strings.Index(sql, "DEFINE ANALYZER text_en")
+	indexIdx := strings.Index(sql, "FULLTEXT ANALYZER text_en BM25")
+	if analyzerIdx == -1 {
+		t.Fatalf("missing DEFINE ANALYZER in sql = %q", sql)
+	}
+	if indexIdx == -1 {
+		t.Fatalf("missing FULLTEXT index in sql = %q", sql)
+	}
+	// The analyzer DDL must precede the index that references it.
+	if analyzerIdx > indexIdx {
+		t.Errorf("analyzer at %d should precede index at %d; sql = %q", analyzerIdx, indexIdx, sql)
+	}
+}
+
+func TestGenerateSchemaSQLFromSlicesWithAnalyzers_InvalidAnalyzerErrors(t *testing.T) {
+	_, err := GenerateSchemaSQLFromSlicesWithAnalyzers(
+		[]AnalyzerDefinition{Analyzer("")}, nil, nil, false,
+	)
+	if err == nil {
+		t.Fatal("expected error for invalid analyzer")
+	}
+	if !stdErrors.Is(err, surqlerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
 	}
 }
 

--- a/pkg/surql/schema/table.go
+++ b/pkg/surql/schema/table.go
@@ -134,6 +134,16 @@ type IndexDefinition struct {
 	HnswDistance HnswDistanceType
 	EFC          int // zero means unset
 	M            int // zero means unset
+
+	// Full-text SEARCH-specific. Analyzer is the analyzer name; an empty
+	// string renders the historical default (`ascii`). BM25 emits the
+	// relevance-scoring clause (with the engine's default k1/b parameters),
+	// required for query.Query.SearchScore to return a value. Highlights
+	// stores positional HIGHLIGHTS data (enables search::highlight /
+	// search::offsets).
+	Analyzer   string
+	BM25       bool
+	Highlights bool
 }
 
 // EventDefinition captures a DEFINE EVENT trigger.
@@ -312,9 +322,42 @@ func UniqueIndex(name string, columns []string) IndexDefinition {
 	return NewIndex(name, columns, IndexTypeUnique)
 }
 
-// SearchIndex is sugar for NewIndex(name, columns, IndexTypeSearch).
+// SearchIndex is sugar for NewIndex(name, columns, IndexTypeSearch). With no
+// analyzer set it renders the historical `ascii` default; chain WithAnalyzer /
+// WithBM25 / WithHighlights for a scorable index, or use BM25Index.
 func SearchIndex(name string, columns []string) IndexDefinition {
 	return NewIndex(name, columns, IndexTypeSearch)
+}
+
+// BM25Index builds a BM25-scored full-text SEARCH index over columns, analyzed
+// by analyzer. This is the index to pair with query.Query.FullTextSearch and
+// query.Query.SearchScore for lexical recall — BM25 is what makes
+// search::score return a relevance value.
+func BM25Index(name string, columns []string, analyzer string) IndexDefinition {
+	return SearchIndex(name, columns).WithAnalyzer(analyzer).WithBM25()
+}
+
+// WithAnalyzer sets the full-text SEARCH analyzer (e.g. one defined via
+// Analyzer / StandardAnalyzer). Only affects SEARCH indexes; when unset the
+// index renders the historical `ascii` analyzer. Returns a modified copy.
+func (i IndexDefinition) WithAnalyzer(analyzer string) IndexDefinition {
+	i.Analyzer = analyzer
+	return i
+}
+
+// WithBM25 emits the BM25 relevance-scoring clause on a SEARCH index (with the
+// engine's default parameters). Required for query.Query.SearchScore. Returns
+// a modified copy.
+func (i IndexDefinition) WithBM25() IndexDefinition {
+	i.BM25 = true
+	return i
+}
+
+// WithHighlights stores positional HIGHLIGHTS data on a SEARCH index. Returns
+// a modified copy.
+func (i IndexDefinition) WithHighlights() IndexDefinition {
+	i.Highlights = true
+	return i
 }
 
 // MTreeIndexOptions configures an MTREE vector index.
@@ -499,7 +542,18 @@ func (i IndexDefinition) toSurql(tableName string, ifNotExists bool) string {
 	case IndexTypeUnique:
 		b.WriteString(" UNIQUE")
 	case IndexTypeSearch:
-		b.WriteString(" SEARCH ANALYZER ascii")
+		analyzer := i.Analyzer
+		if analyzer == "" {
+			analyzer = "ascii"
+		}
+		b.WriteString(" FULLTEXT ANALYZER ")
+		b.WriteString(analyzer)
+		if i.BM25 {
+			b.WriteString(" BM25")
+		}
+		if i.Highlights {
+			b.WriteString(" HIGHLIGHTS")
+		}
 	}
 
 	b.WriteString(";")

--- a/pkg/surql/schema/table_test.go
+++ b/pkg/surql/schema/table_test.go
@@ -179,12 +179,63 @@ func TestTableStatements_WithSearchIndex(t *testing.T) {
 	stmts := tbl.ToSurqlStatements()
 	found := false
 	for _, s := range stmts {
-		if s == "DEFINE INDEX content_search ON TABLE post COLUMNS title, content SEARCH ANALYZER ascii;" {
+		if s == "DEFINE INDEX content_search ON TABLE post COLUMNS title, content FULLTEXT ANALYZER ascii;" {
 			found = true
 		}
 	}
 	if !found {
 		t.Errorf("expected search index statement: %v", stmts)
+	}
+}
+
+func TestSearchIndex_ToSurqlDefaultsToFulltextAscii(t *testing.T) {
+	idx := SearchIndex("content_search", []string{"title", "content"})
+	got := idx.ToSurql("post")
+	want := "DEFINE INDEX content_search ON TABLE post COLUMNS title, content FULLTEXT ANALYZER ascii;"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestBM25Index_RendersAnalyzerAndBM25(t *testing.T) {
+	idx := BM25Index("content_bm25", []string{"content"}, "text_en")
+	got := idx.ToSurql("memory")
+	want := "DEFINE INDEX content_bm25 ON TABLE memory COLUMNS content FULLTEXT ANALYZER text_en BM25;"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestSearchIndex_WithAnalyzerBM25Highlights(t *testing.T) {
+	idx := SearchIndex("s", []string{"content"}).
+		WithAnalyzer("text_en").
+		WithBM25().
+		WithHighlights()
+	got := idx.ToSurql("doc")
+	want := "DEFINE INDEX s ON TABLE doc COLUMNS content FULLTEXT ANALYZER text_en BM25 HIGHLIGHTS;"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestBM25Index_IfNotExists(t *testing.T) {
+	idx := BM25Index("content_bm25", []string{"content"}, "text_en")
+	got := idx.ToSurqlIfNotExists("memory")
+	want := "DEFINE INDEX IF NOT EXISTS content_bm25 ON TABLE memory COLUMNS content FULLTEXT ANALYZER text_en BM25;"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestWithAnalyzer_ReturnsModifiedCopy(t *testing.T) {
+	base := SearchIndex("s", []string{"content"})
+	scored := base.WithAnalyzer("text_en").WithBM25()
+	// The original is unchanged (value-receiver clone-on-mutate).
+	if base.Analyzer != "" || base.BM25 {
+		t.Errorf("base index mutated: analyzer=%q bm25=%v", base.Analyzer, base.BM25)
+	}
+	if scored.Analyzer != "text_en" || !scored.BM25 {
+		t.Errorf("derived index missing config: analyzer=%q bm25=%v", scored.Analyzer, scored.BM25)
 	}
 }
 


### PR DESCRIPTION
Ports the full-text BM25 feature to parity with the sibling libraries (surql-rs v0.29.0, surql, surql-py).

**Added:** `AnalyzerDefinition` + `Tokenizer`/`TokenFilter` (`Analyzer`/`StandardAnalyzer`); BM25 `FULLTEXT` index (`BM25Index`, `WithAnalyzer`/`WithBM25`/`WithHighlights`); full-text query (`FullTextSearch`/`SearchScore` + `FullTextSearchQuery`); `GenerateAnalyzerSQL`.
**Fixed:** SurrealDB 3.x `SEARCH`→`FULLTEXT` keyword (old form was a parse error on v3); parser accepts both; migration diff emits FULLTEXT. See docs/v3-patterns.md.

Target version 0.3.0 (CHANGELOG). Gates (via Docker golang:1.26): `go test ./... -race` ok, `go vet` ok, golangci-lint zero findings in changed files. No tag/release in this PR.