### PR TITLE
docs(changelog): retitle [Unreleased] to 0.4.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-07-30
 
 ### Added
 


### PR DESCRIPTION
Release housekeeping per repo convention: the [Unreleased] files/buckets + sessions section becomes 0.4.0 dated today, ahead of the v0.4.0 tag.