### PR TITLE
feat(graph): add row-level conditions; fix v3 incoming-edge ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Row-level filtering on the graph helpers (`conditions`).** `Traverse`,
+  `TraverseWithDepth`, `GetOutgoingEdges`, `GetIncomingEdges`,
+  `GetRelatedRecords`, and `ShortestPath` take a trailing `conditions []any`.
+  Each entry is rendered by `Query.Where`, so raw SurrealQL strings and
+  `types.Operator` values are both accepted and may be mixed in one slice;
+  entries combine with `AND`. Pass `nil` to filter nothing. Restores parity
+  with the sibling ports, which have accepted `conditions` on their graph
+  helpers since surql-py 1.6.0.
+
+  Previously these helpers emitted a bare `SELECT * FROM record->edge` with no
+  filtering hook at all, so a caller needing row-level isolation -- a mandatory
+  `WHERE tenant_id = ...` alongside engine-enforced `PERMISSIONS` -- could not
+  express it and had to abandon the helpers for a hand-rolled
+  equality-filtered edge table.
+
+### Fixed
+
+- **`GetIncomingEdges` and `CountRelated` (incoming direction) were broken on
+  SurrealDB v3.** Both emitted the Python port's `FROM <-edge<-record`
+  ordering, which v3 rejects outright: `SELECT * FROM <-follows<-person:bob`
+  fails to parse with ``Unexpected token `;` `` (verified against v3.0.5).
+  Both now put the record at the head of the `FROM` expression
+  (`FROM record<-edge`), matching the ordering the Rust port already used.
+  Any caller relying on incoming-edge traversal was receiving a parse error.
+
+### Changed
+
+- **Graph helpers compose through `Query` instead of `fmt.Sprintf`.** Every
+  `SELECT`-shaped helper now builds its statement with
+  `NewQuery().Select(nil).FromTable(...).Traverse(...)` rather than
+  interpolating identifiers into a format string. Statement construction moved
+  into `selectTraversalSurql` / `applyConditions`, which are unit-testable
+  without a live client.
+
+- **BREAKING -- graph helper signatures.** The six helpers above take a new
+  trailing `conditions []any` parameter. Go has no default arguments, so this
+  follows the package's existing convention for optional arguments (as
+  `TraverseWithDepth`'s `depth *int` already does). Existing call sites migrate
+  by passing `nil`, which leaves the emitted SurrealQL unchanged. `CountRelated`
+  is deliberately **not** given `conditions` -- surql-py does not filter it
+  either, and diverging would break the 1:1 contract.
+
 ## [0.4.0] - 2026-07-30
 
 ### Added

--- a/pkg/surql/query/graph.go
+++ b/pkg/surql/query/graph.go
@@ -69,6 +69,43 @@ func recordToString(record any, role string) (string, error) {
 	}
 }
 
+// applyConditions appends each entry of conditions to q as a WHERE
+// clause. Entries combine with AND and each is rendered by
+// [Query.Where], so raw SurrealQL strings and types.Operator values are
+// both accepted and may be mixed in one slice. A nil or empty slice is
+// a no-op, which is what keeps the emitted SurrealQL unchanged for
+// callers that do not filter.
+func applyConditions(q Query, conditions []any) (Query, error) {
+	for _, condition := range conditions {
+		next, err := q.Where(condition)
+		if err != nil {
+			return Query{}, err
+		}
+		q = next
+	}
+	return q, nil
+}
+
+// selectTraversalSurql renders `SELECT * FROM <start><path> [WHERE ...];`.
+//
+// Split out from the helpers so statement construction is testable
+// without a live client.
+func selectTraversalSurql(start, path string, conditions []any) (string, error) {
+	q, err := NewQuery().Select(nil).FromTable(start)
+	if err != nil {
+		return "", err
+	}
+	q, err = applyConditions(q.Traverse(path), conditions)
+	if err != nil {
+		return "", err
+	}
+	stmt, err := q.ToSurql()
+	if err != nil {
+		return "", err
+	}
+	return stmt + ";", nil
+}
+
 // Traverse navigates the graph from a starting record along a raw
 // SurrealQL path (e.g. `->likes->post`, `<-follows<-user`) and returns
 // the destination rows. Mirrors surql-py's traverse.
@@ -76,11 +113,18 @@ func recordToString(record any, role string) (string, error) {
 // Path is injected verbatim — callers compose paths from validated
 // identifiers via TraverseWithDepth or by building the path
 // themselves.
+//
+// conditions are appended as WHERE clauses combined with AND; each
+// entry may be a raw SurrealQL string or a types.Operator. Pass nil to
+// filter nothing. This is the hook for row-level isolation — a
+// traversal that must stay inside a tenant boundary carries its guard
+// here rather than abandoning the helper.
 func Traverse(
 	ctx context.Context,
 	client *connection.DatabaseClient,
 	start any,
 	path string,
+	conditions []any,
 ) ([]map[string]any, error) {
 	if client == nil {
 		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
@@ -92,7 +136,11 @@ func Traverse(
 	if path == "" {
 		return nil, surqlerrors.New(surqlerrors.ErrValidation, "path cannot be empty")
 	}
-	raw, err := client.Query(ctx, fmt.Sprintf("SELECT * FROM %s%s;", startStr, path))
+	stmt, err := selectTraversalSurql(startStr, path, conditions)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := client.Query(ctx, stmt)
 	if err != nil {
 		return nil, err
 	}
@@ -111,6 +159,7 @@ func TraverseWithDepth(
 	edgeTable, targetTable string,
 	direction TraverseDirection,
 	depth *int,
+	conditions []any,
 ) ([]map[string]any, error) {
 	if client == nil {
 		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
@@ -133,7 +182,7 @@ func TraverseWithDepth(
 		depthStr = fmt.Sprintf("%d", *depth)
 	}
 	path := fmt.Sprintf("%s%s%s%s%s", arrow, edgeTable, depthStr, arrow, targetTable)
-	return Traverse(ctx, client, start, path)
+	return Traverse(ctx, client, start, path, conditions)
 }
 
 // CreateRelation opens a single RELATE statement between two records,
@@ -210,6 +259,7 @@ func GetOutgoingEdges(
 	client *connection.DatabaseClient,
 	record any,
 	edgeTable string,
+	conditions []any,
 ) ([]map[string]any, error) {
 	if client == nil {
 		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
@@ -221,7 +271,10 @@ func GetOutgoingEdges(
 	if err != nil {
 		return nil, err
 	}
-	stmt := fmt.Sprintf("SELECT * FROM %s->%s;", recordStr, edgeTable)
+	stmt, err := selectTraversalSurql(recordStr, "->"+edgeTable, conditions)
+	if err != nil {
+		return nil, err
+	}
 	raw, err := client.Query(ctx, stmt)
 	if err != nil {
 		if isTableMissingError(err) {
@@ -233,12 +286,20 @@ func GetOutgoingEdges(
 }
 
 // GetIncomingEdges returns every edge of `edgeTable` terminating at
-// `record`. Mirrors surql-py's get_incoming_edges.
+// `record`.
+//
+// Deviates from the Python source's `FROM <-edge<-record` ordering:
+// SurrealDB v3 requires the record at the head of the `FROM`
+// expression (`FROM record<-edge`). The Python shape is a parse error
+// on v3 -- verified against v3.0.5, which rejects
+// `SELECT * FROM <-follows<-person:bob` with "Unexpected token `;`".
+// This matches the ordering the Rust port already uses.
 func GetIncomingEdges(
 	ctx context.Context,
 	client *connection.DatabaseClient,
 	record any,
 	edgeTable string,
+	conditions []any,
 ) ([]map[string]any, error) {
 	if client == nil {
 		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
@@ -250,7 +311,10 @@ func GetIncomingEdges(
 	if err != nil {
 		return nil, err
 	}
-	stmt := fmt.Sprintf("SELECT * FROM <-%s<-%s;", edgeTable, recordStr)
+	stmt, err := selectTraversalSurql(recordStr, "<-"+edgeTable, conditions)
+	if err != nil {
+		return nil, err
+	}
 	raw, err := client.Query(ctx, stmt)
 	if err != nil {
 		if isTableMissingError(err) {
@@ -271,6 +335,7 @@ func GetRelatedRecords(
 	record any,
 	edgeTable, targetTable string,
 	direction TraverseDirection,
+	conditions []any,
 ) ([]map[string]any, error) {
 	if client == nil {
 		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
@@ -297,7 +362,11 @@ func GetRelatedRecords(
 			"invalid direction %q: must be \"out\" or \"in\"", string(direction),
 		)
 	}
-	raw, err := client.Query(ctx, fmt.Sprintf("SELECT * FROM %s%s;", recordStr, path))
+	stmt, err := selectTraversalSurql(recordStr, path, conditions)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := client.Query(ctx, stmt)
 	if err != nil {
 		if isTableMissingError(err) {
 			return nil, nil
@@ -328,20 +397,29 @@ func CountRelated(
 	if err != nil {
 		return 0, err
 	}
-	var target string
+	var path string
 	switch direction {
 	case TraverseOut, "":
-		target = fmt.Sprintf("%s->%s", recordStr, edgeTable)
+		path = "->" + edgeTable
 	case TraverseIn:
-		target = fmt.Sprintf("<-%s<-%s", edgeTable, recordStr)
+		// Record-first, as in GetIncomingEdges: `FROM <-edge<-record`
+		// is a parse error on SurrealDB v3.
+		path = "<-" + edgeTable
 	default:
 		return 0, surqlerrors.Newf(
 			surqlerrors.ErrValidation,
 			"invalid direction %q: must be \"out\" or \"in\"", string(direction),
 		)
 	}
-	stmt := fmt.Sprintf("SELECT count() FROM %s GROUP ALL;", target)
-	raw, err := client.Query(ctx, stmt)
+	counted, err := NewQuery().Select([]string{"count()"}).FromTable(recordStr)
+	if err != nil {
+		return 0, err
+	}
+	stmt, err := counted.Traverse(path).GroupAll().ToSurql()
+	if err != nil {
+		return 0, err
+	}
+	raw, err := client.Query(ctx, stmt+";")
 	if err != nil {
 		if isTableMissingError(err) {
 			return 0, nil
@@ -372,6 +450,7 @@ func ShortestPath(
 	fromRecord, toRecord any,
 	edgeTable string,
 	maxDepth int,
+	conditions []any,
 ) ([]map[string]any, error) {
 	if client == nil {
 		return nil, surqlerrors.New(surqlerrors.ErrValidation, "client cannot be nil")
@@ -393,7 +472,14 @@ func ShortestPath(
 	step := "->" + edgeTable + "->?"
 	for depth := 1; depth <= maxDepth; depth++ {
 		path := strings.Repeat(step, depth)
-		stmt := fmt.Sprintf("SELECT * FROM %s%s WHERE id = %s;", fromStr, path, toStr)
+		// The identity predicate leads; caller guards narrow it further.
+		guards := make([]any, 0, len(conditions)+1)
+		guards = append(guards, fmt.Sprintf("id = %s", toStr))
+		guards = append(guards, conditions...)
+		stmt, err := selectTraversalSurql(fromStr, path, guards)
+		if err != nil {
+			return nil, err
+		}
 		raw, err := client.Query(ctx, stmt)
 		if err != nil {
 			if isTableMissingError(err) {

--- a/pkg/surql/query/graph_integration_test.go
+++ b/pkg/surql/query/graph_integration_test.go
@@ -39,6 +39,7 @@ func TestIntegration_Traverse(t *testing.T) {
 	got, err := Traverse(ctx, client,
 		"surqlgo_graph_user:alice",
 		"->surqlgo_graph_likes->surqlgo_graph_post",
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("Traverse: %v", err)
@@ -51,7 +52,7 @@ func TestIntegration_Traverse(t *testing.T) {
 	got2, err := TraverseWithDepth(ctx, client,
 		"surqlgo_graph_user:alice",
 		"surqlgo_graph_likes", "surqlgo_graph_post",
-		TraverseOut, nil,
+		TraverseOut, nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("TraverseWithDepth: %v", err)
@@ -87,7 +88,7 @@ func TestIntegration_ShortestPath(t *testing.T) {
 
 	got, err := ShortestPath(ctx, client,
 		"surqlgo_graph_sp_user:a", "surqlgo_graph_sp_user:c",
-		"surqlgo_graph_sp_follows", 5,
+		"surqlgo_graph_sp_follows", 5, nil,
 	)
 	if err != nil {
 		t.Fatalf("ShortestPath: %v", err)

--- a/pkg/surql/query/graph_test.go
+++ b/pkg/surql/query/graph_test.go
@@ -78,7 +78,7 @@ func TestRecordToString(t *testing.T) {
 }
 
 func TestTraverse_NilClientRejected(t *testing.T) {
-	_, err := Traverse(context.Background(), nil, "user:alice", "->follows->user")
+	_, err := Traverse(context.Background(), nil, "user:alice", "->follows->user", nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -89,7 +89,7 @@ func TestTraverse_EmptyPathRejected(t *testing.T) {
 	// rely on the client guard firing first. Instead reach the path
 	// check by using the helper via TraverseWithDepth which validates
 	// before touching the client.
-	_, err := Traverse(context.Background(), nil, "", "")
+	_, err := Traverse(context.Background(), nil, "", "", nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -99,7 +99,7 @@ func TestTraverseWithDepth_InvalidDirection(t *testing.T) {
 	_, err := TraverseWithDepth(
 		context.Background(), nil,
 		"user:alice", "follows", "user",
-		TraverseDirection("diagonal"), nil,
+		TraverseDirection("diagonal"), nil, nil,
 	)
 	if err == nil {
 		t.Fatal("expected error")
@@ -110,7 +110,7 @@ func TestTraverseWithDepth_InvalidEdge(t *testing.T) {
 	_, err := TraverseWithDepth(
 		context.Background(), nil,
 		"user:alice", "bad edge", "user",
-		TraverseOut, nil,
+		TraverseOut, nil, nil,
 	)
 	if err == nil {
 		t.Fatal("expected error")
@@ -121,7 +121,7 @@ func TestTraverseWithDepth_InvalidTarget(t *testing.T) {
 	_, err := TraverseWithDepth(
 		context.Background(), nil,
 		"user:alice", "follows", "bad target",
-		TraverseOut, nil,
+		TraverseOut, nil, nil,
 	)
 	if err == nil {
 		t.Fatal("expected error")
@@ -133,7 +133,7 @@ func TestTraverseWithDepth_NegativeDepthRejected(t *testing.T) {
 	_, err := TraverseWithDepth(
 		context.Background(), nil,
 		"user:alice", "follows", "user",
-		TraverseOut, &d,
+		TraverseOut, &d, nil,
 	)
 	if err == nil {
 		t.Fatal("expected error")
@@ -155,14 +155,14 @@ func TestRemoveRelation_NilClient(t *testing.T) {
 }
 
 func TestGetOutgoingEdges_NilClient(t *testing.T) {
-	_, err := GetOutgoingEdges(context.Background(), nil, "user:a", "follows")
+	_, err := GetOutgoingEdges(context.Background(), nil, "user:a", "follows", nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
 }
 
 func TestGetIncomingEdges_NilClient(t *testing.T) {
-	_, err := GetIncomingEdges(context.Background(), nil, "user:a", "follows")
+	_, err := GetIncomingEdges(context.Background(), nil, "user:a", "follows", nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -172,7 +172,7 @@ func TestGetRelatedRecords_InvalidDirection(t *testing.T) {
 	_, err := GetRelatedRecords(
 		context.Background(), nil,
 		"user:a", "follows", "user",
-		TraverseBoth,
+		TraverseBoth, nil,
 	)
 	if err == nil {
 		t.Fatal("expected error for 'both' direction in GetRelatedRecords")
@@ -191,14 +191,14 @@ func TestCountRelated_InvalidDirection(t *testing.T) {
 }
 
 func TestShortestPath_InvalidEdge(t *testing.T) {
-	_, err := ShortestPath(context.Background(), nil, "user:a", "user:b", "bad edge", 5)
+	_, err := ShortestPath(context.Background(), nil, "user:a", "user:b", "bad edge", 5, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
 }
 
 func TestShortestPath_NilClient(t *testing.T) {
-	_, err := ShortestPath(context.Background(), nil, "user:a", "user:b", "follows", 5)
+	_, err := ShortestPath(context.Background(), nil, "user:a", "user:b", "follows", 5, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -223,5 +223,91 @@ func TestBuildGraphPath(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// --- conditions on the graph helpers -------------------------------------
+
+func TestSelectTraversalSurql_NoConditionsIsUnchanged(t *testing.T) {
+	// Guards the refactor onto the Query builder: with no conditions the
+	// emitted statement must match what the previous Sprintf produced.
+	got, err := selectTraversalSurql("user:alice", "->likes->post", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "SELECT * FROM user:alice->likes->post;"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSelectTraversalSurql_EmptySliceMatchesNil(t *testing.T) {
+	withNil, err := selectTraversalSurql("user:alice", "->likes->post", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	withEmpty, err := selectTraversalSurql("user:alice", "->likes->post", []any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if withNil != withEmpty {
+		t.Errorf("empty slice %q differs from nil %q", withEmpty, withNil)
+	}
+}
+
+func TestSelectTraversalSurql_OperatorCondition(t *testing.T) {
+	got, err := selectTraversalSurql("user:alice", "->likes->post",
+		[]any{types.EqOp("tenant_id", "acme")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "SELECT * FROM user:alice->likes->post WHERE (tenant_id = 'acme');"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSelectTraversalSurql_RawFragmentCondition(t *testing.T) {
+	got, err := selectTraversalSurql("user:alice", "->likes->post", []any{"age > 18"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "SELECT * FROM user:alice->likes->post WHERE (age > 18);"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSelectTraversalSurql_MixedConditionsCombineWithAnd(t *testing.T) {
+	// One slice, both forms, joined by AND in the order given -- the
+	// `str | Operator` union the sibling ports accept.
+	got, err := selectTraversalSurql("user:alice", "->likes->post",
+		[]any{types.EqOp("tenant_id", "acme"), "age > 18"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "SELECT * FROM user:alice->likes->post WHERE (tenant_id = 'acme') AND (age > 18);"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSelectTraversalSurql_RejectsInvalidCondition(t *testing.T) {
+	if _, err := selectTraversalSurql("user:alice", "->likes->post", []any{42}); err == nil {
+		t.Fatal("expected error for a non-string, non-Operator condition")
+	}
+}
+
+// TestIncomingPathIsRecordFirst pins the v3 ordering fix: SurrealDB v3
+// rejects `FROM <-edge<-record` with a parse error, so incoming
+// traversals must put the record at the head of FROM.
+func TestIncomingPathIsRecordFirst(t *testing.T) {
+	got, err := selectTraversalSurql("person:bob", "<-follows", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "SELECT * FROM person:bob<-follows;"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
Go half of the graph-helper parity work. Rust half: Oneiriq/surql-rs#145 (merged).

## Why

`query`'s graph helpers emitted a bare `SELECT * FROM record->edge` with **no filtering hook at all**. A caller needing row-level isolation -- a mandatory `WHERE tenant_id = ...` alongside engine-enforced `PERMISSIONS` -- could not express it, and had to abandon the helpers for a hand-rolled equality-filtered edge table.

This is a **polyglot parity gap**: `surql-py` has accepted `conditions` on these helpers since 1.6.0 and `surql` (TS) carries it too. Go and Rust were the two ports still missing it.

## What

- `conditions []any` on `Traverse`, `TraverseWithDepth`, `GetOutgoingEdges`, `GetIncomingEdges`, `GetRelatedRecords`, `ShortestPath`. Entries combine with `AND`; `nil` filters nothing.
  - **No new `Condition` type needed** (unlike the Rust port, which had to add one): `Query.Where` already takes `any` and type-switches over `string | types.Operator`, so `[]any` is the natural analogue of surql-py's `list[str | Operator]`.
  - `CountRelated` is **excluded** -- surql-py does not filter it either, and diverging would break 1:1.
- **The `SELECT`-shaped helpers now compose through `Query` instead of `fmt.Sprintf`.** The builder already had everything required -- `Traverse`, `Where`, `GroupAll`, and a `FromTable` that accepts a record id -- it was simply never used here. That single omission is what left *both* the missing filter hook and the identifier-interpolation surface in place.
- Statement construction extracted into `selectTraversalSurql` / `applyConditions`, unit-testable without a live client.

## Bug found while refactoring

`GetIncomingEdges` and `CountRelated`'s incoming branch both emitted the Python port's `FROM <-edge<-record` ordering. **SurrealDB v3 rejects that outright.** Verified against a throwaway v3.0.5 instance:

```
SELECT * FROM <-follows<-person:bob;   -- Parse error: Unexpected token `;`
SELECT * FROM person:bob<-follows;     -- returns the edge
```

So incoming-edge traversal in this port has never worked on v3 -- any caller was getting a parse error back. Both now put the record at the head of `FROM`, which is the ordering the Rust port already used and documented. Pinned by a unit test.

## Breaking

The six helpers take a new trailing parameter. Go has no default arguments, so this follows the package's existing convention for optional arguments, as `TraverseWithDepth`'s `depth *int` already does. **Existing call sites migrate by passing `nil`, which leaves the emitted SurrealQL unchanged** -- there is a test asserting exactly that.

## Verification

- 7 new unit tests: no-conditions-unchanged, empty-slice-equals-nil, operator, raw fragment, mixed AND-combined, invalid-condition rejection, and the record-first incoming ordering.
- `go build ./...`, `go vet ./pkg/surql/query/`, and `go vet -tags=integration ./pkg/surql/query/` all clean; full `go test ./...` green.
- Integration test call sites updated for the new signature.

## Note on line endings

The first push of this branch failed three checks on gofmt. Cause: this repo has `core.autocrlf = false` locally while surql-rs has `true`, so CRLF working-copy line endings were committed verbatim into the index for the three files touched here (`graph_test.go` came out mixed, from an LF heredoc appended to a CRLF file). Every other file in the repo is `i/lf`, which is why CI flagged only these three.

Fixed by normalising those three files to LF and amending, so the diff stays content-only rather than whole-file churn. `git ls-files --eol` now reports `i/lf w/lf` for all three.

A repo-level `.gitattributes` with `* text=auto eol=lf` would prevent this recurring, but that is a repo-wide behaviour change and is deliberately **not** bundled here -- it belongs in its own PR.

CHANGELOG `[Unreleased]` updated. Tag-based versioning, so no version file to bump. No release cut.