### PR TITLE
feat(schema,query): DISKANN indexes, the F16 element type, and index-backed KNN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,43 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   express it and had to abandon the helpers for a hand-rolled
   equality-filtered edge table.
 
+- **DISKANN vector indexes and the F16 element type (SurrealDB 3.2).**
+  `IndexTypeDiskAnn` and `DiskAnnIndex(name, column, dimension,
+  DiskAnnIndexOptions{...})` define the on-disk ANN graph the 3.2 engine
+  parses, with `DiskAnnDistanceType` for the metric (`COSINE` /
+  `COSINE_NORMALIZED` / `EUCLIDEAN` / `INNER_PRODUCT`). It is its own type
+  because the engine's DISKANN metric set neither contains nor is contained by
+  the HNSW one, so an out-of-set metric is unrepresentable rather than merely
+  refused. `MTreeVectorType` gained `F16`, `I8`, and `U8`, which HNSW also
+  accepts, alongside `ValidForMTree` / `ValidForDiskAnn` predicates. The
+  schema emitter, the `INFO FOR TABLE` parser, and the migration diff all
+  carry the new form.
+
+  The engine echoes a DISKANN index with `DIST` / `TYPE` / `DEGREE` /
+  `L_BUILD` / `ALPHA` always spelled, defaults `EUCLIDEAN` / `F32` / 64 / 100
+  / 1.2 filled in even when the definition never stated them, and a float
+  `ALPHA` carrying a trailing `f` suffix (`ALPHA 1.2f`). The emitter spells
+  the defaults, `CanonicalAlpha` renders a whole number bare (`ALPHA 2`), and
+  the parser excludes the `f` from its capture, so a definition compares equal
+  to its own echo instead of re-applying on every reconcile.
+
+  `IndexDefinition.Validate` refuses what the engine refuses, by name: a
+  DISKANN element type outside `F32` / `F16` / `I8` / `U8`, an MTREE element
+  type among the new `F16` / `I8` / `U8` (MTREE still parses only its
+  historical five), and an MTREE/HNSW metric aimed at a DISKANN index, which
+  only `DiskAnnDistance` can carry.
+
+- **`Query.VectorSearchIndexed(field, vector, k, ef)` reaches a vector
+  index.** The second argument of the KNN operator decides the plan: an
+  integer is the exploration factor and the engine answers with a `KnnScan`
+  over the field's HNSW or DISKANN index, while a metric keyword there asks
+  for an exhaustive `KnnTopK` over a table scan. Only the metric form existed,
+  so a query against an indexed column scanned the table and the index it was
+  paying to build served nothing. `VectorSearch` keeps its meaning for a
+  deliberate exhaustive comparison; reach for the new method whenever the
+  column carries an index. The metric belongs to the index, so the new method
+  takes none.
+
 ### Fixed
 
 - **`GetIncomingEdges` and `CountRelated` (incoming direction) were broken on
@@ -33,6 +70,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Both now put the record at the head of the `FROM` expression
   (`FROM record<-edge`), matching the ordering the Rust port already used.
   Any caller relying on incoming-edge traversal was receiving a parse error.
+
+- **The `INFO FOR TABLE` parser dropped unrecognised vector element types.**
+  `extractVectorType` matched against a fixed set of five, so an index
+  defined with any newer element type parsed back with an empty type and the
+  next reconcile saw a difference that was not there. The map now covers every
+  member of `MTreeVectorType`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A code-first database toolkit for [SurrealDB](https://surrealdb.com/). Define sc
 - **Code-First Migrations** -- Schema changes defined in code with automatic migration generation (auto-diff + `.surql` file output with `-- @up` / `-- @down` sections, squash, watcher, auto-snapshot hooks)
 - **Type-Safe Query Builder** -- Immutable fluent API with operator-typed `Where`, `SelectExpr` / `SelectAliased` aggregations, function factories, and `encoding/json` struct tags
 - **v3 Interactive Transactions** -- Native `BEGIN` / `COMMIT` / `ROLLBACK` via `DatabaseClient.Begin`, plus raw record-id targets and `GROUP ALL`
-- **Vector Search** -- HNSW and MTREE index support with 8 distance metrics and EFC/M tuning
+- **Vector Search** -- HNSW, DISKANN, and MTREE index support with 8 distance metrics, EFC/M tuning, F16 half-precision vectors, and index-backed KNN
 - **Full-Text Search (BM25)** -- the lexical leg of hybrid retrieval: `DEFINE ANALYZER` in code (`Analyzer` / `StandardAnalyzer`), BM25-scored `FULLTEXT` indexes (`BM25Index`), and `Query.FullTextSearch` / `Query.SearchScore` to query and rank
 - **Graph Traversal** -- Native SurrealDB graph features with edge relationships and a fluent `GraphQuery` builder
 - **Schema Visualization** -- Mermaid, GraphViz, and ASCII diagrams with theming

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ Define schemas, generate migrations, build queries, and perform typed CRUD
 - **v3 Transactions** -- Native interactive `BEGIN` / `COMMIT` / `ROLLBACK`
   via `DatabaseClient.Begin`, plus raw record-id targets
   (`types.TypeRecord` / `types.TypeThing`) and `GROUP ALL` aggregation.
-- **Vector Search** -- HNSW and MTREE index support with 8 distance metrics
+- **Vector Search** -- HNSW, DISKANN, and MTREE index support with 8 distance metrics, F16 half-precision vectors, and index-backed KNN
   and EFC/M tuning.
 - **Graph Traversal** -- Native SurrealDB graph features with edge
   relationships + fluent `GraphQuery` builder.

--- a/pkg/surql/migration/diff.go
+++ b/pkg/surql/migration/diff.go
@@ -998,15 +998,29 @@ func fieldToSQL(tableName string, f schema.FieldDefinition) (string, error) {
 // diff and the schema generator stay byte-for-byte consistent (a full-text
 // index emits the SurrealDB 3.x FULLTEXT keyword plus its analyzer / BM25 /
 // HIGHLIGHTS clauses); MTREE and HNSW flavours route through their dedicated
-// helpers. Returns ErrValidation for MTREE / HNSW indexes missing a dimension.
+// helpers. Returns ErrValidation for a vector index missing a dimension.
 func indexToSQL(tableName string, idx schema.IndexDefinition) (string, error) {
 	switch idx.Type {
 	case schema.IndexTypeMTree:
 		return mtreeIndexToSQL(tableName, idx)
 	case schema.IndexTypeHNSW:
 		return hnswIndexToSQL(tableName, idx)
+	case schema.IndexTypeDiskAnn:
+		return diskAnnIndexToSQL(tableName, idx)
 	}
 
+	return idx.ToSurql(tableName), nil
+}
+
+// diskAnnIndexToSQL guards the dimension and then delegates to the canonical
+// renderer. Unlike the MTREE and HNSW helpers it does not restate the clause
+// order, because the DISKANN form has engine defaults that must be spelled
+// exactly and a second copy of them is a second place to get them wrong.
+func diskAnnIndexToSQL(tableName string, idx schema.IndexDefinition) (string, error) {
+	if idx.Dimension <= 0 {
+		return "", surqlerrors.Newf(surqlerrors.ErrValidation,
+			"DISKANN index %q must have dimension specified", idx.Name)
+	}
 	return idx.ToSurql(tableName), nil
 }
 

--- a/pkg/surql/migration/diff_test.go
+++ b/pkg/surql/migration/diff_test.go
@@ -1185,3 +1185,36 @@ func TestDiffTablesModifyFieldAndIndex(t *testing.T) {
 		t.Errorf("expected 1 add_index, got %d", len(findByOp(diffs, DiffOperationAddIndex)))
 	}
 }
+
+func TestIndexToSQL_DiskAnn(t *testing.T) {
+	idx := schema.DiskAnnIndex("emb_idx", "embedding", 1536, schema.DiskAnnIndexOptions{
+		Distance:   schema.DiskAnnDistanceCosine,
+		VectorType: schema.MTreeVectorF16,
+	})
+	got, err := indexToSQL("documents", idx)
+	if err != nil {
+		t.Fatalf("indexToSQL: %v", err)
+	}
+	want := "DEFINE INDEX emb_idx ON TABLE documents COLUMNS embedding DISKANN DIMENSION 1536 " +
+		"DIST COSINE TYPE F16 DEGREE 64 L_BUILD 100 ALPHA 1.2;"
+	if got != want {
+		t.Errorf("indexToSQL = %q, want %q", got, want)
+	}
+	// The migration path and the schema path must agree, or a migrated index
+	// differs from a reconciled one.
+	if got != idx.ToSurql("documents") {
+		t.Errorf("migration emitter and schema emitter disagree:\n got %q\nwant %q",
+			got, idx.ToSurql("documents"))
+	}
+}
+
+func TestIndexToSQL_DiskAnnRefusesAMissingDimension(t *testing.T) {
+	idx := schema.IndexDefinition{
+		Name:    "bad",
+		Columns: []string{"v"},
+		Type:    schema.IndexTypeDiskAnn,
+	}
+	if _, err := indexToSQL("documents", idx); err == nil {
+		t.Error("a zero dimension was accepted, want a refusal")
+	}
+}

--- a/pkg/surql/query/builder.go
+++ b/pkg/surql/query/builder.go
@@ -98,6 +98,7 @@ type Query struct {
 	VectorK         *int
 	VectorDistance  VectorDistanceType
 	VectorThreshold *float64
+	VectorEF        *int
 
 	// Full-text search parameters (the `@@` / `@n@` matches operator).
 	// FulltextField is the matched column; FulltextReference is the match
@@ -466,6 +467,48 @@ func (q Query) VectorSearch(
 	return out, nil
 }
 
+// VectorSearchIndexed configures an index-backed k-nearest-neighbour search,
+// rendering the integer exploration form `<|k,ef|>`.
+//
+// The second argument of the KNN operator decides the plan. An integer is the
+// exploration factor and the engine answers with a KnnScan over the field's
+// HNSW or DISKANN index; a metric keyword there asks for an exhaustive KnnTopK
+// over a table scan instead. Use this method whenever the field carries a
+// vector index, and VectorSearch only when an exhaustive comparison is what
+// you want.
+//
+// The metric belongs to the index, so this method takes none. The bare `<|k|>`
+// form of the KTree era is a parse error on SurrealDB 3.x.
+func (q Query) VectorSearchIndexed(
+	field string,
+	vector []float64,
+	k int,
+	ef int,
+) (Query, error) {
+	if k < 1 {
+		return Query{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"k must be at least 1, got %d", k)
+	}
+	if ef < 1 {
+		return Query{}, surqlerrors.Newf(surqlerrors.ErrValidation,
+			"ef must be at least 1, got %d", ef)
+	}
+	if len(vector) == 0 {
+		return Query{}, surqlerrors.New(surqlerrors.ErrValidation, "Vector cannot be empty")
+	}
+	kv, efv := k, ef
+	out := q.clone()
+	out.VectorField = field
+	out.VectorValue = append([]float64(nil), vector...)
+	out.VectorK = &kv
+	out.VectorEF = &efv
+	// Clear the exhaustive members so a chained call cannot leave both forms
+	// armed and quietly fall back to a table scan.
+	out.VectorDistance = ""
+	out.VectorThreshold = nil
+	return out, nil
+}
+
 // SimilarityScore adds `vector::similarity::<metric>(field, vector) AS alias`
 // to the projection.
 func (q Query) SimilarityScore(field string, vector []float64, metric VectorDistanceType, alias string) Query {
@@ -689,12 +732,16 @@ func (q Query) buildSelect() (string, error) {
 	parts = append(parts, q.JoinClauses...)
 
 	var whereParts []string
-	if q.VectorField != "" && len(q.VectorValue) > 0 && q.VectorK != nil && q.VectorDistance != "" {
+	if q.VectorField != "" && len(q.VectorValue) > 0 && q.VectorK != nil &&
+		(q.VectorDistance != "" || q.VectorEF != nil) {
 		vec := renderVectorLiteral(q.VectorValue)
 		var op string
-		if q.VectorThreshold != nil {
+		switch {
+		case q.VectorEF != nil:
+			op = fmt.Sprintf("<|%d,%d|>", *q.VectorK, *q.VectorEF)
+		case q.VectorThreshold != nil:
 			op = fmt.Sprintf("<|%d,%s,%s|>", *q.VectorK, string(q.VectorDistance), formatFloat(*q.VectorThreshold))
-		} else {
+		default:
 			op = fmt.Sprintf("<|%d,%s|>", *q.VectorK, string(q.VectorDistance))
 		}
 		whereParts = append(whereParts, fmt.Sprintf("%s %s %s", q.VectorField, op, vec))

--- a/pkg/surql/query/builder_test.go
+++ b/pkg/surql/query/builder_test.go
@@ -636,3 +636,64 @@ func TestSearchScore_ImmutabilityPreserved(t *testing.T) {
 		t.Errorf("got %q want %q", scoredSQL, want)
 	}
 }
+
+// The second argument of the KNN operator decides the plan: an integer is the
+// exploration factor and reaches the field's index, while a metric keyword
+// asks for an exhaustive scan.
+func TestVectorSearchIndexed_RendersTheIntegerForm(t *testing.T) {
+	q, err := Query{}.Select(nil).FromTable("documents")
+	if err != nil {
+		t.Fatalf("FromTable: %v", err)
+	}
+	q, err = q.VectorSearchIndexed("embedding", []float64{0.1, 0.2, 0.3}, 10, 40)
+	if err != nil {
+		t.Fatalf("VectorSearchIndexed: %v", err)
+	}
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatalf("ToSurql: %v", err)
+	}
+	if want := "SELECT * FROM documents WHERE embedding <|10,40|> [0.1, 0.2, 0.3]"; got != want {
+		t.Errorf("ToSurql = %q, want %q", got, want)
+	}
+}
+
+func TestVectorSearchIndexed_ClearsAPreviouslySetMetric(t *testing.T) {
+	// Chaining must not leave both forms armed, which would render the metric
+	// and quietly return to a table scan.
+	q, err := Query{}.Select(nil).FromTable("documents")
+	if err != nil {
+		t.Fatalf("FromTable: %v", err)
+	}
+	threshold := 0.7
+	q, err = q.VectorSearch("embedding", []float64{0.1, 0.2}, 5, DistanceCosine, &threshold)
+	if err != nil {
+		t.Fatalf("VectorSearch: %v", err)
+	}
+	q, err = q.VectorSearchIndexed("embedding", []float64{0.1, 0.2}, 5, 64)
+	if err != nil {
+		t.Fatalf("VectorSearchIndexed: %v", err)
+	}
+	got, err := q.ToSurql()
+	if err != nil {
+		t.Fatalf("ToSurql: %v", err)
+	}
+	if !strings.Contains(got, "<|5,64|>") {
+		t.Errorf("indexed form missing: %q", got)
+	}
+	if strings.Contains(got, "COSINE") {
+		t.Errorf("the exhaustive metric survived: %q", got)
+	}
+}
+
+func TestVectorSearchIndexed_Refusals(t *testing.T) {
+	if _, err := (Query{}).VectorSearchIndexed("embedding", []float64{0.1}, 0, 40); err == nil {
+		t.Error("k of 0 accepted, want a refusal")
+	}
+	if _, err := (Query{}).VectorSearchIndexed("embedding", []float64{0.1}, 10, 0); err == nil {
+		t.Error("ef of 0 accepted, want a refusal")
+	}
+	if _, err := (Query{}).VectorSearchIndexed("embedding", nil, 10, 40); err == nil {
+		t.Error("empty vector accepted, want a refusal")
+	}
+}

--- a/pkg/surql/schema/diskann_test.go
+++ b/pkg/surql/schema/diskann_test.go
@@ -1,0 +1,271 @@
+package schema
+
+import (
+	"strings"
+	"testing"
+)
+
+// The rendered shapes here are the ones SurrealDB 3.2 echoes back from
+// INFO FOR TABLE. A definition that renders differently from its own echo
+// re-applies on every reconcile, so these compare whole strings wherever the
+// echo shape is the point.
+
+func TestDiskAnnIndex_SpellsTheDefaults(t *testing.T) {
+	idx := DiskAnnIndex("vec_idx", "v", 3, DiskAnnIndexOptions{
+		Distance:   DiskAnnDistanceCosine,
+		VectorType: MTreeVectorF32,
+	})
+	got := idx.ToSurql("doc")
+	want := "DEFINE INDEX vec_idx ON TABLE doc COLUMNS v DISKANN DIMENSION 3 " +
+		"DIST COSINE TYPE F32 DEGREE 64 L_BUILD 100 ALPHA 1.2;"
+	if got != want {
+		t.Errorf("ToSurql = %q, want %q", got, want)
+	}
+}
+
+func TestDiskAnnIndex_TunedTailAndHashedVector(t *testing.T) {
+	idx := DiskAnnIndex("vec_idx", "v", 3, DiskAnnIndexOptions{
+		Distance:     DiskAnnDistanceCosine,
+		VectorType:   MTreeVectorF16,
+		Degree:       48,
+		LBuild:       90,
+		Alpha:        "1.5",
+		HashedVector: true,
+	})
+	got := idx.ToSurql("doc")
+	want := "DEFINE INDEX vec_idx ON TABLE doc COLUMNS v DISKANN DIMENSION 3 " +
+		"DIST COSINE TYPE F16 DEGREE 48 L_BUILD 90 ALPHA 1.5 HASHED_VECTOR;"
+	if got != want {
+		t.Errorf("ToSurql = %q, want %q", got, want)
+	}
+}
+
+func TestDiskAnnIndex_Defaults(t *testing.T) {
+	idx := DiskAnnIndex("e", "v", 8, DiskAnnIndexOptions{})
+	if idx.DiskAnnDistance != DiskAnnDistanceEuclidean {
+		t.Errorf("default distance = %q, want EUCLIDEAN", idx.DiskAnnDistance)
+	}
+	if idx.VectorType != MTreeVectorF32 {
+		t.Errorf("default vector type = %q, want F32", idx.VectorType)
+	}
+	if idx.Degree != DiskAnnDefaultDegree {
+		t.Errorf("default degree = %d, want %d", idx.Degree, DiskAnnDefaultDegree)
+	}
+	if idx.LBuild != DiskAnnDefaultLBuild {
+		t.Errorf("default l_build = %d, want %d", idx.LBuild, DiskAnnDefaultLBuild)
+	}
+	if idx.Alpha != DiskAnnDefaultAlpha {
+		t.Errorf("default alpha = %q, want %q", idx.Alpha, DiskAnnDefaultAlpha)
+	}
+}
+
+func TestDiskAnnIndex_IfNotExists(t *testing.T) {
+	idx := DiskAnnIndex("vec_idx", "v", 3, DiskAnnIndexOptions{})
+	if got := idx.ToSurqlIfNotExists("doc"); !strings.HasPrefix(got, "DEFINE INDEX IF NOT EXISTS vec_idx") {
+		t.Errorf("IF NOT EXISTS missing: %q", got)
+	}
+}
+
+func TestDiskAnnIndex_EveryMetricRenders(t *testing.T) {
+	cases := []struct {
+		metric DiskAnnDistanceType
+		want   string
+	}{
+		{DiskAnnDistanceCosine, "DIST COSINE"},
+		{DiskAnnDistanceCosineNormalized, "DIST COSINE_NORMALIZED"},
+		{DiskAnnDistanceEuclidean, "DIST EUCLIDEAN"},
+		{DiskAnnDistanceInnerProduct, "DIST INNER_PRODUCT"},
+	}
+	for _, tc := range cases {
+		idx := DiskAnnIndex("vec_idx", "v", 3, DiskAnnIndexOptions{Distance: tc.metric})
+		if got := idx.ToSurql("doc"); !strings.Contains(got, tc.want) {
+			t.Errorf("metric %q rendered %q, want it to contain %q", tc.metric, got, tc.want)
+		}
+	}
+}
+
+func TestCanonicalAlpha(t *testing.T) {
+	// The engine echoes an integer ALPHA bare, so 2.0 must not render as 2.0.
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		{1.2, "1.2"},
+		{2.0, "2"},
+		{1.5, "1.5"},
+	}
+	for _, tc := range cases {
+		if got := CanonicalAlpha(tc.in); got != tc.want {
+			t.Errorf("CanonicalAlpha(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+	if CanonicalAlpha(1.2) != DiskAnnDefaultAlpha {
+		t.Error("the default constant and the canonical rendering disagree")
+	}
+}
+
+func TestParseIndex_DiskAnnRoundTrip(t *testing.T) {
+	// Rendering, then parsing the echo, returns the same definition. This is
+	// the property that keeps a reconciler from looping.
+	idx := DiskAnnIndex("vec_idx", "v", 3, DiskAnnIndexOptions{
+		Distance:   DiskAnnDistanceCosine,
+		VectorType: MTreeVectorF16,
+		Degree:     48,
+		LBuild:     90,
+		Alpha:      "1.5",
+	})
+	parsed, err := ParseIndex("vec_idx", idx.ToSurql("doc"))
+	if err != nil {
+		t.Fatalf("ParseIndex: %v", err)
+	}
+	if parsed.Type != IndexTypeDiskAnn {
+		t.Errorf("type = %q, want DISKANN", parsed.Type)
+	}
+	if parsed.Dimension != 3 || parsed.VectorType != MTreeVectorF16 {
+		t.Errorf("dimension/type = %d/%q, want 3/F16", parsed.Dimension, parsed.VectorType)
+	}
+	if parsed.DiskAnnDistance != DiskAnnDistanceCosine {
+		t.Errorf("distance = %q, want COSINE", parsed.DiskAnnDistance)
+	}
+	if parsed.Degree != 48 || parsed.LBuild != 90 || parsed.Alpha != "1.5" {
+		t.Errorf("tail = %d/%d/%q, want 48/90/1.5", parsed.Degree, parsed.LBuild, parsed.Alpha)
+	}
+	if parsed.ToSurql("doc") != idx.ToSurql("doc") {
+		t.Errorf("re-render differs:\n got %q\nwant %q", parsed.ToSurql("doc"), idx.ToSurql("doc"))
+	}
+}
+
+func TestParseIndex_StripsTheEngineAlphaSuffix(t *testing.T) {
+	// A float ALPHA echoes as 1.2f; reading it as anything but 1.2 makes every
+	// reconcile re-apply the index.
+	echo := "DEFINE INDEX vec_idx ON TABLE doc COLUMNS v DISKANN DIMENSION 3 " +
+		"DIST COSINE TYPE F16 DEGREE 64 L_BUILD 100 ALPHA 1.2f"
+	parsed, err := ParseIndex("vec_idx", echo)
+	if err != nil {
+		t.Fatalf("ParseIndex: %v", err)
+	}
+	if parsed.Alpha != "1.2" {
+		t.Errorf("alpha = %q, want %q", parsed.Alpha, "1.2")
+	}
+}
+
+func TestParseIndex_IntegerAlphaEchoesBare(t *testing.T) {
+	echo := "DEFINE INDEX vec_idx ON TABLE doc COLUMNS v DISKANN DIMENSION 3 " +
+		"DIST COSINE TYPE F32 DEGREE 64 L_BUILD 100 ALPHA 2"
+	parsed, err := ParseIndex("vec_idx", echo)
+	if err != nil {
+		t.Fatalf("ParseIndex: %v", err)
+	}
+	if parsed.Alpha != "2" {
+		t.Errorf("alpha = %q, want %q", parsed.Alpha, "2")
+	}
+}
+
+func TestParseIndex_DiskAnnHashedVectorAndColumns(t *testing.T) {
+	idx := DiskAnnIndex("vec_idx", "v", 3, DiskAnnIndexOptions{HashedVector: true})
+	parsed, err := ParseIndex("vec_idx", idx.ToSurql("doc"))
+	if err != nil {
+		t.Fatalf("ParseIndex: %v", err)
+	}
+	if !parsed.HashedVector {
+		t.Error("HASHED_VECTOR not read back")
+	}
+	if len(parsed.Columns) != 1 || parsed.Columns[0] != "v" {
+		t.Errorf("columns = %v, want [v]", parsed.Columns)
+	}
+}
+
+func TestParseIndex_UnderscoredMetricsSurviveTheCapture(t *testing.T) {
+	for _, metric := range []DiskAnnDistanceType{
+		DiskAnnDistanceCosineNormalized,
+		DiskAnnDistanceInnerProduct,
+	} {
+		idx := DiskAnnIndex("vec_idx", "v", 3, DiskAnnIndexOptions{Distance: metric})
+		parsed, err := ParseIndex("vec_idx", idx.ToSurql("doc"))
+		if err != nil {
+			t.Fatalf("ParseIndex(%q): %v", metric, err)
+		}
+		if parsed.DiskAnnDistance != metric {
+			t.Errorf("distance = %q, want %q", parsed.DiskAnnDistance, metric)
+		}
+	}
+}
+
+func TestVectorType_NarrowTypesAcrossKinds(t *testing.T) {
+	narrow := []MTreeVectorType{MTreeVectorF16, MTreeVectorI8, MTreeVectorU8}
+
+	// HNSW takes every element type.
+	for _, vt := range narrow {
+		idx := HnswIndex("feat_idx", "features", 3, HnswIndexOptions{VectorType: vt})
+		if err := idx.Validate(); err != nil {
+			t.Errorf("HNSW rejected %q: %v", vt, err)
+		}
+	}
+
+	// MTREE parses only its historical five; the engine answers a bare parse
+	// error, so the refusal carries the teaching here.
+	for _, vt := range narrow {
+		idx := MTreeIndex("bad_idx", "v", 3, MTreeIndexOptions{VectorType: vt})
+		err := idx.Validate()
+		if err == nil {
+			t.Errorf("MTREE accepted %q, want a refusal", vt)
+			continue
+		}
+		if !strings.Contains(err.Error(), "F64, F32, I64, I32, or I16") {
+			t.Errorf("MTREE refusal for %q does not name the accepted set: %v", vt, err)
+		}
+	}
+
+	// DISKANN takes only F32 / F16 / I8 / U8.
+	for _, vt := range []MTreeVectorType{MTreeVectorF32, MTreeVectorF16, MTreeVectorI8, MTreeVectorU8} {
+		idx := DiskAnnIndex("ok_idx", "v", 3, DiskAnnIndexOptions{VectorType: vt})
+		if err := idx.Validate(); err != nil {
+			t.Errorf("DISKANN rejected %q: %v", vt, err)
+		}
+	}
+	for _, vt := range []MTreeVectorType{MTreeVectorF64, MTreeVectorI64, MTreeVectorI32, MTreeVectorI16} {
+		idx := DiskAnnIndex("bad_idx", "v", 3, DiskAnnIndexOptions{VectorType: vt})
+		err := idx.Validate()
+		if err == nil {
+			t.Errorf("DISKANN accepted %q, want a refusal", vt)
+			continue
+		}
+		if !strings.Contains(err.Error(), "F32, F16, I8, or U8") {
+			t.Errorf("DISKANN refusal for %q does not name the accepted set: %v", vt, err)
+		}
+	}
+}
+
+func TestDiskAnnIndex_RefusesAMetricFromAnotherKind(t *testing.T) {
+	// An MTREE or HNSW metric aimed at DISKANN would be dropped by the
+	// renderer, so it is refused rather than silently ignored.
+	withMTree := DiskAnnIndex("bad_idx", "v", 3, DiskAnnIndexOptions{})
+	withMTree.Distance = MTreeDistanceCosine
+	if err := withMTree.Validate(); err == nil {
+		t.Error("DISKANN accepted an MTREE metric, want a refusal")
+	} else if !strings.Contains(err.Error(), "DiskAnnDistance") {
+		t.Errorf("refusal does not name the right member: %v", err)
+	}
+
+	withHnsw := DiskAnnIndex("bad_idx", "v", 3, DiskAnnIndexOptions{})
+	withHnsw.HnswDistance = HnswDistancePearson
+	if err := withHnsw.Validate(); err == nil {
+		t.Error("DISKANN accepted an HNSW metric, want a refusal")
+	}
+}
+
+func TestDiskAnnIndex_RefusesAMissingDimension(t *testing.T) {
+	idx := DiskAnnIndex("bad_idx", "v", 0, DiskAnnIndexOptions{})
+	if err := idx.Validate(); err == nil {
+		t.Error("DISKANN accepted a zero dimension, want a refusal")
+	}
+}
+
+func TestIndexType_DiskAnnIsValid(t *testing.T) {
+	if !IndexTypeDiskAnn.IsValid() {
+		t.Error("IndexTypeDiskAnn should be recognised")
+	}
+	if string(IndexTypeDiskAnn) != "DISKANN" {
+		t.Errorf("IndexTypeDiskAnn = %q, want DISKANN", IndexTypeDiskAnn)
+	}
+}

--- a/pkg/surql/schema/parser.go
+++ b/pkg/surql/schema/parser.go
@@ -207,6 +207,14 @@ func ParseIndex(indexName, definition string) (IndexDefinition, error) {
 		idx.HnswDistance = extractHnswDistance(definition)
 		idx.EFC = extractHnswEFC(definition)
 		idx.M = extractHnswM(definition)
+	case IndexTypeDiskAnn:
+		idx.Dimension = extractMtreeDimension(definition)
+		idx.VectorType = extractVectorType(definition)
+		idx.DiskAnnDistance = extractDiskAnnDistance(definition)
+		idx.Degree = extractDiskAnnDegree(definition)
+		idx.LBuild = extractDiskAnnLBuild(definition)
+		idx.Alpha = extractDiskAnnAlpha(definition)
+		idx.HashedVector = strings.Contains(strings.ToUpper(definition), "HASHED_VECTOR")
 	case IndexTypeSearch:
 		idx.Analyzer = extractIndexAnalyzer(definition)
 		up := strings.ToUpper(definition)
@@ -545,14 +553,20 @@ func extractFlexible(def string) bool {
 // -----------------------------------------------------------------------------
 
 var (
-	reIndexColumns = regexp.MustCompile(`(?i)COLUMNS\s+([^;]+?)(?:\s+UNIQUE\b|\s+FULLTEXT\b|\s+SEARCH\b|\s+HNSW\b|\s+MTREE\b|\s*;|\s*$)`)
-	reIndexFields  = regexp.MustCompile(`(?i)FIELDS\s+([^;]+?)(?:\s+UNIQUE\b|\s+FULLTEXT\b|\s+SEARCH\b|\s+HNSW\b|\s+MTREE\b|\s*;|\s*$)`)
+	reIndexColumns = regexp.MustCompile(`(?i)COLUMNS\s+([^;]+?)(?:\s+UNIQUE\b|\s+FULLTEXT\b|\s+SEARCH\b|\s+HNSW\b|\s+MTREE\b|\s+DISKANN\b|\s*;|\s*$)`)
+	reIndexFields  = regexp.MustCompile(`(?i)FIELDS\s+([^;]+?)(?:\s+UNIQUE\b|\s+FULLTEXT\b|\s+SEARCH\b|\s+HNSW\b|\s+MTREE\b|\s+DISKANN\b|\s*;|\s*$)`)
 	reIndexDim     = regexp.MustCompile(`(?i)DIMENSION\s+(\d+)`)
 	reIndexDist    = regexp.MustCompile(`(?i)(?:DIST|DISTANCE)\s+([A-Za-z_]\w*)`)
 	reVectorType   = regexp.MustCompile(`(?i)TYPE\s+([A-Za-z_]\w*)`)
 	reIndexEFC     = regexp.MustCompile(`(?i)\bEFC\s+(\d+)`)
 	reIndexM       = regexp.MustCompile(`(?i)\bM\s+(\d+)`)
 	reIndexAnlzr   = regexp.MustCompile(`(?i)ANALYZER\s+(\w+)`)
+	reIndexDegree  = regexp.MustCompile(`(?i)\bDEGREE\s+(\d+)`)
+	reIndexLBuild  = regexp.MustCompile(`(?i)\bL_BUILD\s+(\d+)`)
+	// The engine echoes a float ALPHA with a trailing f suffix (ALPHA 1.2f)
+	// and an integer one bare (ALPHA 2). The capture excludes the suffix so
+	// the stored value matches what code declares.
+	reIndexAlpha = regexp.MustCompile(`(?i)\bALPHA\s+(\d+(?:\.\d+)?)`)
 )
 
 func splitColumns(raw string) []string {
@@ -590,6 +604,8 @@ func extractIndexType(def string) IndexType {
 		return IndexTypeHNSW
 	case strings.Contains(up, "MTREE"):
 		return IndexTypeMTree
+	case strings.Contains(up, "DISKANN"):
+		return IndexTypeDiskAnn
 	case strings.Contains(up, "FULLTEXT"), strings.Contains(up, "SEARCH"):
 		// SurrealDB 3.x renamed the full-text keyword SEARCH -> FULLTEXT;
 		// recognise both spellings so v1/v2 and v3 INFO output round-trip.
@@ -661,9 +677,12 @@ func extractHnswDistance(def string) HnswDistanceType {
 var vectorTypeMap = map[string]MTreeVectorType{
 	"F64": MTreeVectorF64,
 	"F32": MTreeVectorF32,
+	"F16": MTreeVectorF16,
 	"I64": MTreeVectorI64,
 	"I32": MTreeVectorI32,
 	"I16": MTreeVectorI16,
+	"I8":  MTreeVectorI8,
+	"U8":  MTreeVectorU8,
 }
 
 func extractVectorType(def string) MTreeVectorType {
@@ -671,6 +690,44 @@ func extractVectorType(def string) MTreeVectorType {
 		if v, ok := vectorTypeMap[strings.ToUpper(m[1])]; ok {
 			return v
 		}
+	}
+	return ""
+}
+
+// extractDiskAnnDistance pulls the DIST metric out of a DISKANN definition.
+// COSINE_NORMALIZED and INNER_PRODUCT carry an underscore, which the shared
+// distance pattern already admits.
+func extractDiskAnnDistance(def string) DiskAnnDistanceType {
+	if m := reIndexDist.FindStringSubmatch(def); len(m) == 2 {
+		d := DiskAnnDistanceType(strings.ToUpper(m[1]))
+		if d.IsValid() {
+			return d
+		}
+	}
+	return ""
+}
+
+func extractDiskAnnDegree(def string) int {
+	if m := reIndexDegree.FindStringSubmatch(def); len(m) == 2 {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+func extractDiskAnnLBuild(def string) int {
+	if m := reIndexLBuild.FindStringSubmatch(def); len(m) == 2 {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+func extractDiskAnnAlpha(def string) string {
+	if m := reIndexAlpha.FindStringSubmatch(def); len(m) == 2 {
+		return m[1]
 	}
 	return ""
 }

--- a/pkg/surql/schema/table.go
+++ b/pkg/surql/schema/table.go
@@ -37,12 +37,17 @@ const (
 	IndexTypeSearch   IndexType = "SEARCH"
 	IndexTypeMTree    IndexType = "MTREE"
 	IndexTypeHNSW     IndexType = "HNSW"
+	// IndexTypeDiskAnn is an on-disk approximate-nearest-neighbour graph
+	// (SurrealDB 3.2+). The graph lives on disk rather than in memory, so an
+	// index outgrows RAM without outgrowing the box. Build it with DiskAnnIndex.
+	IndexTypeDiskAnn IndexType = "DISKANN"
 )
 
 // IsValid reports whether the IndexType is recognised.
 func (t IndexType) IsValid() bool {
 	switch t {
-	case IndexTypeStandard, IndexTypeUnique, IndexTypeSearch, IndexTypeMTree, IndexTypeHNSW:
+	case IndexTypeStandard, IndexTypeUnique, IndexTypeSearch, IndexTypeMTree,
+		IndexTypeHNSW, IndexTypeDiskAnn:
 		return true
 	}
 	return false
@@ -95,23 +100,76 @@ func (d HnswDistanceType) IsValid() bool {
 	return false
 }
 
-// MTreeVectorType enumerates the vector component numeric types supported by
-// both MTREE and HNSW indexes.
+// DiskAnnDistanceType enumerates distance metrics for DISKANN indexes.
+//
+// Its own type rather than a reuse of HnswDistanceType: the engine's DISKANN
+// set both adds metrics HNSW lacks (INNER_PRODUCT, COSINE_NORMALIZED) and
+// refuses every HNSW metric outside it, so an out-of-set metric is
+// unrepresentable here.
+type DiskAnnDistanceType string
+
+// DiskAnnDistanceType values.
+const (
+	DiskAnnDistanceCosine           DiskAnnDistanceType = "COSINE"
+	DiskAnnDistanceCosineNormalized DiskAnnDistanceType = "COSINE_NORMALIZED"
+	DiskAnnDistanceEuclidean        DiskAnnDistanceType = "EUCLIDEAN"
+	DiskAnnDistanceInnerProduct     DiskAnnDistanceType = "INNER_PRODUCT"
+)
+
+// IsValid reports whether the DiskAnnDistanceType is recognised.
+func (d DiskAnnDistanceType) IsValid() bool {
+	switch d {
+	case DiskAnnDistanceCosine, DiskAnnDistanceCosineNormalized,
+		DiskAnnDistanceEuclidean, DiskAnnDistanceInnerProduct:
+		return true
+	}
+	return false
+}
+
+// MTreeVectorType enumerates the vector component numeric types. One shared
+// vocabulary; each index kind accepts a subset. The engine takes every value
+// for HNSW, refuses F16 / I8 / U8 for MTREE, and refuses everything but
+// F32 / F16 / I8 / U8 for DISKANN. IndexDefinition.Validate teaches those
+// limits before a statement is sent.
 type MTreeVectorType string
 
 // MTreeVectorType values.
 const (
 	MTreeVectorF64 MTreeVectorType = "F64"
 	MTreeVectorF32 MTreeVectorType = "F32"
+	MTreeVectorF16 MTreeVectorType = "F16"
 	MTreeVectorI64 MTreeVectorType = "I64"
 	MTreeVectorI32 MTreeVectorType = "I32"
 	MTreeVectorI16 MTreeVectorType = "I16"
+	MTreeVectorI8  MTreeVectorType = "I8"
+	MTreeVectorU8  MTreeVectorType = "U8"
 )
 
 // IsValid reports whether the MTreeVectorType is recognised.
 func (v MTreeVectorType) IsValid() bool {
 	switch v {
+	case MTreeVectorF64, MTreeVectorF32, MTreeVectorF16, MTreeVectorI64,
+		MTreeVectorI32, MTreeVectorI16, MTreeVectorI8, MTreeVectorU8:
+		return true
+	}
+	return false
+}
+
+// ValidForMTree reports whether MTREE parses this element type. MTREE takes
+// only its historical five; the narrow three are a parse error with no
+// teaching message from the engine.
+func (v MTreeVectorType) ValidForMTree() bool {
+	switch v {
 	case MTreeVectorF64, MTreeVectorF32, MTreeVectorI64, MTreeVectorI32, MTreeVectorI16:
+		return true
+	}
+	return false
+}
+
+// ValidForDiskAnn reports whether DISKANN accepts this element type.
+func (v MTreeVectorType) ValidForDiskAnn() bool {
+	switch v {
+	case MTreeVectorF32, MTreeVectorF16, MTreeVectorI8, MTreeVectorU8:
 		return true
 	}
 	return false
@@ -134,6 +192,17 @@ type IndexDefinition struct {
 	HnswDistance HnswDistanceType
 	EFC          int // zero means unset
 	M            int // zero means unset
+
+	// DISKANN-specific. Degree, LBuild, and Alpha carry the engine's own
+	// defaults rather than staying unset, because the engine echoes them back
+	// filled in; see the DiskAnnDefault constants. Alpha is the decimal literal
+	// the statement carries, since the engine echoes a float with a trailing f
+	// suffix (ALPHA 1.2f) that the parser strips.
+	DiskAnnDistance DiskAnnDistanceType
+	Degree          int // zero means unset
+	LBuild          int // zero means unset
+	Alpha           string
+	HashedVector    bool
 
 	// Full-text SEARCH-specific. Analyzer is the analyzer name; an empty
 	// string renders the historical default (`ascii`). BM25 emits the
@@ -413,6 +482,65 @@ func HnswIndex(name, column string, dimension int, opts HnswIndexOptions) IndexD
 	}
 }
 
+// Engine defaults a DISKANN index echoes back when the definition never stated
+// them. The builder fills the same values up front so a definition compares
+// equal to its own echo instead of re-applying on every reconcile.
+const (
+	DiskAnnDefaultDegree = 64
+	DiskAnnDefaultLBuild = 100
+	DiskAnnDefaultAlpha  = "1.2"
+)
+
+// CanonicalAlpha renders a DISKANN ALPHA value the way the engine echoes it: a
+// whole number bare (ALPHA 2) and a fractional one as a plain decimal, which is
+// what a float echo (ALPHA 1.2f) reads back as once its suffix is stripped.
+func CanonicalAlpha(alpha float64) string {
+	return strconv.FormatFloat(alpha, 'f', -1, 64)
+}
+
+// DiskAnnIndexOptions configures a DISKANN vector index. Degree, LBuild, and
+// Alpha are optional; zero (or empty) takes the engine default, which is then
+// spelled explicitly in the rendered statement.
+type DiskAnnIndexOptions struct {
+	Distance     DiskAnnDistanceType
+	VectorType   MTreeVectorType
+	Degree       int
+	LBuild       int
+	Alpha        string
+	HashedVector bool
+}
+
+// DiskAnnIndex builds a DISKANN IndexDefinition.
+func DiskAnnIndex(name, column string, dimension int, opts DiskAnnIndexOptions) IndexDefinition {
+	if opts.Distance == "" {
+		opts.Distance = DiskAnnDistanceEuclidean
+	}
+	if opts.VectorType == "" {
+		opts.VectorType = MTreeVectorF32
+	}
+	if opts.Degree == 0 {
+		opts.Degree = DiskAnnDefaultDegree
+	}
+	if opts.LBuild == 0 {
+		opts.LBuild = DiskAnnDefaultLBuild
+	}
+	if opts.Alpha == "" {
+		opts.Alpha = DiskAnnDefaultAlpha
+	}
+	return IndexDefinition{
+		Name:            name,
+		Columns:         []string{column},
+		Type:            IndexTypeDiskAnn,
+		Dimension:       dimension,
+		VectorType:      opts.VectorType,
+		DiskAnnDistance: opts.Distance,
+		Degree:          opts.Degree,
+		LBuild:          opts.LBuild,
+		Alpha:           opts.Alpha,
+		HashedVector:    opts.HashedVector,
+	}
+}
+
 // Validate verifies structural invariants of the index definition.
 func (i IndexDefinition) Validate() error {
 	if i.Name == "" {
@@ -447,6 +575,11 @@ func (i IndexDefinition) Validate() error {
 			return surqlerrors.Newf(surqlerrors.ErrValidation,
 				"MTREE index %q has invalid vector type %q", i.Name, string(i.VectorType))
 		}
+		if i.VectorType != "" && !i.VectorType.ValidForMTree() {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"MTREE index %q cannot use TYPE %s: the engine only accepts "+
+					"F64, F32, I64, I32, or I16 for MTREE", i.Name, string(i.VectorType))
+		}
 	case IndexTypeHNSW:
 		if i.Dimension <= 0 {
 			return surqlerrors.Newf(surqlerrors.ErrValidation,
@@ -459,6 +592,33 @@ func (i IndexDefinition) Validate() error {
 		if i.VectorType != "" && !i.VectorType.IsValid() {
 			return surqlerrors.Newf(surqlerrors.ErrValidation,
 				"HNSW index %q has invalid vector type %q", i.Name, string(i.VectorType))
+		}
+	case IndexTypeDiskAnn:
+		if i.Dimension <= 0 {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"DISKANN index %q requires a positive dimension", i.Name)
+		}
+		if i.DiskAnnDistance != "" && !i.DiskAnnDistance.IsValid() {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"DISKANN index %q has invalid distance %q", i.Name, string(i.DiskAnnDistance))
+		}
+		if i.VectorType != "" && !i.VectorType.IsValid() {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"DISKANN index %q has invalid vector type %q", i.Name, string(i.VectorType))
+		}
+		if i.VectorType != "" && !i.VectorType.ValidForDiskAnn() {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"DISKANN index %q cannot use TYPE %s: the engine only accepts "+
+					"F32, F16, I8, or U8 for DISKANN", i.Name, string(i.VectorType))
+		}
+		// A metric aimed at DISKANN through the MTREE or HNSW member would be
+		// dropped by the renderer, so the mistake is refused rather than
+		// silently ignored.
+		if i.Distance != "" || i.HnswDistance != "" {
+			return surqlerrors.Newf(surqlerrors.ErrValidation,
+				"DISKANN index %q takes its metric through DiskAnnDistance "+
+					"(EUCLIDEAN, COSINE, INNER_PRODUCT, or COSINE_NORMALIZED); the engine "+
+					"refuses every other MTREE/HNSW metric for DISKANN", i.Name)
 		}
 	}
 	return nil
@@ -530,6 +690,56 @@ func (i IndexDefinition) toSurql(tableName string, ifNotExists bool) string {
 		if i.M > 0 {
 			b.WriteString(" M ")
 			b.WriteString(strconv.Itoa(i.M))
+		}
+		b.WriteString(";")
+		return b.String()
+
+	case IndexTypeDiskAnn:
+		// The engine always echoes DIST / TYPE / DEGREE / L_BUILD / ALPHA back
+		// with its defaults filled in, even when the definition never stated
+		// them, so this spells them all. A definition that omitted one would
+		// never compare equal to its own echo, and a reconcile would re-apply
+		// the index on every boot.
+		field := ""
+		if len(i.Columns) > 0 {
+			field = i.Columns[0]
+		}
+		distance := i.DiskAnnDistance
+		if distance == "" {
+			distance = DiskAnnDistanceEuclidean
+		}
+		vectorType := i.VectorType
+		if vectorType == "" {
+			vectorType = MTreeVectorF32
+		}
+		degree := i.Degree
+		if degree == 0 {
+			degree = DiskAnnDefaultDegree
+		}
+		lBuild := i.LBuild
+		if lBuild == 0 {
+			lBuild = DiskAnnDefaultLBuild
+		}
+		alpha := i.Alpha
+		if alpha == "" {
+			alpha = DiskAnnDefaultAlpha
+		}
+		b.WriteString(" COLUMNS ")
+		b.WriteString(field)
+		b.WriteString(" DISKANN DIMENSION ")
+		b.WriteString(strconv.Itoa(i.Dimension))
+		b.WriteString(" DIST ")
+		b.WriteString(string(distance))
+		b.WriteString(" TYPE ")
+		b.WriteString(string(vectorType))
+		b.WriteString(" DEGREE ")
+		b.WriteString(strconv.Itoa(degree))
+		b.WriteString(" L_BUILD ")
+		b.WriteString(strconv.Itoa(lBuild))
+		b.WriteString(" ALPHA ")
+		b.WriteString(alpha)
+		if i.HashedVector {
+			b.WriteString(" HASHED_VECTOR")
 		}
 		b.WriteString(";")
 		return b.String()


### PR DESCRIPTION
Brings the vector surface to parity with surql-rs 0.33.0, so a schema defined in Go reaches the same SurrealDB 3.2 features as one defined in Rust.

## Added

`IndexTypeDiskAnn` and `DiskAnnIndex(name, column, dimension, DiskAnnIndexOptions{...})` define the on-disk ANN graph the 3.2 engine parses, with `DiskAnnDistanceType` for the metric. It is its own type because the engine's DISKANN metric set neither contains nor is contained by the HNSW one, so an out-of-set metric is unrepresentable rather than merely refused. `MTreeVectorType` gained `F16`, `I8`, and `U8`, plus `ValidForMTree` / `ValidForDiskAnn` predicates for the subsets each kind accepts.

The engine echoes a DISKANN index with `DIST` / `TYPE` / `DEGREE` / `L_BUILD` / `ALPHA` always spelled, defaults filled in even when the definition never stated them, and a float `ALPHA` carrying a trailing `f` suffix. The emitter spells the defaults, `CanonicalAlpha` renders a whole number bare, and the parser excludes the `f` from its capture, so a definition compares equal to its own echo instead of re-applying on every reconcile.

`IndexDefinition.Validate` refuses what the engine refuses, by name: a DISKANN element type outside `F32` / `F16` / `I8` / `U8`, an MTREE element type among the narrow three, and an MTREE or HNSW metric aimed at a DISKANN index.

## Fixed

`Query.VectorSearch` renders `<|k,METRIC|>`, which the engine plans as an exhaustive `KnnTopK` over a table scan. There was no way to render the integer form, so a query against an indexed column scanned the table and the index it was paying to build served nothing. `VectorSearchIndexed(field, vector, k, ef)` renders `<|k,ef|>` and reaches the index through a `KnnScan`.

The `INFO FOR TABLE` parser dropped unrecognised vector element types: `extractVectorType` matched against a fixed set of five, so an index defined with any newer element type parsed back with an empty type and the next reconcile saw a difference that was not there. Found by the new round-trip test, not by inspection.

## Verification

Every package passes, `go vet` clean. New tests cover the echo shape, the round-trip, the `f`-suffix strip, every refusal, the migration emitter agreeing with the schema emitter, and both KNN renderings.