### PR TITLE
chore(ci): bump pinned actions to current releases

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
             -covermode=atomic
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           files: coverage.out
           fail_ci_if_error: false

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - name: Get PR metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for required checks
-        uses: lewagon/wait-on-check-action@v1.4.0
+        uses: lewagon/wait-on-check-action@v1.9.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           running-workflow-name: auto-merge


### PR DESCRIPTION
Supersedes the stale dependabot PRs #108 and #109.

| action | dependabot proposed | this PR |
|---|---|---|
| `lewagon/wait-on-check-action` | v1.8.0 (#108) | **v1.9.1** |
| `dependabot/fetch-metadata` | v3 (#109) | v3 |
| `actions/dependency-review-action` | not proposed | v5 |
| `codecov/codecov-action` | not proposed | v7 |

#108 would land v1.8.0, which is two releases behind. Rebasing each PR individually also costs a CI run apiece on the aur0 queue, and the checks on both are stale from May (#113's jobs show `24h0m1s` durations, meaning they hung and were killed rather than genuinely failing).