### PR TITLE
chore(deps): move surrealdb.go to the released v1.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/spf13/cobra v1.10.2
-	github.com/surrealdb/surrealdb.go v1.4.1-0.20260430110252-aef39d3a439f
+	github.com/surrealdb/surrealdb.go v1.6.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -48,10 +48,10 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/surrealdb/surrealdb.go v1.4.1-0.20260430110252-aef39d3a439f h1:wgm5sUqryzDQKFYIv9O54ABFdlaNQzNP7hs9mwEQSkE=
-github.com/surrealdb/surrealdb.go v1.4.1-0.20260430110252-aef39d3a439f/go.mod h1:ju3vn9OHXde9Ulvc7/fP9I8ylkiapOdBSdrEs2PmTtA=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/surrealdb/surrealdb.go v1.6.0 h1:x88b/W0gDQN7FAtHRsBTEcHLr8UBKNV0uo2MjNKR52s=
+github.com/surrealdb/surrealdb.go v1.6.0/go.mod h1:mKSZxow8ZN2tkR2p/fWzjIbinRFXWOGCOpfIdiYYZzc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=


### PR DESCRIPTION
Split out of #120 so it can be judged on its own.

#99 pinned a pseudo-version (`v1.4.1-0.20260430110252-aef39d3a439f`) to pick up an unreleased live-query Kill race fix. That fix has since shipped, so the pin can retire and the module can track a tagged release again.

`go build`, `go vet`, and all ten unit suites pass. The reason this is separate from the routine bumps: it crosses two driver minors, and the live-query behaviour it touches is only exercised by the integration suite, which needs a running SurrealDB. That is the coverage to watch here.