### PR TITLE
chore(ci): move the nightly jobs to aur0 and add concurrency groups

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,6 +20,10 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
       - main
       - 'release/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,10 @@ on:
       - main
       - 'release/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -6,6 +6,10 @@ on:
       - main
       - 'release/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,10 @@
 name: Dependabot Auto-merge
 on: pull_request_target
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
   contents: write

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,17 +5,20 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
   nightly-ci:
-    name: Nightly sanity (${{ matrix.os }}, Go ${{ matrix.go }})
-    runs-on: ${{ matrix.os }}
+    name: Nightly sanity (Go ${{ matrix.go }})
+    runs-on: [self-hosted, aur0]
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         go: ['1.26', 'stable']
     steps:
       - uses: actions/checkout@v6
@@ -49,7 +52,7 @@ jobs:
 
   nightly-lint:
     name: Nightly golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     # golangci-lint v2.1.x is built with Go 1.24 and panics ("package
     # requires newer Go version go1.26") when linting a module with
     # `go 1.26` in go.mod. Marked continue-on-error to match the
@@ -74,7 +77,7 @@ jobs:
 
   nightly-audit:
     name: Nightly govulncheck
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, aur0]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -8,6 +8,10 @@ on:
       - synchronize
       - reopened
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     types: [published]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 


### PR DESCRIPTION
Closes #87 and closes #85. Both touch the same workflow files, so they travel together.

## #87 — the last jobs move to aur0

The three nightly jobs (sanity matrix, `golangci-lint`, `govulncheck`) were the only CI left on GitHub-hosted runners. They now use `[self-hosted, aur0]` like everything else. The sanity matrix drops its `os` dimension, which was single-valued (`[ubuntu-latest]`) and existed only to feed `runs-on`; the Go version matrix is unchanged.

## #85 — concurrency groups

Eight of nine workflows had none, so iterative pushes to a PR piled up rather than superseding each other. macOS was already gone from every matrix, which was the larger cost item.

| cancel in flight | why |
|---|---|
| `ci`, `coverage`, `dep-review`, `pr-title`, `audit`, `dependabot-auto-merge` | PR-triggered; a newer push supersedes the old signal |
| `release`, `nightly` | never kill a publish mid-flight, and a nightly has nothing to race |

## One caveat on the aur0 move

surql-py#103 moved a job *off* aur0 for a specific reason: a nightly that fails every night "accumulates state there and degrades the runner over time," and aur0 also serves oniq / kushtakas / sigilbuzz. `nightly-audit` is exactly that shape.

This repository has already shown the symptom today. On #118, `golangci-lint` failed twice under a doubled workspace path (`/_work/aur0-oneiriq/surql-go/surql-go/...`), unable to read its own checkout, and therefore unable to honour `//nolint` directives — so it reported four suppressed findings as failures. The identical commit passed on a fresh run. That runner's workspace is worth clearing, and the nightly result is worth watching for a few days after this lands.