### PR TITLE
docs: cover vectors, graph traversal, and object storage

### DIFF
--- a/docs/graph.md
+++ b/docs/graph.md
@@ -1,0 +1,64 @@
+# Graph Traversal
+
+Six helpers navigate edges from a starting record, plus a fluent `GraphQuery`
+builder for composing paths.
+
+## The helpers
+
+```go
+rows, err := query.Traverse(ctx, client, "person:alice", "->likes->post", nil)
+rows, err := query.TraverseWithDepth(ctx, client, "person:alice", "likes", "post", &depth, nil)
+rows, err := query.GetOutgoingEdges(ctx, client, "person:alice", "follows", nil)
+rows, err := query.GetIncomingEdges(ctx, client, "person:bob", "follows", nil)
+rows, err := query.GetRelatedRecords(ctx, client, "person:alice", "follows", "person", nil)
+path, err := query.ShortestPath(ctx, client, "person:alice", "person:bob", "follows", nil)
+n, err := query.CountRelated(ctx, client, "person:alice", "follows")
+```
+
+`Traverse` injects `path` verbatim, so compose it from validated identifiers or
+use `TraverseWithDepth`, which builds the path for you.
+
+## Row-level filtering
+
+Every helper above except `CountRelated` takes a trailing `conditions []any`.
+Each entry is rendered through `Query.Where`, so raw SurrealQL strings and
+`types.Operator` values both work, and entries combine with `AND`.
+
+```go
+rows, err := query.GetOutgoingEdges(ctx, client, "person:alice", "follows",
+    []any{types.Gt("since", "2026-01-01"), "active = true"})
+```
+
+Pass `nil` to filter nothing, which leaves the emitted statement unchanged from
+the unfiltered form.
+
+`CountRelated` takes no conditions, matching surql-py, so the two ports keep
+a one-to-one contract.
+
+### Upgrading
+
+The `conditions` parameter is a breaking signature change. Go has no default
+arguments, so it follows the convention `TraverseWithDepth` already set with
+its `depth *int`. Existing call sites migrate by passing `nil`:
+
+```go
+// before
+rows, err := query.GetOutgoingEdges(ctx, client, start, "follows")
+// after
+rows, err := query.GetOutgoingEdges(ctx, client, start, "follows", nil)
+```
+
+## Direction and SurrealDB v3
+
+Incoming traversal puts the record at the head of the `FROM` expression:
+
+```sql
+SELECT * FROM person:bob<-follows
+```
+
+The reverse ordering (`FROM <-follows<-person:bob`) is a parse error on v3. The
+helpers emit the correct form; the note matters only when hand-writing a
+statement or reading older examples.
+
+See [v3 Patterns](v3-patterns.md) for the rest of the version-specific
+grammar.

--- a/docs/objects.md
+++ b/docs/objects.md
@@ -1,0 +1,95 @@
+# Object Storage and Sessions
+
+Two SurrealDB v3 surfaces that the schema and connection layers both reach:
+storage buckets for file data, and multiple sessions over one connection.
+
+## Buckets
+
+A bucket is declared in code like any other definition and managed by the
+migration engine (`ADD_BUCKET` / `DROP_BUCKET` / `MODIFY_BUCKET`).
+
+```go
+b := schema.NewBucket("avatars", "memory")
+
+// Shorthands for the common backends.
+b = schema.MemoryBucket("scratch")
+b = schema.FileBucket("uploads", "/var/lib/surreal/uploads")
+b = schema.S3Bucket("archive", "s3://bucket-name")
+```
+
+Options: `WithBucketReadOnly`, `WithBucketPermissions`, `WithBucketComment`.
+
+Buckets require a server with the experimental files capability enabled:
+
+```
+SURREAL_CAPS_ALLOW_EXPERIMENTAL=files
+```
+
+The capability is not covered by `--allow-all`. Prefer the environment variable
+over the `--allow-experimental files` flag, which swallows the trailing
+`memory` datastore positional.
+
+### File-typed fields
+
+```go
+schema.FileField("avatar")
+schema.BytesField("thumbnail")
+```
+
+A file-typed column carries a `types.FileRef`, a `{Bucket, Key}` pair that
+renders as the SurrealQL pointer `<bucket>:/<key>`. SurrealDB stores keys in a
+canonical form with a leading slash, so `a.txt` and `/a.txt` name the same
+file.
+
+### Runtime
+
+```go
+bucket := client.Bucket("avatars")
+
+err := bucket.Put(ctx, "u/1.png", data)
+err = bucket.PutIfNotExists(ctx, "u/1.png", data)
+
+raw, err := bucket.Get(ctx, "u/1.png")
+text, err := bucket.GetText(ctx, "notes.md")
+ok, err := bucket.Exists(ctx, "u/1.png")
+meta, err := bucket.Head(ctx, "u/1.png")
+refs, err := bucket.List(ctx)
+
+err = bucket.Copy(ctx, "u/1.png", "u/2.png")
+err = bucket.Rename(ctx, "u/1.png", "u/3.png")
+err = bucket.Delete(ctx, "u/3.png")
+```
+
+`CopyIfNotExists` and `RenameIfNotExists` are the guarded forms. Every
+operation binds `type::file($bucket, $key)` parameters rather than
+interpolating the key into a statement.
+
+The CLI covers the same surface: `surql bucket define | list | rm | put | get |
+delete | exists | files`.
+
+## Sessions
+
+`Attach` opens a second session over the existing connection, which suits work
+that needs its own authentication without a second client.
+
+```go
+session, err := client.Attach(ctx)
+if err != nil {
+    return err
+}
+defer session.Detach(ctx)
+
+if err := session.Authenticate(ctx, token); err != nil {
+    return err
+}
+```
+
+A session mirrors the client surface (`Create`, `Select`, `Merge`, `Delete`,
+`Query`, `QueryWithVars`, `Signin`, and `Bucket` through `SessionBucket`). Two
+properties matter in practice: a session needs a live WebSocket connection, and
+it starts unauthenticated. Sign in on the session when it needs more than guest
+access. `CurrentAuthType` and `CurrentToken` report where a session stands.
+
+`Detach` releases the session and `IsDetached` reports whether it already has.
+`Invalidate` drops the session's authentication while keeping the session
+itself.

--- a/docs/vectors.md
+++ b/docs/vectors.md
@@ -1,0 +1,108 @@
+# Vector Search
+
+surql-go defines three vector index kinds and two ways to query them. The
+choice of index decides where the graph lives; the choice of query operator
+decides whether the index is used at all.
+
+## Choosing an index
+
+| kind | graph lives | use when |
+|---|---|---|
+| `HNSW` | memory | recall latency matters and the working set fits in RAM |
+| `DISKANN` | disk | the corpus grows past the memory an HNSW graph would need (SurrealDB 3.2+) |
+| `MTREE` | memory | legacy; prefer HNSW for new work |
+
+### HNSW
+
+```go
+idx := schema.HnswIndex("embedding_idx", "embedding", 1536, schema.HnswIndexOptions{
+    Distance:   schema.HnswDistanceCosine,
+    VectorType: schema.MTreeVectorF32,
+    EFC:        150,
+    M:          12,
+})
+```
+
+`EFC` and `M` are optional; zero omits the clause and takes the server default.
+
+### DISKANN
+
+```go
+idx := schema.DiskAnnIndex("embedding_idx", "embedding", 1536, schema.DiskAnnIndexOptions{
+    Distance:   schema.DiskAnnDistanceCosine,
+    VectorType: schema.MTreeVectorF16,
+    Degree:     48,   // graph out-degree, default 64
+    LBuild:     90,   // build-time candidate list, default 100
+    Alpha:      "1.5", // pruning slack, default "1.2"
+})
+```
+
+`DiskAnnDistanceType` is a separate type from `HnswDistanceType` by design:
+the engine's DISKANN metric set adds `INNER_PRODUCT` and
+`COSINE_NORMALIZED`, and refuses every HNSW metric outside its own four. An
+out-of-set metric is therefore unrepresentable rather than merely rejected at
+runtime.
+
+Rendered form:
+
+```sql
+DEFINE INDEX embedding_idx ON TABLE documents COLUMNS embedding DISKANN
+  DIMENSION 1536 DIST COSINE TYPE F16 DEGREE 48 L_BUILD 90 ALPHA 1.5;
+```
+
+`DIST`, `TYPE`, `DEGREE`, `L_BUILD`, and `ALPHA` are always spelled, even when
+the definition never stated them. The engine fills those defaults in when it
+echoes the index back from `INFO FOR TABLE`, so a definition that omitted one
+would never compare equal to its own echo and a reconciler would re-apply the
+index on every boot. `CanonicalAlpha` renders a whole number bare (`ALPHA 2`)
+for the same reason.
+
+## Element types
+
+`MTreeVectorType` is one shared vocabulary and each index kind takes a subset.
+
+| type | MTREE | HNSW | DISKANN |
+|---|---|---|---|
+| `F64`, `I64`, `I32`, `I16` | yes | yes | no |
+| `F32` | yes | yes | yes |
+| `F16`, `I8`, `U8` | no | yes | yes |
+
+`IndexDefinition.Validate` refuses the combinations the engine refuses, naming
+the accepted set. That matters most for MTREE, where the engine answers a bare
+parse error with no explanation of its own.
+
+`F16` halves the memory a graph holds, at a modest cost in recall. Pair it with
+a reranking pass over the candidates if precision matters.
+
+## Querying
+
+The second argument of the KNN operator decides the query plan.
+
+```go
+// Reaches the index: the engine plans a KnnScan over the HNSW or DISKANN graph.
+q, err := query.Query{}.Select(nil).FromTable("documents")
+q, err = q.VectorSearchIndexed("embedding", vec, 10, 40)
+// SELECT * FROM documents WHERE embedding <|10,40|> [...]
+
+// Exhaustive: the engine plans a KnnTopK over a table scan, comparing every row.
+q, err = q.VectorSearch("embedding", vec, 10, query.DistanceCosine, nil)
+// SELECT * FROM documents WHERE embedding <|10,COSINE|> [...]
+```
+
+An integer in the second position is the exploration factor and reaches the
+index. A metric keyword there asks for an exhaustive comparison and the index
+serves nothing, which is easy to ship by accident: the statement is valid, the
+results are correct, and the cost is a full scan.
+
+`VectorSearchIndexed` takes no metric, because the metric belongs to the index.
+Higher `ef` trades speed for recall.
+
+The bare `<|k|>` form of the KTree era is a parse error on SurrealDB 3.x and
+neither method emits it.
+
+## Hybrid retrieval
+
+The dense leg above pairs with the lexical leg from a BM25 full-text index. Run
+both and fuse the two orders by rank (Reciprocal Rank Fusion) rather than by
+score, since the two scales are not comparable. See
+[Query Builder](queries.md) for `FullTextSearch` and `SearchScore`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,9 @@ nav:
       - Query Builder: queries.md
       - Query UX Helpers: query-ux.md
       - Query Hints: query_hints.md
+      - Vector Search: vectors.md
+      - Graph Traversal: graph.md
+      - Object Storage and Sessions: objects.md
       - v3 Patterns: v3-patterns.md
       - Visualization: visualization.md
   - Reference:


### PR DESCRIPTION
Toward #82.

Four shipped feature waves had **no documentation at all**. A reader of the site could not find any of them:

| feature | shipped in | doc files mentioning it |
|---|---|---|
| DISKANN / F16 / indexed KNN | #118 | 0 |
| buckets and files | #114 | 0 |
| sessions | #114 | 0 |
| graph `conditions` | #117 | 0 |

## New pages

**`vectors.md`** — the three index kinds and when each applies, the element-type matrix per kind (`F16`/`I8`/`U8` are HNSW and DISKANN only, MTREE refuses them), why `DiskAnnDistanceType` is its own type, why the emitter spells every default, and the KNN operator distinction: an integer second argument reaches the index, a metric keyword scans the table. That last one is easy to ship by accident, because the statement is valid and the results are correct.

**`graph.md`** — the six helpers, the `conditions` parameter with an upgrade note (it is a breaking signature change; existing call sites pass `nil`), and the v3 incoming-edge ordering.

**`objects.md`** — bucket declaration and the runtime handle, file-typed fields and `FileRef`, the experimental-files capability and the flag caveat, and sessions.

All three are added to the `mkdocs.yml` nav under Guides. `mkdocs build --strict` passes.

## On accuracy

Every symbol referenced was checked against `go doc` rather than written from memory. That caught a session example calling a `Close` method that does not exist; the real pair is `Detach` / `IsDetached`.

## Remaining under #82

Not covered here, and worth their own pass: module pages for `cache` and `orchestration` (16 and 22 exported symbols, one and two doc mentions between them), a per-subcommand CLI reference, and the docs version label.