### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-08-12
 
 ### Added
 

--- a/pkg/surql/surql.go
+++ b/pkg/surql/surql.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Version is the current surql-go release.
-const Version = "0.2.1"
+const Version = "0.5.0"
 
 // ExtractOne returns the first record from a raw response or
 // (nil, nil) when the envelope is empty. Mirrors the Python


### PR DESCRIPTION
Cuts 0.5.0. Seven commits since v0.4.0.

## Added

- Row-level filtering on the graph helpers via a trailing `conditions` parameter
- DISKANN vector indexes and the F16 element type, with `ValidForMTree` / `ValidForDiskAnn` for the subsets each kind accepts
- `Query.VectorSearchIndexed`, which renders the integer exploration form the engine plans as a `KnnScan`

## Fixed

- `GetIncomingEdges` and `CountRelated` emitted an ordering v3 rejects outright
- The `INFO FOR TABLE` parser dropped unrecognised vector element types, so an index carrying one parsed back with no type and the next reconcile saw a phantom difference

## Why minor, not patch

**The graph helper signatures changed.** The six `SELECT`-shaped helpers take a trailing `conditions []any`; existing call sites migrate by passing `nil`, which leaves the emitted SurrealQL unchanged. Go has no default arguments, so this follows the convention `TraverseWithDepth` already set with its `depth *int`.

## One correction rolled in

`surql.Version` still read `0.2.1`. Main was tagged v0.3.0 and v0.4.0 without it moving, so `surql --version` has under-reported for two releases. It now reads `0.5.0`.

All ten package suites pass.